### PR TITLE
chore: expand package keywords for discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,15 @@
     "music",
     "ai",
     "mcp",
-    "ableton"
+    "ableton",
+    "electronic-music",
+    "music-production",
+    "ableton-live",
+    "max-for-live",
+    "indie-dance",
+    "techno",
+    "house-music",
+    "music-theory"
   ],
   "scripts": {
     "dev": "npm run parser:build && rollup -c config/rollup.config.mjs -w",


### PR DESCRIPTION
## Summary
- Expanded package.json keywords from 4 to 12 entries
- Added: electronic-music, music-production, ableton-live, max-for-live, indie-dance, techno, house-music, music-theory
- .env.example audited — already clean, no stale Producer Pal references

## Test plan
- [ ] No lint violations
- [ ] No typecheck violations