### PR TITLE
feat: add adj-generate tool for Euclidean rhythm patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ See `docs/PROJECT_INDEX.md` — full directory map, tool list, entry points, bui
 system, notation system. See `docs/` for deeper documentation on specific
 topics.
 
-## 21 Tools (all prefixed `adj-`)
+## 22 Tools (all prefixed `adj-`)
 
 | Domain     | Tools                                           |
 | ---------- | ----------------------------------------------- |
@@ -52,6 +52,7 @@ topics.
 | Device     | `read-device`, `create-device`, `update-device` |
 | Operations | `delete`, `duplicate`                           |
 | Control    | `select`, `playback`                            |
+| Generative | `generate` (Euclidean rhythms, no Live API)     |
 | Dev-only   | `raw-live-api` (env flag required)              |
 
 Each tool has a `.def.ts` (Zod schema) and a `.ts` (implementation).

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ grounded, specific advice instead of generic music theory.
 
 ## How it works
 
-The server runs inside a Max for Live device embedded in your Live set. A
-portal bridges your AI client (stdio) to the server over HTTP. Tools prefixed
-`adj-` let the AI read and manipulate the Live set in real time.
+The server runs inside a Max for Live device embedded in your Live set. A portal
+bridges your AI client (stdio) to the server over HTTP. Tools prefixed `adj-`
+let the AI read and manipulate the Live set in real time.
 
 ## Requirements
 

