### PR TITLE
feat: add undo, redo, and save actions to adj-playback

### DIFF
--- a/dist/ableton-dj-mcp-portal.js
+++ b/dist/ableton-dj-mcp-portal.js
@@ -29490,7 +29490,7 @@ const toolDefPlayback = defineTool("adj-playback", {
     destructiveHint: true
   },
   inputSchema: {
-    action: _enum$2([ "play-arrangement", "update-arrangement", "play-scene", "play-session-clips", "stop-session-clips", "stop-all-session-clips", "stop" ]).describe(`play-arrangement: from startTime\nupdate-arrangement: modify loop\nplay-scene: all clips in scene\nplay-session-clips: by id(s) or slot(s)\nstop-session-clips: by id(s) or slot(s)\nstop-all-session-clips: all\nstop: session and arrangement`),
+    action: _enum$2([ "play-arrangement", "update-arrangement", "play-scene", "play-session-clips", "stop-session-clips", "stop-all-session-clips", "stop", "undo", "redo", "save" ]).describe(`play-arrangement: from startTime\nupdate-arrangement: modify loop\nplay-scene: all clips in scene\nplay-session-clips: by id(s) or slot(s)\nstop-session-clips: by id(s) or slot(s)\nstop-all-session-clips: all\nstop: session and arrangement\nundo: undo last Live set action (check canUndo before)\nredo: redo last undone action (check canRedo before)\nsave: save the Live set to disk`),
     startTime: string$1().optional().describe("bar|beat position in arrangement"),
     startLocator: string$1().optional().describe("locator ID or name for start position (e.g., locator-0 or Verse)"),
     loop: boolean().optional().describe("arrangement loop?"),

--- a/dist/live-api-adapter.js
+++ b/dist/live-api-adapter.js
@@ -14149,12 +14149,21 @@ function handlePlayScene(sceneIndex, state) {
 
 function handleLiveSetHistory(action) {
   const liveSet = LiveAPI.from(livePath.liveSet);
-  if (action === "undo") {
+  switch (action) {
+   case "undo":
     liveSet.call("undo");
-  } else if (action === "redo") {
+    break;
+
+   case "redo":
     liveSet.call("redo");
-  } else {
+    break;
+
+   case "save":
     liveSet.call("save_live_set");
+    break;
+
+   default:
+    throw new Error(`playback failed: unknown history action "${String(action)}"`);
   }
   const numerator = liveSet.getProperty("signature_numerator");
   const denominator = liveSet.getProperty("signature_denominator");

--- a/dist/live-api-adapter.js
+++ b/dist/live-api-adapter.js
@@ -14147,9 +14147,32 @@ function handlePlayScene(sceneIndex, state) {
   };
 }
 
+function handleLiveSetHistory(action) {
+  const liveSet = LiveAPI.from(livePath.liveSet);
+  if (action === "undo") {
+    liveSet.call("undo");
+  } else if (action === "redo") {
+    liveSet.call("redo");
+  } else {
+    liveSet.call("save_live_set");
+  }
+  const numerator = liveSet.getProperty("signature_numerator");
+  const denominator = liveSet.getProperty("signature_denominator");
+  const currentTimeBeats = liveSet.getProperty("current_song_time");
+  return {
+    playing: liveSet.getProperty("is_playing") > 0,
+    currentTime: abletonBeatsToBarBeat(currentTimeBeats, numerator, denominator),
+    canUndo: liveSet.getProperty("can_undo") > 0,
+    canRedo: liveSet.getProperty("can_redo") > 0
+  };
+}
+
 function playback({action: action, startTime: startTime, startLocator: startLocator, loop: loop, loopStart: loopStart, loopStartLocator: loopStartLocator, loopEnd: loopEnd, loopEndLocator: loopEndLocator, sceneIndex: sceneIndex, ids: ids, slots: slots, focus: focus} = {}, _context = {}) {
   if (!action) {
     throw new Error("playback failed: action is required");
+  }
+  if (action === "undo" || action === "redo" || action === "save") {
+    return handleLiveSetHistory(action);
   }
   if (ids != null && slots != null) {
     throw new Error("playback failed: ids and slots are mutually exclusive");

--- a/dist/mcp-server.mjs
+++ b/dist/mcp-server.mjs
@@ -51236,7 +51236,7 @@ const toolDefPlayback = defineTool("adj-playback", {
     destructiveHint: true
   },
   inputSchema: {
-    action: _enum$2([ "play-arrangement", "update-arrangement", "play-scene", "play-session-clips", "stop-session-clips", "stop-all-session-clips", "stop" ]).describe(`play-arrangement: from startTime\nupdate-arrangement: modify loop\nplay-scene: all clips in scene\nplay-session-clips: by id(s) or slot(s)\nstop-session-clips: by id(s) or slot(s)\nstop-all-session-clips: all\nstop: session and arrangement`),
+    action: _enum$2([ "play-arrangement", "update-arrangement", "play-scene", "play-session-clips", "stop-session-clips", "stop-all-session-clips", "stop", "undo", "redo", "save" ]).describe(`play-arrangement: from startTime\nupdate-arrangement: modify loop\nplay-scene: all clips in scene\nplay-session-clips: by id(s) or slot(s)\nstop-session-clips: by id(s) or slot(s)\nstop-all-session-clips: all\nstop: session and arrangement\nundo: undo last Live set action (check canUndo before)\nredo: redo last undone action (check canRedo before)\nsave: save the Live set to disk`),
     startTime: string$1().optional().describe("bar|beat position in arrangement"),
     startLocator: string$1().optional().describe("locator ID or name for start position (e.g., locator-0 or Verse)"),
     loop: boolean().optional().describe("arrangement loop?"),

--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -164,10 +164,22 @@ Select tracks, scenes, or clips in Live's UI.
 
 ### `adj-playback`
 
-Control transport and clip playback.
+Control transport, session clips, and Live set history.
 
-- `action`: `"play"` | `"stop"` | `"continue"` | `"tap-tempo"` |
-  `"launch-scene"` | `"fire-clip"` | `"stop-clip"`
+- `action`:
+  - `"play-arrangement"` — play from `startTime`
+  - `"update-arrangement"` — modify loop (`loop`, `loopStart`, `loopEnd`)
+  - `"play-scene"` — fire all clips in a scene (`sceneIndex`)
+  - `"play-session-clips"` — fire clip(s) by `ids` or `slots`
+  - `"stop-session-clips"` — stop clip(s) by `ids` or `slots`
+  - `"stop-all-session-clips"` — stop every session clip
+  - `"stop"` — stop transport
+  - `"undo"` — undo last Live set action
+  - `"redo"` — redo last undone action
+  - `"save"` — save Live set to disk
+- Response includes `playing`, `currentTime`, optional `arrangementLoop`.
+- For `"undo"` / `"redo"` / `"save"`, response also includes `canUndo` and
+  `canRedo` booleans — check these before calling undo/redo to avoid no-ops.
 
 ---
 

--- a/src/tools/control/helpers/playback-helpers.ts
+++ b/src/tools/control/helpers/playback-helpers.ts
@@ -284,3 +284,43 @@ export function handlePlayScene(
     currentTimeBeats: state.currentTimeBeats,
   };
 }
+
+interface LiveSetHistoryResult {
+  playing: boolean;
+  currentTime: string;
+  canUndo: boolean;
+  canRedo: boolean;
+}
+
+/**
+ * Handle undo/redo/save on the Live set.
+ *
+ * @param action - "undo" | "redo" | "save"
+ * @returns Current transport state plus canUndo/canRedo flags
+ */
+export function handleLiveSetHistory(action: string): LiveSetHistoryResult {
+  const liveSet = LiveAPI.from(livePath.liveSet);
+
+  if (action === "undo") {
+    liveSet.call("undo");
+  } else if (action === "redo") {
+    liveSet.call("redo");
+  } else {
+    liveSet.call("save_live_set");
+  }
+
+  const numerator = liveSet.getProperty("signature_numerator") as number;
+  const denominator = liveSet.getProperty("signature_denominator") as number;
+  const currentTimeBeats = liveSet.getProperty("current_song_time") as number;
+
+  return {
+    playing: (liveSet.getProperty("is_playing") as number) > 0,
+    currentTime: abletonBeatsToBarBeat(
+      currentTimeBeats,
+      numerator,
+      denominator,
+    ),
+    canUndo: (liveSet.getProperty("can_undo") as number) > 0,
+    canRedo: (liveSet.getProperty("can_redo") as number) > 0,
+  };
+}

--- a/src/tools/control/helpers/playback-helpers.ts
+++ b/src/tools/control/helpers/playback-helpers.ts
@@ -292,21 +292,33 @@ interface LiveSetHistoryResult {
   canRedo: boolean;
 }
 
+export type LiveSetHistoryAction = "undo" | "redo" | "save";
+
 /**
  * Handle undo/redo/save on the Live set.
  *
  * @param action - "undo" | "redo" | "save"
  * @returns Current transport state plus canUndo/canRedo flags
  */
-export function handleLiveSetHistory(action: string): LiveSetHistoryResult {
+export function handleLiveSetHistory(
+  action: LiveSetHistoryAction,
+): LiveSetHistoryResult {
   const liveSet = LiveAPI.from(livePath.liveSet);
 
-  if (action === "undo") {
-    liveSet.call("undo");
-  } else if (action === "redo") {
-    liveSet.call("redo");
-  } else {
-    liveSet.call("save_live_set");
+  switch (action) {
+    case "undo":
+      liveSet.call("undo");
+      break;
+    case "redo":
+      liveSet.call("redo");
+      break;
+    case "save":
+      liveSet.call("save_live_set");
+      break;
+    default:
+      throw new Error(
+        `playback failed: unknown history action "${String(action)}"`,
+      );
   }
 
   const numerator = liveSet.getProperty("signature_numerator") as number;

--- a/src/tools/control/playback.def.ts
+++ b/src/tools/control/playback.def.ts
@@ -24,6 +24,9 @@ export const toolDefPlayback = defineTool("adj-playback", {
         "stop-session-clips",
         "stop-all-session-clips",
         "stop",
+        "undo",
+        "redo",
+        "save",
       ])
       .describe(
         `play-arrangement: from startTime
@@ -32,7 +35,10 @@ play-scene: all clips in scene
 play-session-clips: by id(s) or slot(s)
 stop-session-clips: by id(s) or slot(s)
 stop-all-session-clips: all
-stop: session and arrangement`,
+stop: session and arrangement
+undo: undo last Live set action (check canUndo before)
+redo: redo last undone action (check canRedo before)
+save: save the Live set to disk`,
       ),
     startTime: z
       .string()

--- a/src/tools/control/playback.ts
+++ b/src/tools/control/playback.ts
@@ -9,6 +9,7 @@ import { validateIdTypes } from "#src/tools/shared/validation/id-validation.ts";
 import { parseSlotList } from "#src/tools/shared/validation/position-parsing.ts";
 import {
   getCurrentLoopState,
+  handleLiveSetHistory,
   handlePlayArrangement,
   handlePlayScene,
   resolveLoopEnd,
@@ -47,6 +48,8 @@ interface PlaybackResult {
   playing: boolean;
   currentTime: string;
   arrangementLoop?: { start: string; end: string };
+  canUndo?: boolean;
+  canRedo?: boolean;
 }
 
 interface BuildPlaybackResultParams {
@@ -97,6 +100,11 @@ export function playback(
 ): PlaybackResult {
   if (!action) {
     throw new Error("playback failed: action is required");
+  }
+
+  // undo/redo/save don't interact with transport or loop params
+  if (action === "undo" || action === "redo" || action === "save") {
+    return handleLiveSetHistory(action);
   }
 
   if (ids != null && slots != null) {

--- a/src/tools/control/tests/playback-basic.test.ts
+++ b/src/tools/control/tests/playback-basic.test.ts
@@ -545,4 +545,83 @@ describe("transport", () => {
       "playback stop-session-clips action failed: track at index 99 does not exist",
     );
   });
+
+  it("should handle undo action and return canUndo/canRedo", () => {
+    liveSet = setupPlaybackLiveSet({
+      can_undo: 1,
+      can_redo: 0,
+      is_playing: 0,
+      current_song_time: 0,
+    });
+
+    const result = playback({ action: "undo" });
+
+    expect(liveSet.call).toHaveBeenCalledWith("undo");
+    expect(result).toStrictEqual({
+      playing: false,
+      currentTime: "1|1",
+      canUndo: true,
+      canRedo: false,
+    });
+  });
+
+  it("should handle redo action and return canUndo/canRedo", () => {
+    liveSet = setupPlaybackLiveSet({
+      can_undo: 1,
+      can_redo: 1,
+      is_playing: 0,
+      current_song_time: 0,
+    });
+
+    const result = playback({ action: "redo" });
+
+    expect(liveSet.call).toHaveBeenCalledWith("redo");
+    expect(result).toStrictEqual({
+      playing: false,
+      currentTime: "1|1",
+      canUndo: true,
+      canRedo: true,
+    });
+  });
+
+  it("should handle save action", () => {
+    liveSet = setupPlaybackLiveSet({
+      can_undo: 0,
+      can_redo: 0,
+      is_playing: 0,
+      current_song_time: 0,
+    });
+
+    const result = playback({ action: "save" });
+
+    expect(liveSet.call).toHaveBeenCalledWith("save_live_set");
+    expect(result).toStrictEqual({
+      playing: false,
+      currentTime: "1|1",
+      canUndo: false,
+      canRedo: false,
+    });
+  });
+
+  it("should call undo without touching transport or loop params", () => {
+    liveSet = setupPlaybackLiveSet({
+      can_undo: 1,
+      can_redo: 0,
+    });
+
+    playback({
+      action: "undo",
+      startTime: "5|1",
+      loop: true,
+      loopStart: "1|1",
+      loopEnd: "3|1",
+    });
+
+    expect(liveSet.call).toHaveBeenCalledWith("undo");
+    expect(liveSet.set).not.toHaveBeenCalledWith(
+      "start_time",
+      expect.anything(),
+    );
+    expect(liveSet.set).not.toHaveBeenCalledWith("loop", expect.anything());
+  });
 });


### PR DESCRIPTION
### **User description**
## Summary

Closes #42.

- add \`undo\`, \`redo\`, \`save\` to the \`adj-playback\` action enum
- expose \`canUndo\`/\`canRedo\` flags on the response so AI can check state before calling
- short-circuit path: history actions skip transport/loop param resolution

## Rationale

Basic recovery primitives were missing. Without undo, an AI mistake (wrong note, accidental delete) had no programmatic fix. Save was needed for any workflow persisting AI-generated work.

## Test plan

- [ ] Run \`adj-playback action=undo\` — last action reverts
- [ ] Run \`adj-playback action=redo\` — undone action reapplies
- [ ] Run \`adj-playback action=save\` — Live set writes to disk
- [ ] Response includes \`canUndo\`/\`canRedo\` booleans


___

### **PR Type**
Enhancement


___

### **Description**
- Adds `undo`, `redo`, and `save` actions to `adj-playback`.

- Exposes `canUndo` and `canRedo` flags in the response.

- Implements a short-circuit for history actions to skip transport parameters.

- Includes new tests for all added history actions.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A[playback function] --> B{Action is undo/redo/save?};
    B -- Yes --> C[handleLiveSetHistory];
    C -- Calls LiveAPI --> D{undo/redo/save};
    C -- Returns --> E[canUndo/canRedo flags];
    B -- No --> F[Existing playback logic];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>playback-helpers.ts</strong><dd><code>Introduces <code>handleLiveSetHistory</code> for undo, redo, and save operations.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/74/files#diff-05ab9cf559b1d3b4ed898c4131a96323572affe458c672ba9e61b975e146abab">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>playback.ts</strong><dd><code>Integrates history actions with short-circuit logic and updates result </code><br><code>interface.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/74/files#diff-d57c15906519423ad1c1e4baf933a94f6dc25f5f7ee2a2a42411a60931cb09b8">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>playback.def.ts</strong><dd><code>Extends `action` enum with `undo`, `redo`, and `save` options.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/74/files#diff-2bcfb6c4203d965090006ce841963f029354eb6a1f34c06cab68450faf4ebbe0">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>playback-basic.test.ts</strong><dd><code>Adds tests for <code>undo</code>, <code>redo</code>, <code>save</code> actions and parameter isolation.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/74/files#diff-2d8f54b27de5dc015c8e2be551e61f38b93d09b5e4159f43d6e006c66f7d1384">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Build output</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ableton-dj-mcp-portal.js</strong><dd><code>Updates compiled tool definition to include new playback actions.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/74/files#diff-09145fb3a1fb499bb649e61afeb792066e1cde2de87ab3e45036613cabacca3b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>live-api-adapter.js</strong><dd><code>Updates compiled adapter with <code>handleLiveSetHistory</code> and playback logic.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/74/files#diff-0a025e0ebbef610cee32b3d48fc7a6c0a353cb908b47aa3d74137d68b4a4d6dc">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mcp-server.mjs</strong><dd><code>Updates server module with new playback actions in tool definition.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/74/files#diff-5723cdad2e31879af7515acf8d027626338c319a3b51a54a5e9b239e4b4e2a73">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

