### PR TITLE
ci: pass GITHUB_TOKEN explicitly to release-please action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,5 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- release-please was failing with "GitHub Actions is not permitted to create or approve pull requests"
- Root cause: token was not passed explicitly to the action, so it couldn't inherit the declared permissions
- Fix: pass `token: ${{ secrets.GITHUB_TOKEN }}` directly to the action

## Test plan
- [ ] Release Please workflow passes on next push to main