--- a/docs/PROJECT_INDEX.md
+++ b/docs/PROJECT_INDEX.md
@@ -14,7 +14,7 @@ AI Client (Claude Desktop, etc.)
             -> Ableton Live JS API
 ```
 
-## 21 MCP Tools
+## 22 MCP Tools
 
 All prefixed `adj-`.
 
@@ -28,6 +28,7 @@ All prefixed `adj-`.
 | Device     | `read-device`, `create-device`, `update-device`      |
 | Operations | `delete`, `duplicate`                                |
 | Control    | `select`, `playback`                                 |
+| Generative | `generate` (algorithmic patterns, no Live API)       |
 | Dev-only   | `raw-live-api` (requires `ENABLE_RAW_LIVE_API=true`) |
 
 ## Code Layers

--- a/src/live-api-adapter/live-api-adapter.ts
+++ b/src/live-api-adapter/live-api-adapter.ts
@@ -26,6 +26,7 @@ import { select } from "#src/tools/control/select.ts";
 import { createDevice } from "#src/tools/device/create/create-device.ts";
 import { readDevice } from "#src/tools/device/read/read-device.ts";
 import { updateDevice } from "#src/tools/device/update/update-device.ts";
+import { generate } from "#src/tools/generative/generate.ts";
 import { readLiveSet } from "#src/tools/live-set/read-live-set.ts";
 import { updateLiveSet } from "#src/tools/live-set/update-live-set.ts";
 import { deleteObject } from "#src/tools/operations/delete/delete.ts";
@@ -95,6 +96,7 @@ const tools: Record<string, (args: unknown) => unknown> = {
   "adj-update-device": (args) => updateDevice(args as any, context),
   "adj-playback": (args) => playback(args as any, context),
   "adj-select": (args) => select(args as any, context),
+  "adj-generate": (args) => generate(args as any, context),
   "adj-delete": (args) => deleteObject(args as any, context),
   "adj-duplicate": (args) => {
     initHoldingArea();

--- a/src/mcp-server/create-mcp-server.ts
+++ b/src/mcp-server/create-mcp-server.ts
@@ -13,6 +13,7 @@ import { toolDefSelect } from "#src/tools/control/select.def.ts";
 import { toolDefCreateDevice } from "#src/tools/device/create/create-device.def.ts";
 import { toolDefReadDevice } from "#src/tools/device/read/read-device.def.ts";
 import { toolDefUpdateDevice } from "#src/tools/device/update/update-device.def.ts";
+import { toolDefGenerate } from "#src/tools/generative/generate.def.ts";
 import { toolDefReadLiveSet } from "#src/tools/live-set/read-live-set.def.ts";
 import { toolDefUpdateLiveSet } from "#src/tools/live-set/update-live-set.def.ts";
 import { toolDefDelete } from "#src/tools/operations/delete/delete.def.ts";
@@ -53,6 +54,7 @@ export const STANDARD_TOOL_DEFS: ToolDefFunction[] = [
   toolDefDuplicate,
   toolDefSelect,
   toolDefPlayback,
+  toolDefGenerate,
 ];
 
 /** All standard tool names (frozen). Does not include dev-only tools like adj-raw-live-api. */

--- a/src/mcp-server/tests/create-express-app.test.ts
+++ b/src/mcp-server/tests/create-express-app.test.ts
@@ -127,6 +127,7 @@ describe("MCP Express App", () => {
         "adj-duplicate",
         "adj-select",
         "adj-playback",
+        "adj-generate",
         "adj-raw-live-api",
       ]);
     });

--- a/src/tools/generative/generate.def.ts
+++ b/src/tools/generative/generate.def.ts
@@ -1,0 +1,77 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { z } from "zod";
+import { defineTool } from "#src/tools/shared/tool-framework/define-tool.ts";
+import { NAMED_PATTERN_NAMES } from "./helpers/named-patterns.ts";
+
+export const toolDefGenerate = defineTool("adj-generate", {
+  title: "Generate",
+  description:
+    "Generate algorithmic note patterns. Returns notes in bar|beat notation " +
+    "that plug directly into adj-create-clip's `notes` param. Pure computation, " +
+    "no Live API calls.",
+
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+  },
+
+  inputSchema: {
+    algorithm: z
+      .enum(["euclidean"])
+      .describe("euclidean: Bjorklund-style even distribution of pulses"),
+
+    pattern: z
+      .enum(NAMED_PATTERN_NAMES as [string, ...string[]])
+      .optional()
+      .describe(
+        `named pattern (overrides steps/pulses/rotation): ${NAMED_PATTERN_NAMES.join(", ")}`,
+      ),
+
+    pitch: z.string().describe("MIDI note name for hits (e.g., C1, F#2)"),
+
+    steps: z.coerce
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("total steps per bar (e.g., 16 for sixteenths)"),
+
+    pulses: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe("active hits to distribute across steps"),
+
+    rotation: z.coerce
+      .number()
+      .int()
+      .optional()
+      .describe("rotate pattern left by N steps (default 0)"),
+
+    bars: z.coerce
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("how many bars to tile the pattern across (default 1)"),
+
+    velocity: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .max(127)
+      .optional()
+      .describe("hit velocity 0-127 (default 100)"),
+
+    duration: z
+      .string()
+      .optional()
+      .describe(
+        "note duration in barbeat syntax without `t` prefix (e.g., /16, 1/8). default: one step length",
+      ),
+  },
+});

--- a/src/tools/generative/generate.ts
+++ b/src/tools/generative/generate.ts
@@ -1,0 +1,122 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { euclidean, rotate } from "./helpers/bjorklund.ts";
+import { NAMED_PATTERNS, type NamedPattern } from "./helpers/named-patterns.ts";
+import { formatPatternToBarbeat } from "./helpers/notes-formatter.ts";
+
+const DEFAULT_VELOCITY = 100;
+
+interface GenerateArgs {
+  algorithm?: string;
+  pattern?: string;
+  pitch?: string;
+  steps?: number;
+  pulses?: number;
+  rotation?: number;
+  bars?: number;
+  velocity?: number;
+  duration?: string;
+}
+
+interface GenerateResult {
+  notes: string;
+  steps: number;
+  pulses: number;
+  rotation: number;
+  bars: number;
+}
+
+/**
+ * Generate algorithmic note patterns. Returns barbeat-notation notes ready to
+ * pass to adj-create-clip.
+ *
+ * @param args - Generation parameters
+ * @param _context - Unused, kept for tool interface consistency
+ * @returns Generated notes string + pattern metadata
+ */
+export function generate(
+  args: GenerateArgs = {},
+  _context: Partial<ToolContext> = {},
+): GenerateResult {
+  const { algorithm, pattern: namedPattern, pitch } = args;
+
+  if (!algorithm) {
+    throw new Error("generate failed: algorithm is required");
+  }
+
+  if (algorithm !== "euclidean") {
+    throw new Error(`generate failed: unknown algorithm "${algorithm}"`);
+  }
+
+  if (!pitch) {
+    throw new Error("generate failed: pitch is required");
+  }
+
+  const bars = args.bars ?? 1;
+  const velocity = args.velocity ?? DEFAULT_VELOCITY;
+  const rotation = args.rotation ?? 0;
+
+  const { steps, basePattern } = resolvePattern(namedPattern, args);
+  const rotated = rotate(basePattern, rotation);
+  const pulses = rotated.filter(Boolean).length;
+  const duration = args.duration ?? `/${steps}`;
+
+  const notes = formatPatternToBarbeat({
+    pattern: rotated,
+    steps,
+    pitch,
+    velocity,
+    duration,
+    bars,
+  });
+
+  return { notes, steps, pulses, rotation, bars };
+}
+
+interface ResolvedPattern {
+  steps: number;
+  basePattern: boolean[];
+}
+
+/**
+ * Resolve the base pattern from either a named preset or steps/pulses params.
+ *
+ * @param namedPattern - Optional preset name
+ * @param args - Generate args (used for steps/pulses fallback)
+ * @returns Steps count + boolean pattern array
+ */
+function resolvePattern(
+  namedPattern: string | undefined,
+  args: GenerateArgs,
+): ResolvedPattern {
+  if (namedPattern != null) {
+    const spec = (NAMED_PATTERNS as Record<string, NamedPattern | undefined>)[
+      namedPattern
+    ];
+
+    if (!spec) {
+      throw new Error(`generate failed: unknown pattern "${namedPattern}"`);
+    }
+
+    return { steps: spec.steps, basePattern: [...spec.pattern] };
+  }
+
+  if (args.steps == null) {
+    throw new Error(
+      "generate failed: steps is required when pattern is not set",
+    );
+  }
+
+  if (args.pulses == null) {
+    throw new Error(
+      "generate failed: pulses is required when pattern is not set",
+    );
+  }
+
+  return {
+    steps: args.steps,
+    basePattern: euclidean(args.pulses, args.steps),
+  };
+}

--- a/src/tools/generative/helpers/bjorklund.ts
+++ b/src/tools/generative/helpers/bjorklund.ts
@@ -1,0 +1,58 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Generate a Euclidean rhythm: distribute `pulses` evenly across `steps`.
+ * Uses the Bresenham line algorithm, which produces the same maximally-even
+ * distribution as Bjorklund for the cases that matter musically.
+ *
+ * @param pulses - Number of active hits to distribute
+ * @param steps - Total step count
+ * @returns Boolean array of length `steps`, true = hit
+ */
+export function euclidean(pulses: number, steps: number): boolean[] {
+  if (steps <= 0) {
+    throw new Error("euclidean failed: steps must be positive");
+  }
+
+  if (pulses < 0) {
+    throw new Error("euclidean failed: pulses must be non-negative");
+  }
+
+  if (pulses > steps) {
+    throw new Error("euclidean failed: pulses cannot exceed steps");
+  }
+
+  if (pulses === 0) {
+    return new Array<boolean>(steps).fill(false);
+  }
+
+  const result: boolean[] = [];
+  let prev = -1;
+
+  for (let i = 0; i < steps; i++) {
+    const curr = Math.floor((i * pulses) / steps);
+
+    result.push(curr !== prev);
+    prev = curr;
+  }
+
+  return result;
+}
+
+/**
+ * Rotate an array left by `offset` positions.
+ * Positive offset shifts later steps to the front (pattern starts later in time).
+ *
+ * @param arr - Source array
+ * @param offset - Steps to rotate (any integer, normalised to array length)
+ * @returns New rotated array
+ */
+export function rotate<T>(arr: T[], offset: number): T[] {
+  if (arr.length === 0) return arr;
+
+  const o = ((offset % arr.length) + arr.length) % arr.length;
+
+  return [...arr.slice(o), ...arr.slice(0, o)];
+}

--- a/src/tools/generative/helpers/named-patterns.ts
+++ b/src/tools/generative/helpers/named-patterns.ts
@@ -1,0 +1,42 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+export interface NamedPattern {
+  steps: number;
+  pattern: boolean[];
+}
+
+const T = true;
+const F = false;
+
+/**
+ * Canonical, hardcoded patterns for musical accuracy.
+ * Some (clave) don't fall out of pure Bjorklund — explicit values preserve feel.
+ */
+export const NAMED_PATTERNS = {
+  tresillo: { steps: 8, pattern: [T, F, F, T, F, F, T, F] },
+  cinquillo: { steps: 8, pattern: [T, F, T, T, F, T, T, F] },
+  "bossa-nova": {
+    steps: 16,
+    pattern: [T, F, F, T, F, F, T, F, F, F, T, F, F, T, F, F],
+  },
+  "son-clave": {
+    steps: 16,
+    pattern: [T, F, F, T, F, F, T, F, F, F, T, F, T, F, F, F],
+  },
+  "rumba-clave": {
+    steps: 16,
+    pattern: [T, F, F, T, F, F, F, T, F, F, T, F, T, F, F, F],
+  },
+  "16th-4": {
+    steps: 16,
+    pattern: [T, F, F, F, T, F, F, F, T, F, F, F, T, F, F, F],
+  },
+} as const satisfies Record<string, NamedPattern>;
+
+export type NamedPatternName = keyof typeof NAMED_PATTERNS;
+
+export const NAMED_PATTERN_NAMES = Object.keys(
+  NAMED_PATTERNS,
+) as NamedPatternName[];

--- a/src/tools/generative/helpers/notes-formatter.ts
+++ b/src/tools/generative/helpers/notes-formatter.ts
@@ -1,0 +1,53 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+const BEATS_PER_BAR = 4;
+const FLOAT_PRECISION = 10000;
+
+export interface FormatPatternOptions {
+  pattern: boolean[];
+  steps: number;
+  pitch: string;
+  velocity: number;
+  duration: string;
+  bars: number;
+}
+
+/**
+ * Convert a boolean step pattern into bar|beat notation lines that plug
+ * directly into adj-create-clip's `notes` parameter.
+ *
+ * Assumes 4/4: `steps` subdivisions per bar, evenly spaced.
+ *
+ * @param opts - Pattern + format options
+ * @returns Multiline string (one note per line)
+ */
+export function formatPatternToBarbeat(opts: FormatPatternOptions): string {
+  const { pattern, steps, pitch, velocity, duration, bars } = opts;
+  const beatsPerStep = BEATS_PER_BAR / steps;
+  const lines: string[] = [];
+
+  for (let bar = 1; bar <= bars; bar++) {
+    for (let step = 0; step < steps; step++) {
+      if (!pattern[step]) continue;
+
+      const beat = formatBeat(step * beatsPerStep + 1);
+
+      lines.push(`${bar}|${beat} v${velocity} t${duration} ${pitch}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Format a beat number with float-artefact protection.
+ * @param beat - Beat position (1-based, may be fractional)
+ * @returns String form, trailing zeros stripped
+ */
+function formatBeat(beat: number): string {
+  const rounded = Math.round(beat * FLOAT_PRECISION) / FLOAT_PRECISION;
+
+  return String(rounded);
+}

