### PR TITLE
chore: add PR label and assignee conventions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,6 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      - name: Label and assign
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR="${{ github.event.pull_request.html_url }}"
+          # Assign owner
+          gh pr edit "$PR" --add-assignee gabrielpulga
+          # Pick label based on branch name
+          BRANCH="${{ github.head_ref }}"
+          if [[ "$BRANCH" == dependabot/github_actions/* ]]; then
+            gh pr edit "$PR" --add-label "ci"
+          else
+            gh pr edit "$PR" --add-label "deps"
+          fi
+
       - name: Auto-approve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,20 @@ Each tool has a `.def.ts` (Zod schema) and a `.ts` (implementation).
 - `main` — stable
 - Feature branches: `gabriel/<description>`
 
+## Pull requests
+
+Every PR must include:
+
+- **Assignee**: `gabrielpulga`
+- **Label**: one of the 5 standard labels (pick the best fit):
+  - `bug` — fixes a defect
+  - `feature` — new functionality
+  - `chore` — maintenance, cleanup, config, refactoring
+  - `deps` — dependency updates
+  - `ci` — CI/CD and workflow changes
+
+`gh pr create` flags: `--assignee gabrielpulga --label <label>`
+
 ## Commit style
 
 Use conventional commits — release-please reads these to auto-generate the


### PR DESCRIPTION
## Summary
- Created 5 standard labels: bug, feature, chore, deps, ci
- Updated CLAUDE.md with PR conventions (always add label + assign gabrielpulga)
- Updated auto-merge workflow to auto-label and auto-assign future Dependabot PRs (ci for GHA bumps, deps for npm bumps)
- Applied labels and assignee retroactively to all open Dependabot PRs (#1-7)

## Test plan
- [ ] No lint violations
- [ ] No typecheck violations