### PR TITLE
fix: sync src/shared/version.ts with release-please bumps

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,14 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "packages": {
-    ".": {}
+    ".": {
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "src/shared/version.ts"
+        }
+      ]
+    }
   },
   "changelog-sections": [
     { "type": "feat", "section": "Features" },

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -4,7 +4,7 @@
 
 // Semantic versioning: major.minor.patch
 // Currently in pre-release, working towards 1.0.0
-export const VERSION = "1.6.0";
+export const VERSION = "1.8.0"; // x-release-please-version
 
 // Minimum required Ableton Live version (no "v" prefix)
 export const MIN_LIVE_VERSION = "12.3.0";


### PR DESCRIPTION
### **User description**
## Problem

`src/shared/version.ts` exports a hardcoded `VERSION` constant. Release-please bumps `package.json` on each release but never touched `version.ts`. Result: every dist bundle since v1.6.0 reports the wrong version at runtime.

Concrete: v1.7.0 and v1.8.0 both ship dist bundles whose adapter logs `\"1.6.0 Live API adapter ready\"` because `VERSION` was frozen at `\"1.6.0\"`.

## Fix

1. Add `extra-files` to `release-please-config.json` pointing at `src/shared/version.ts`
2. Annotate the version line in `version.ts` with `// x-release-please-version` — the marker release-please's `generic` updater scans for
3. Bump current value to `1.8.0` to unblock testing

Future releases will update both files atomically.

## Test plan

- [x] Build succeeds — `npm run build`
- [x] Bundle reports correct version — `grep -o '1\\.[0-9]\\.[0-9]' dist/live-api-adapter.js` returns `1.8.0`
- [ ] Verify on next release: release-please PR diff includes both `package.json` and `src/shared/version.ts`


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes stale `VERSION` constant in `src/shared/version.ts`.

- Configures `release-please` to update `version.ts`.

- Updates `VERSION` to `1.8.0` for immediate correction.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["release-please"] -- "Updates version" --> B["package.json"];
  A -- "Updates version" --> C["src/shared/version.ts"];
  C -- "Provides correct version" --> D["Dist Bundle"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version.ts</strong><dd><code>Update version constant and add release-please annotation</code></dd></summary>
<hr>

src/shared/version.ts

<ul><li>Updated the <code>VERSION</code> constant from <code>"1.6.0"</code> to <code>"1.8.0"</code>.<br> <li> Added the <code>// x-release-please-version</code> annotation to the <code>VERSION</code> line.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/82/files#diff-1689d187e184968cae22728972bef890ce607727aed5d86b17af607f6fc6518e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-please-config.json</strong><dd><code>Configure release-please to update `version.ts`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-please-config.json

<ul><li>Added <code>extra-files</code> configuration under the root package.<br> <li> Configured <code>release-please</code> to update <code>src/shared/version.ts</code> using the <br><code>generic</code> type.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/82/files#diff-c55d4dcb68c348b2c06d263819702fbce72eeeb35b662956d02049a5a18fcf2b">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