--- a/src/tools/generative/tests/bjorklund.test.ts
+++ b/src/tools/generative/tests/bjorklund.test.ts
@@ -1,0 +1,93 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { euclidean, rotate } from "../helpers/bjorklund.ts";
+
+describe("euclidean", () => {
+  it("produces tresillo for (3, 8)", () => {
+    expect(euclidean(3, 8)).toStrictEqual([
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+    ]);
+  });
+
+  it("produces four-on-the-floor for (4, 16)", () => {
+    expect(euclidean(4, 16)).toStrictEqual([
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+    ]);
+  });
+
+  it("returns all-false when pulses is 0", () => {
+    expect(euclidean(0, 4)).toStrictEqual([false, false, false, false]);
+  });
+
+  it("returns all-true when pulses equals steps", () => {
+    expect(euclidean(4, 4)).toStrictEqual([true, true, true, true]);
+  });
+
+  it("places exactly `pulses` hits", () => {
+    const result = euclidean(5, 13);
+
+    expect(result.filter(Boolean)).toHaveLength(5);
+    expect(result).toHaveLength(13);
+  });
+
+  it("throws when steps is non-positive", () => {
+    expect(() => euclidean(1, 0)).toThrow("steps must be positive");
+    expect(() => euclidean(1, -1)).toThrow("steps must be positive");
+  });
+
+  it("throws when pulses is negative", () => {
+    expect(() => euclidean(-1, 8)).toThrow("pulses must be non-negative");
+  });
+
+  it("throws when pulses exceeds steps", () => {
+    expect(() => euclidean(9, 8)).toThrow("pulses cannot exceed steps");
+  });
+});
+
+describe("rotate", () => {
+  it("rotates left by positive offset", () => {
+    expect(rotate([1, 2, 3, 4], 1)).toStrictEqual([2, 3, 4, 1]);
+    expect(rotate([1, 2, 3, 4], 2)).toStrictEqual([3, 4, 1, 2]);
+  });
+
+  it("handles negative offset", () => {
+    expect(rotate([1, 2, 3, 4], -1)).toStrictEqual([4, 1, 2, 3]);
+  });
+
+  it("normalises offset larger than length", () => {
+    expect(rotate([1, 2, 3], 4)).toStrictEqual([2, 3, 1]);
+  });
+
+  it("returns identity for offset 0", () => {
+    expect(rotate([1, 2, 3], 0)).toStrictEqual([1, 2, 3]);
+  });
+
+  it("handles empty array", () => {
+    expect(rotate([], 3)).toStrictEqual([]);
+  });
+});

