### PR TITLE
ci: add PR-Agent with Claude Sonnet for automated PR review

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,22 @@
+name: PR Agent
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+
+jobs:
+  pr-agent:
+    name: Review with Claude
+    if: ${{ github.event.sender.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Run PR Agent
+        uses: qodo-ai/pr-agent@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC.KEY: ${{ secrets.ANTHROPIC_KEY }}

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,23 @@
+[config]
+model = "anthropic/claude-sonnet-4-5-20250929"
+fallback_models = ["anthropic/claude-3-5-haiku-20241022"]
+
+[github_action_config]
+auto_review = true
+auto_describe = true
+auto_improve = true
+
+[pr_reviewer]
+extra_instructions = """
+This is a TypeScript MCP server for AI-assisted electronic music production in Ableton Live.
+Focus on:
+- Correctness of MCP tool implementations and Zod schema definitions
+- Type safety and proper error handling
+- Music domain logic (MIDI, note durations, bar|beat positions, velocity ranges)
+- Security (especially around raw Live API access gating)
+- Test coverage for new tool behaviour
+"""
+
+[pr_code_suggestions]
+num_code_suggestions = 5
+suggestions_score_threshold = 7


### PR DESCRIPTION
## Summary
- Adds PR-Agent (by Qodo) running on Claude Sonnet 4.5 via GitHub Actions
- Auto-runs review, description, and improvement suggestions on every new PR
- Also responds to manual commands in PR comments: \`/review\`, \`/describe\`, \`/improve\`, \`/ask\`
- Falls back to Claude Haiku for lighter requests
- Configured with project-specific context (MCP tools, Zod schemas, music domain logic, security focus)

## Required setup
Add `ANTHROPIC_KEY` to repo secrets (Settings → Secrets and variables → Actions) before merging.

## Test plan
- [ ] ANTHROPIC_KEY secret added to repo
- [ ] Opens a test PR to verify review runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated pull request analysis and review workflow
  * Integrated AI-powered code suggestions with intelligent quality scoring
  * Configured automatic triggers for PR analysis on open, reopen, and ready-for-review events
  * Enabled fallback AI models to ensure consistent review performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->