### PR TITLE
chore: add local/ folder convention for personal files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ report/
 
 # Live project backups
 **/live-sets/**/Backup
+
+# Personal/local-only files (notes, scratch tests, machine-specific configs)
+local/


### PR DESCRIPTION
## Summary
- Adds `local/` to `.gitignore` as a designated location for machine-specific or personal files (notes, scratch tests, local Live sets, machine-specific configs).
- Anything inside `local/` will be excluded from commits.

## Why
Provides a clean convention so personal files don't accidentally end up in this public repo. Single ignored directory beats scattering `.local`-prefixed files everywhere.

## Test plan
- [x] `git check-ignore local/` confirms folder is ignored
- [x] `git status` shows only `.gitignore` modified, not `local/` contents