--- a/src/tools/generative/tests/generate.test.ts
+++ b/src/tools/generative/tests/generate.test.ts
@@ -1,0 +1,155 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { generate } from "../generate.ts";
+
+describe("generate", () => {
+  describe("validation", () => {
+    it("requires algorithm", () => {
+      expect(() => generate({})).toThrow("algorithm is required");
+    });
+
+    it("rejects unknown algorithm", () => {
+      expect(() =>
+        generate({ algorithm: "bogus", pitch: "C1", steps: 8, pulses: 3 }),
+      ).toThrow('unknown algorithm "bogus"');
+    });
+
+    it("requires pitch", () => {
+      expect(() =>
+        generate({ algorithm: "euclidean", steps: 8, pulses: 3 }),
+      ).toThrow("pitch is required");
+    });
+
+    it("requires steps when pattern is not set", () => {
+      expect(() =>
+        generate({ algorithm: "euclidean", pitch: "C1", pulses: 3 }),
+      ).toThrow("steps is required");
+    });
+
+    it("requires pulses when pattern is not set", () => {
+      expect(() =>
+        generate({ algorithm: "euclidean", pitch: "C1", steps: 8 }),
+      ).toThrow("pulses is required");
+    });
+
+    it("rejects unknown named pattern", () => {
+      expect(() =>
+        generate({ algorithm: "euclidean", pitch: "C1", pattern: "bogus" }),
+      ).toThrow('unknown pattern "bogus"');
+    });
+  });
+
+  describe("euclidean", () => {
+    it("generates tresillo from (3, 8)", () => {
+      const result = generate({
+        algorithm: "euclidean",
+        pitch: "C1",
+        steps: 8,
+        pulses: 3,
+      });
+
+      expect(result.notes).toBe(
+        "1|1 v100 t/8 C1\n1|2.5 v100 t/8 C1\n1|4 v100 t/8 C1",
+      );
+      expect(result.steps).toBe(8);
+      expect(result.pulses).toBe(3);
+      expect(result.rotation).toBe(0);
+      expect(result.bars).toBe(1);
+    });
+
+    it("applies rotation", () => {
+      const noRot = generate({
+        algorithm: "euclidean",
+        pitch: "C1",
+        steps: 8,
+        pulses: 3,
+      });
+      const rotated = generate({
+        algorithm: "euclidean",
+        pitch: "C1",
+        steps: 8,
+        pulses: 3,
+        rotation: 1,
+      });
+
+      expect(rotated.notes).not.toBe(noRot.notes);
+      expect(rotated.rotation).toBe(1);
+    });
+
+    it("respects custom velocity and duration", () => {
+      const result = generate({
+        algorithm: "euclidean",
+        pitch: "D2",
+        steps: 4,
+        pulses: 2,
+        velocity: 64,
+        duration: "1/4",
+      });
+
+      expect(result.notes).toContain("v64 t1/4 D2");
+    });
+
+    it("tiles across multiple bars", () => {
+      const result = generate({
+        algorithm: "euclidean",
+        pitch: "C1",
+        steps: 4,
+        pulses: 1,
+        bars: 3,
+      });
+
+      const lines = result.notes.split("\n");
+
+      expect(lines).toHaveLength(3);
+      expect(lines[0]).toMatch(/^1\|1/);
+      expect(lines[1]).toMatch(/^2\|1/);
+      expect(lines[2]).toMatch(/^3\|1/);
+    });
+  });
+
+  describe("named patterns", () => {
+    it("generates tresillo by name", () => {
+      const named = generate({
+        algorithm: "euclidean",
+        pitch: "C1",
+        pattern: "tresillo",
+      });
+      const algo = generate({
+        algorithm: "euclidean",
+        pitch: "C1",
+        steps: 8,
+        pulses: 3,
+      });
+
+      expect(named.notes).toBe(algo.notes);
+    });
+
+    it("generates son-clave with 5 hits in 16 steps", () => {
+      const result = generate({
+        algorithm: "euclidean",
+        pitch: "C1",
+        pattern: "son-clave",
+      });
+
+      expect(result.notes.split("\n")).toHaveLength(5);
+      expect(result.steps).toBe(16);
+      expect(result.pulses).toBe(5);
+    });
+
+    it("named pattern overrides explicit steps/pulses", () => {
+      const result = generate({
+        algorithm: "euclidean",
+        pitch: "C1",
+        pattern: "tresillo",
+        steps: 16,
+        pulses: 8,
+      });
+
+      expect(result.steps).toBe(8);
+      expect(result.pulses).toBe(3);
+    });
+  });
+});

