### PR TITLE
chore: exclude CHANGELOG.md from Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
-# generated files:
+# generated files (do not format):
+CHANGELOG.md
 .claude
 coverage
 knowledge-base


### PR DESCRIPTION
## Summary
- CHANGELOG.md is auto-generated by release-please and should not be reformatted by Prettier
- Adds CHANGELOG.md to .prettierignore to prevent spurious CI failures after every release

## Test plan
- [ ] Format check passes