--- a/src/tools/generative/tests/named-patterns.test.ts
+++ b/src/tools/generative/tests/named-patterns.test.ts
@@ -1,0 +1,62 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import {
+  NAMED_PATTERN_NAMES,
+  NAMED_PATTERNS,
+} from "../helpers/named-patterns.ts";
+
+describe("NAMED_PATTERNS", () => {
+  it("exposes the documented preset names", () => {
+    expect(NAMED_PATTERN_NAMES).toStrictEqual([
+      "tresillo",
+      "cinquillo",
+      "bossa-nova",
+      "son-clave",
+      "rumba-clave",
+      "16th-4",
+    ]);
+  });
+
+  it("each pattern's array length matches its declared steps", () => {
+    for (const name of NAMED_PATTERN_NAMES) {
+      const spec = NAMED_PATTERNS[name];
+
+      expect(spec.pattern).toHaveLength(spec.steps);
+    }
+  });
+
+  it("tresillo has 3 hits in 8 steps", () => {
+    const spec = NAMED_PATTERNS.tresillo;
+
+    expect(spec.pattern.filter(Boolean)).toHaveLength(3);
+    expect(spec.steps).toBe(8);
+  });
+
+  it("son-clave and rumba-clave both have 5 hits in 16 steps", () => {
+    const son = NAMED_PATTERNS["son-clave"];
+    const rumba = NAMED_PATTERNS["rumba-clave"];
+
+    expect(son.pattern.filter(Boolean)).toHaveLength(5);
+    expect(rumba.pattern.filter(Boolean)).toHaveLength(5);
+    expect(son.steps).toBe(16);
+    expect(rumba.steps).toBe(16);
+  });
+
+  it("son-clave and rumba-clave differ", () => {
+    expect(NAMED_PATTERNS["son-clave"].pattern).not.toStrictEqual(
+      NAMED_PATTERNS["rumba-clave"].pattern,
+    );
+  });
+
+  it("16th-4 places hits on every quarter", () => {
+    const spec = NAMED_PATTERNS["16th-4"];
+    const hitIndices = spec.pattern
+      .map((hit, i) => (hit ? i : -1))
+      .filter((i) => i >= 0);
+
+    expect(hitIndices).toStrictEqual([0, 4, 8, 12]);
+  });
+});

--- a/src/tools/generative/tests/notes-formatter.test.ts
+++ b/src/tools/generative/tests/notes-formatter.test.ts
@@ -1,0 +1,66 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { formatPatternToBarbeat } from "../helpers/notes-formatter.ts";
+
+describe("formatPatternToBarbeat", () => {
+  it("emits one line per active step in 8-step grid", () => {
+    const notes = formatPatternToBarbeat({
+      pattern: [true, false, false, true, false, false, true, false],
+      steps: 8,
+      pitch: "C1",
+      velocity: 100,
+      duration: "/8",
+      bars: 1,
+    });
+
+    expect(notes).toBe("1|1 v100 t/8 C1\n1|2.5 v100 t/8 C1\n1|4 v100 t/8 C1");
+  });
+
+  it("converts step positions to fractional beats in 16-step grid", () => {
+    const notes = formatPatternToBarbeat({
+      pattern: [true, false, true, false, false, false, false, false].concat(
+        new Array<boolean>(8).fill(false),
+      ),
+      steps: 16,
+      pitch: "D2",
+      velocity: 90,
+      duration: "/16",
+      bars: 1,
+    });
+
+    expect(notes).toBe("1|1 v90 t/16 D2\n1|1.5 v90 t/16 D2");
+  });
+
+  it("tiles pattern across multiple bars", () => {
+    const notes = formatPatternToBarbeat({
+      pattern: [true, false, false, false],
+      steps: 4,
+      pitch: "C1",
+      velocity: 100,
+      duration: "/4",
+      bars: 3,
+    });
+
+    expect(notes.split("\n")).toStrictEqual([
+      "1|1 v100 t/4 C1",
+      "2|1 v100 t/4 C1",
+      "3|1 v100 t/4 C1",
+    ]);
+  });
+
+  it("returns empty string when pattern has no hits", () => {
+    const notes = formatPatternToBarbeat({
+      pattern: [false, false, false, false],
+      steps: 4,
+      pitch: "C1",
+      velocity: 100,
+      duration: "/4",
+      bars: 2,
+    });
+
+    expect(notes).toBe("");
+  });
+});


### PR DESCRIPTION
### **User description**
Closes #34.

## Summary

- New `adj-generate` MCP tool — pure computation, no Live API
- Bjorklund-style Euclidean rhythm distribution
- 6 named patterns: `tresillo`, `cinquillo`, `bossa-nova`, `son-clave`, `rumba-clave`, `16th-4`
- Output is bar|beat notation that plugs straight into `adj-create-clip`'s `notes` param
- 36 new unit tests, all green

## Example usage

```jsonc
// Generate tresillo as kick (C1) for 2 bars
{
  "algorithm": "euclidean",
  "pattern": "tresillo",
  "pitch": "C1",
  "bars": 2
}
// → "1|1 v100 t/8 C1\n1|2.5 v100 t/8 C1\n1|4 v100 t/8 C1\n2|1 v100 t/8 C1\n..."

// Or by raw spec
{
  "algorithm": "euclidean",
  "pitch": "D1",
  "steps": 16,
  "pulses": 5,
  "rotation": 2
}
```

## What's deferred

Issue #34 mentions optional `phase-shift` (Steve Reich) and `additive` (Philip Glass) algorithms — both deferred to a follow-up to keep this PR focused.

## Files

- `src/tools/generative/generate.{def,}.ts` — tool schema + orchestrator
- `src/tools/generative/helpers/bjorklund.ts` — Euclidean algorithm + rotation
- `src/tools/generative/helpers/named-patterns.ts` — preset library (musically-correct, hand-built)
- `src/tools/generative/helpers/notes-formatter.ts` — boolean[] → bar|beat string
- `src/tools/generative/tests/*` — full coverage
- Registered in `create-mcp-server.ts` + `live-api-adapter.ts`
- Updated `CLAUDE.md`, `docs/PROJECT_INDEX.md`, tool-list test

## Test plan

- [x] `npm test` — 3736 passed, 0 failed
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run duplication` — clean
- [ ] Manual: invoke `adj-generate` from MCP client, pipe output into `adj-create-clip`, verify clip plays the expected rhythm in Ableton

## Note

Pre-existing format violation on `README.md` shows up in `npm run check` — not introduced by this PR.


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce new `adj-generate` tool for algorithmic note patterns.

- Generate Euclidean rhythms using a Bjorklund-style distribution.

- Support named patterns like `tresillo`, `cinquillo`, and `son-clave`.

- Output notes in `bar|beat` format, compatible with `adj-create-clip`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A[adj-generate Tool] --> B{Input Args};
    B -- "pattern name or steps/pulses" --> C{Resolve Pattern};
    C -- "base pattern (boolean[])" --> D{Apply Rotation};
    D -- "rotated pattern" --> E{Format to bar|beat};
    E -- "notes string" --> F[Output Notes];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>live-api-adapter.ts</strong><dd><code>Register `adj-generate` tool in the Live API adapter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/80/files#diff-c3a24f2d8f92d74167cb7edd9f305472348b32e132e241b7f654f7d993292a4d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>create-mcp-server.ts</strong><dd><code>Register `adj-generate` tool definition in the MCP server</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/80/files#diff-9aedb34621fd14bd2830d9f454c3b5fbf3fc108d294bcc60b01f4247cd306f04">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>create-express-app.test.ts</strong><dd><code>Update tool list in Express app tests to include `adj-generate`</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/80/files#diff-ba023da9e605a5eb98132a10ff03265f8f4a2a7037de25f2d4622fac0d85c0c9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bjorklund.test.ts</strong><dd><code>Add unit tests for Euclidean rhythm and rotation functions</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/80/files#diff-587a63f331a447dc9a4919f2023f6b9a603cc36b9cf10a510e634639f8ca3ab9">+93/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>generate.test.ts</strong><dd><code>Add comprehensive unit tests for the `adj-generate` tool</code>&nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/80/files#diff-fbf7ba824614a0b3a6d2fc258dc1c5130e6e131f8f4118f4e43fab920ba5edb0">+155/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>named-patterns.test.ts</strong><dd><code>Add unit tests for the named rhythmic patterns library</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/80/files#diff-2dda085b153a2a81b900202b648e91687e1a4ee2586f2d73f41a7dd875ce28c2">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notes-formatter.test.ts</strong><dd><code>Add unit tests for the `bar|beat` notes formatter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/80/files#diff-92ecfa62e83bfe3980eea51b40258d4dcf81e7dcc345285fd09c1e7ce4b32713">+66/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>New feature</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>generate.def.ts</strong><dd><code>Define schema and documentation for the `adj-generate` tool</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/80/files#diff-36001b3a17de29e5749f2ba176e112e0866a9229e98af36fd8bf92a913c6de6f">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>generate.ts</strong><dd><code>Implement core logic for generating algorithmic note patterns</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/80/files#diff-c969a90c807df17adcbfc6c29ecd46ad44a98edcf8e77ee7289db91006511117">+122/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>bjorklund.ts</strong><dd><code>Add Euclidean rhythm generation and array rotation algorithms</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/80/files#diff-56fb9c78274f664328003a575604ebed627a8f545ad9a938dd3d8f51793b2121">+58/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>named-patterns.ts</strong><dd><code>Define a library of canonical named rhythmic patterns</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/80/files#diff-409960873a10c1b4a3b21f0ba6d821709975e1132a95ef120539107bdece3ecb">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notes-formatter.ts</strong><dd><code>Convert boolean step patterns into `bar|beat` notation strings</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/80/files#diff-00701c620d3b9cef5260948e727d8b5aed6c2817552d8b86208fcf7feea6d986">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CLAUDE.md</strong><dd><code>Update tool count and list `adj-generate` in the main documentation</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/80/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PROJECT_INDEX.md</strong><dd><code>Update tool count and list `adj-generate` in the project index</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/80/files#diff-6b62521c254cc758592c5074ff3eb506453d30d7d0fa720b6c0ff948e3b54120">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

