### PR TITLE
fix: correct adj-generate note output to put pitch before time

### DIFF
--- a/dist/ableton-dj-mcp-portal.js
+++ b/dist/ableton-dj-mcp-portal.js
@@ -29287,7 +29287,7 @@ const EMPTY_COMPLETION_RESULT = {
   }
 };
 
-const VERSION = "1.6.0";
+const VERSION = "1.8.0";
 
 const MAX_SPLIT_POINTS = 32;
 
@@ -29627,6 +29627,59 @@ const toolDefUpdateDevice = defineTool("adj-update-device", {
   }
 });
 
+const T = true;
+
+const F = false;
+
+const NAMED_PATTERNS = {
+  tresillo: {
+    steps: 8,
+    pattern: [ T, F, F, T, F, F, T, F ]
+  },
+  cinquillo: {
+    steps: 8,
+    pattern: [ T, F, T, T, F, T, T, F ]
+  },
+  "bossa-nova": {
+    steps: 16,
+    pattern: [ T, F, F, T, F, F, T, F, F, F, T, F, F, T, F, F ]
+  },
+  "son-clave": {
+    steps: 16,
+    pattern: [ T, F, F, T, F, F, T, F, F, F, T, F, T, F, F, F ]
+  },
+  "rumba-clave": {
+    steps: 16,
+    pattern: [ T, F, F, T, F, F, F, T, F, F, T, F, T, F, F, F ]
+  },
+  "16th-4": {
+    steps: 16,
+    pattern: [ T, F, F, F, T, F, F, F, T, F, F, F, T, F, F, F ]
+  }
+};
+
+const NAMED_PATTERN_NAMES = Object.keys(NAMED_PATTERNS);
+
+const toolDefGenerate = defineTool("adj-generate", {
+  title: "Generate",
+  description: "Generate algorithmic note patterns. Returns notes in bar|beat notation that plug directly into adj-create-clip's `notes` param. Pure computation, no Live API calls.",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false
+  },
+  inputSchema: {
+    algorithm: _enum$2([ "euclidean" ]).describe("euclidean: Bjorklund-style even distribution of pulses"),
+    pattern: _enum$2(NAMED_PATTERN_NAMES).optional().describe(`named pattern (overrides steps/pulses/rotation): ${NAMED_PATTERN_NAMES.join(", ")}`),
+    pitch: string$1().describe("MIDI note name for hits (e.g., C1, F#2)"),
+    steps: number().int().positive().optional().describe("total steps per bar (e.g., 16 for sixteenths)"),
+    pulses: number().int().min(0).optional().describe("active hits to distribute across steps"),
+    rotation: number().int().optional().describe("rotate pattern left by N steps (default 0)"),
+    bars: number().int().positive().optional().describe("how many bars to tile the pattern across (default 1)"),
+    velocity: number().int().min(0).max(127).optional().describe("hit velocity 0-127 (default 100)"),
+    duration: string$1().optional().describe("note duration in barbeat syntax without `t` prefix (e.g., /16, 1/8). default: one step length")
+  }
+});
+
 const toolDefReadLiveSet = defineTool("adj-read-live-set", {
   title: "Read Live Set",
   description: "Read Live Set global settings, track/scene overview. Returns overview by default. Use include to add detail.",
@@ -29895,7 +29948,7 @@ const toolDefContext = defineTool("adj-context", {
   }
 });
 
-const STANDARD_TOOL_DEFS = [ toolDefConnect, toolDefContext, toolDefReadLiveSet, toolDefUpdateLiveSet, toolDefReadTrack, toolDefCreateTrack, toolDefUpdateTrack, toolDefReadScene, toolDefCreateScene, toolDefUpdateScene, toolDefReadClip, toolDefCreateClip, toolDefUpdateClip, toolDefReadDevice, toolDefCreateDevice, toolDefUpdateDevice, toolDefDelete, toolDefDuplicate, toolDefSelect, toolDefPlayback ];
+const STANDARD_TOOL_DEFS = [ toolDefConnect, toolDefContext, toolDefReadLiveSet, toolDefUpdateLiveSet, toolDefReadTrack, toolDefCreateTrack, toolDefUpdateTrack, toolDefReadScene, toolDefCreateScene, toolDefUpdateScene, toolDefReadClip, toolDefCreateClip, toolDefUpdateClip, toolDefReadDevice, toolDefCreateDevice, toolDefUpdateDevice, toolDefDelete, toolDefDuplicate, toolDefSelect, toolDefPlayback, toolDefGenerate ];
 
 Object.freeze(STANDARD_TOOL_DEFS.map(td => td.toolName));
 

--- a/dist/live-api-adapter.js
+++ b/dist/live-api-adapter.js
@@ -1090,7 +1090,7 @@ function hasPreReleaseSuffix(version) {
   return cleaned.includes("-");
 }
 
-const VERSION = "1.6.0";
+const VERSION = "1.8.0";
 
 const MIN_LIVE_VERSION = "12.3.0";
 
@@ -1782,7 +1782,7 @@ function determineAutoDetailView({clipId: clipId, deviceId: deviceId, devicePath
   return void 0;
 }
 
-const DEFAULT_VELOCITY = 100;
+const DEFAULT_VELOCITY$1 = 100;
 
 const DEFAULT_DURATION = 1;
 
@@ -5096,7 +5096,7 @@ function processPitchElement(element, state) {
     velocity = state.currentVelocityMin;
     velocityDeviation = state.currentVelocityMax - state.currentVelocityMin;
   } else {
-    velocity = state.currentVelocity ?? DEFAULT_VELOCITY;
+    velocity = state.currentVelocity ?? DEFAULT_VELOCITY$1;
     velocityDeviation = DEFAULT_VELOCITY_DEVIATION;
   }
   state.currentPitches.push({
@@ -5169,7 +5169,7 @@ function interpretNotation(barBeatExpression, options = {}) {
     const events = [];
     const state = {
       currentTime: DEFAULT_TIME,
-      currentVelocity: DEFAULT_VELOCITY,
+      currentVelocity: DEFAULT_VELOCITY$1,
       currentDuration: DEFAULT_DURATION,
       currentProbability: DEFAULT_PROBABILITY,
       currentVelocityMin: null,
@@ -10182,7 +10182,7 @@ function groupNotesByTime(sortedNotes, config) {
 
 function createInitialState() {
   return {
-    velocity: DEFAULT_VELOCITY,
+    velocity: DEFAULT_VELOCITY$1,
     velocityDeviation: DEFAULT_VELOCITY_DEVIATION,
     duration: DEFAULT_DURATION,
     probability: DEFAULT_PROBABILITY
@@ -16609,6 +16609,153 @@ function updateNonDeviceProperties(target, type, options) {
   }
 }
 
+function euclidean(pulses, steps) {
+  if (steps <= 0) {
+    throw new Error("euclidean failed: steps must be positive");
+  }
+  if (pulses < 0) {
+    throw new Error("euclidean failed: pulses must be non-negative");
+  }
+  if (pulses > steps) {
+    throw new Error("euclidean failed: pulses cannot exceed steps");
+  }
+  if (pulses === 0) {
+    return new Array(steps).fill(false);
+  }
+  const result = [];
+  let prev = -1;
+  for (let i = 0; i < steps; i++) {
+    const curr = Math.floor(i * pulses / steps);
+    result.push(curr !== prev);
+    prev = curr;
+  }
+  return result;
+}
+
+function rotate(arr, offset) {
+  if (arr.length === 0) return arr;
+  const o = (offset % arr.length + arr.length) % arr.length;
+  return [ ...arr.slice(o), ...arr.slice(0, o) ];
+}
+
+const T = true;
+
+const F = false;
+
+const NAMED_PATTERNS = {
+  tresillo: {
+    steps: 8,
+    pattern: [ T, F, F, T, F, F, T, F ]
+  },
+  cinquillo: {
+    steps: 8,
+    pattern: [ T, F, T, T, F, T, T, F ]
+  },
+  "bossa-nova": {
+    steps: 16,
+    pattern: [ T, F, F, T, F, F, T, F, F, F, T, F, F, T, F, F ]
+  },
+  "son-clave": {
+    steps: 16,
+    pattern: [ T, F, F, T, F, F, T, F, F, F, T, F, T, F, F, F ]
+  },
+  "rumba-clave": {
+    steps: 16,
+    pattern: [ T, F, F, T, F, F, F, T, F, F, T, F, T, F, F, F ]
+  },
+  "16th-4": {
+    steps: 16,
+    pattern: [ T, F, F, F, T, F, F, F, T, F, F, F, T, F, F, F ]
+  }
+};
+
+const BEATS_PER_BAR = 4;
+
+const FLOAT_PRECISION = 1e4;
+
+function formatPatternToBarbeat(opts) {
+  const {pattern: pattern, steps: steps, pitch: pitch, velocity: velocity, duration: duration, bars: bars} = opts;
+  const beatsPerStep = BEATS_PER_BAR / steps;
+  const barChunks = [];
+  for (let bar = 1; bar <= bars; bar++) {
+    const beats = [];
+    for (let step = 0; step < steps; step++) {
+      if (!pattern[step]) continue;
+      beats.push(formatBeat(step * beatsPerStep + 1));
+    }
+    if (beats.length > 0) {
+      barChunks.push(`${bar}|${beats.join(",")}`);
+    }
+  }
+  if (barChunks.length === 0) return "";
+  return `v${velocity} t${duration} ${pitch} ${barChunks.join(" ")}`;
+}
+
+function formatBeat(beat) {
+  const rounded = Math.round(beat * FLOAT_PRECISION) / FLOAT_PRECISION;
+  return String(rounded);
+}
+
+const DEFAULT_VELOCITY = 100;
+
+function generate(args = {}, _context = {}) {
+  const {algorithm: algorithm, pattern: namedPattern, pitch: pitch} = args;
+  if (!algorithm) {
+    throw new Error("generate failed: algorithm is required");
+  }
+  if (algorithm !== "euclidean") {
+    throw new Error(`generate failed: unknown algorithm "${algorithm}"`);
+  }
+  if (!pitch) {
+    throw new Error("generate failed: pitch is required");
+  }
+  const bars = args.bars ?? 1;
+  const velocity = args.velocity ?? DEFAULT_VELOCITY;
+  const rotation = args.rotation ?? 0;
+  const {steps: steps, basePattern: basePattern} = resolvePattern(namedPattern, args);
+  const rotated = rotate(basePattern, rotation);
+  const pulses = rotated.filter(Boolean).length;
+  const duration = args.duration ?? `/${steps}`;
+  const notes = formatPatternToBarbeat({
+    pattern: rotated,
+    steps: steps,
+    pitch: pitch,
+    velocity: velocity,
+    duration: duration,
+    bars: bars
+  });
+  return {
+    notes: notes,
+    steps: steps,
+    pulses: pulses,
+    rotation: rotation,
+    bars: bars
+  };
+}
+
+function resolvePattern(namedPattern, args) {
+  if (namedPattern != null) {
+    const spec = NAMED_PATTERNS[namedPattern];
+    if (!spec) {
+      throw new Error(`generate failed: unknown pattern "${namedPattern}"`);
+    }
+    return {
+      steps: spec.steps,
+      basePattern: [ ...spec.pattern ]
+    };
+  }
+  if (args.steps == null) {
+    throw new Error("generate failed: steps is required when pattern is not set");
+  }
+  if (args.pulses == null) {
+    throw new Error("generate failed: pulses is required when pattern is not set");
+  }
+  return {
+    steps: args.steps,
+    basePattern: euclidean(args.pulses, args.steps)
+  };
+}
+
 function readScene(args = {}, _context = {}) {
   const {sceneIndex: sceneIndex, sceneId: sceneId} = args;
   if (sceneId == null && sceneIndex == null) {
@@ -19194,6 +19341,7 @@ const tools = {
   "adj-update-device": args => updateDevice(args, context),
   "adj-playback": args => playback(args, context),
   "adj-select": args => select(args, context),
+  "adj-generate": args => generate(args, context),
   "adj-delete": args => deleteObject(args, context),
   "adj-duplicate": args => {
     initHoldingArea();

--- a/dist/mcp-server.mjs
+++ b/dist/mcp-server.mjs
@@ -795,7 +795,7 @@ function hasPreReleaseSuffix(version) {
   return cleaned.includes("-");
 }
 
-const VERSION = "1.6.0";
+const VERSION = "1.8.0";
 
 var RequestError = class extends Error {
   constructor(message, options) {
@@ -51373,6 +51373,59 @@ const toolDefUpdateDevice = defineTool("adj-update-device", {
   }
 });
 
+const T = true;
+
+const F = false;
+
+const NAMED_PATTERNS = {
+  tresillo: {
+    steps: 8,
+    pattern: [ T, F, F, T, F, F, T, F ]
+  },
+  cinquillo: {
+    steps: 8,
+    pattern: [ T, F, T, T, F, T, T, F ]
+  },
+  "bossa-nova": {
+    steps: 16,
+    pattern: [ T, F, F, T, F, F, T, F, F, F, T, F, F, T, F, F ]
+  },
+  "son-clave": {
+    steps: 16,
+    pattern: [ T, F, F, T, F, F, T, F, F, F, T, F, T, F, F, F ]
+  },
+  "rumba-clave": {
+    steps: 16,
+    pattern: [ T, F, F, T, F, F, F, T, F, F, T, F, T, F, F, F ]
+  },
+  "16th-4": {
+    steps: 16,
+    pattern: [ T, F, F, F, T, F, F, F, T, F, F, F, T, F, F, F ]
+  }
+};
+
+const NAMED_PATTERN_NAMES = Object.keys(NAMED_PATTERNS);
+
+const toolDefGenerate = defineTool("adj-generate", {
+  title: "Generate",
+  description: "Generate algorithmic note patterns. Returns notes in bar|beat notation that plug directly into adj-create-clip's `notes` param. Pure computation, no Live API calls.",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false
+  },
+  inputSchema: {
+    algorithm: _enum$2([ "euclidean" ]).describe("euclidean: Bjorklund-style even distribution of pulses"),
+    pattern: _enum$2(NAMED_PATTERN_NAMES).optional().describe(`named pattern (overrides steps/pulses/rotation): ${NAMED_PATTERN_NAMES.join(", ")}`),
+    pitch: string$1().describe("MIDI note name for hits (e.g., C1, F#2)"),
+    steps: number().int().positive().optional().describe("total steps per bar (e.g., 16 for sixteenths)"),
+    pulses: number().int().min(0).optional().describe("active hits to distribute across steps"),
+    rotation: number().int().optional().describe("rotate pattern left by N steps (default 0)"),
+    bars: number().int().positive().optional().describe("how many bars to tile the pattern across (default 1)"),
+    velocity: number().int().min(0).max(127).optional().describe("hit velocity 0-127 (default 100)"),
+    duration: string$1().optional().describe("note duration in barbeat syntax without `t` prefix (e.g., /16, 1/8). default: one step length")
+  }
+});
+
 const toolDefReadLiveSet = defineTool("adj-read-live-set", {
   title: "Read Live Set",
   description: "Read Live Set global settings, track/scene overview. Returns overview by default. Use include to add detail.",
@@ -51641,7 +51694,7 @@ const toolDefContext = defineTool("adj-context", {
   }
 });
 
-const STANDARD_TOOL_DEFS = [ toolDefConnect, toolDefContext, toolDefReadLiveSet, toolDefUpdateLiveSet, toolDefReadTrack, toolDefCreateTrack, toolDefUpdateTrack, toolDefReadScene, toolDefCreateScene, toolDefUpdateScene, toolDefReadClip, toolDefCreateClip, toolDefUpdateClip, toolDefReadDevice, toolDefCreateDevice, toolDefUpdateDevice, toolDefDelete, toolDefDuplicate, toolDefSelect, toolDefPlayback ];
+const STANDARD_TOOL_DEFS = [ toolDefConnect, toolDefContext, toolDefReadLiveSet, toolDefUpdateLiveSet, toolDefReadTrack, toolDefCreateTrack, toolDefUpdateTrack, toolDefReadScene, toolDefCreateScene, toolDefUpdateScene, toolDefReadClip, toolDefCreateClip, toolDefUpdateClip, toolDefReadDevice, toolDefCreateDevice, toolDefUpdateDevice, toolDefDelete, toolDefDuplicate, toolDefSelect, toolDefPlayback, toolDefGenerate ];
 
 const TOOL_NAMES = Object.freeze(STANDARD_TOOL_DEFS.map(td => td.toolName));
 

--- a/src/tools/generative/helpers/notes-formatter.ts
+++ b/src/tools/generative/helpers/notes-formatter.ts
@@ -15,30 +15,41 @@ export interface FormatPatternOptions {
 }
 
 /**
- * Convert a boolean step pattern into bar|beat notation lines that plug
- * directly into adj-create-clip's `notes` parameter.
+ * Convert a boolean step pattern into bar|beat notation that plugs directly
+ * into adj-create-clip's `notes` parameter.
  *
  * Assumes 4/4: `steps` subdivisions per bar, evenly spaced.
  *
+ * Output groups beats per bar and emits properties + pitch once at the start,
+ * relying on the parser's stateful v/t/pitch behaviour. The barbeat grammar
+ * requires pitch BEFORE time positions; reversing the order silently drops
+ * the first note and shifts the rest.
+ *
  * @param opts - Pattern + format options
- * @returns Multiline string (one note per line)
+ * @returns Single-line notation string (empty if no hits)
  */
 export function formatPatternToBarbeat(opts: FormatPatternOptions): string {
   const { pattern, steps, pitch, velocity, duration, bars } = opts;
   const beatsPerStep = BEATS_PER_BAR / steps;
-  const lines: string[] = [];
+  const barChunks: string[] = [];
 
   for (let bar = 1; bar <= bars; bar++) {
+    const beats: string[] = [];
+
     for (let step = 0; step < steps; step++) {
       if (!pattern[step]) continue;
 
-      const beat = formatBeat(step * beatsPerStep + 1);
+      beats.push(formatBeat(step * beatsPerStep + 1));
+    }
 
-      lines.push(`${bar}|${beat} v${velocity} t${duration} ${pitch}`);
+    if (beats.length > 0) {
+      barChunks.push(`${bar}|${beats.join(",")}`);
     }
   }
 
-  return lines.join("\n");
+  if (barChunks.length === 0) return "";
+
+  return `v${velocity} t${duration} ${pitch} ${barChunks.join(" ")}`;
 }
 
 /**

--- a/src/tools/generative/tests/generate.test.ts
+++ b/src/tools/generative/tests/generate.test.ts
@@ -51,9 +51,7 @@ describe("generate", () => {
         pulses: 3,
       });
 
-      expect(result.notes).toBe(
-        "1|1 v100 t/8 C1\n1|2.5 v100 t/8 C1\n1|4 v100 t/8 C1",
-      );
+      expect(result.notes).toBe("v100 t/8 C1 1|1,2.5,4");
       expect(result.steps).toBe(8);
       expect(result.pulses).toBe(3);
       expect(result.rotation).toBe(0);
@@ -101,12 +99,7 @@ describe("generate", () => {
         bars: 3,
       });
 
-      const lines = result.notes.split("\n");
-
-      expect(lines).toHaveLength(3);
-      expect(lines[0]).toMatch(/^1\|1/);
-      expect(lines[1]).toMatch(/^2\|1/);
-      expect(lines[2]).toMatch(/^3\|1/);
+      expect(result.notes).toBe("v100 t/4 C1 1|1 2|1 3|1");
     });
   });
 
@@ -134,7 +127,7 @@ describe("generate", () => {
         pattern: "son-clave",
       });
 
-      expect(result.notes.split("\n")).toHaveLength(5);
+      expect(result.notes.split(",")).toHaveLength(5);
       expect(result.steps).toBe(16);
       expect(result.pulses).toBe(5);
     });

--- a/src/tools/generative/tests/notes-formatter.test.ts
+++ b/src/tools/generative/tests/notes-formatter.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import { formatPatternToBarbeat } from "../helpers/notes-formatter.ts";
 
 describe("formatPatternToBarbeat", () => {
-  it("emits one line per active step in 8-step grid", () => {
+  it("groups beats per bar with pitch and properties first (8-step grid)", () => {
     const notes = formatPatternToBarbeat({
       pattern: [true, false, false, true, false, false, true, false],
       steps: 8,
@@ -16,7 +16,7 @@ describe("formatPatternToBarbeat", () => {
       bars: 1,
     });
 
-    expect(notes).toBe("1|1 v100 t/8 C1\n1|2.5 v100 t/8 C1\n1|4 v100 t/8 C1");
+    expect(notes).toBe("v100 t/8 C1 1|1,2.5,4");
   });
 
   it("converts step positions to fractional beats in 16-step grid", () => {
@@ -31,10 +31,10 @@ describe("formatPatternToBarbeat", () => {
       bars: 1,
     });
 
-    expect(notes).toBe("1|1 v90 t/16 D2\n1|1.5 v90 t/16 D2");
+    expect(notes).toBe("v90 t/16 D2 1|1,1.5");
   });
 
-  it("tiles pattern across multiple bars", () => {
+  it("tiles pattern across multiple bars as space-separated chunks", () => {
     const notes = formatPatternToBarbeat({
       pattern: [true, false, false, false],
       steps: 4,
@@ -44,11 +44,7 @@ describe("formatPatternToBarbeat", () => {
       bars: 3,
     });
 
-    expect(notes.split("\n")).toStrictEqual([
-      "1|1 v100 t/4 C1",
-      "2|1 v100 t/4 C1",
-      "3|1 v100 t/4 C1",
-    ]);
+    expect(notes).toBe("v100 t/4 C1 1|1 2|1 3|1");
   });
 
   it("returns empty string when pattern has no hits", () => {


### PR DESCRIPTION
### **User description**
## Bug

`adj-generate` ships note strings in the wrong order for the barbeat parser. The parser is stateful and requires pitch BEFORE time positions. The old output `1|1 v100 t/8 C1` is parsed as:

1. `1|1` = time position (no buffered pitch → warning: \"Time position 1|1 has no pitches\")
2. `v100 t/8 C1` = properties + buffer C1 for next emission

Result: every generated clip drops the first note and shifts all remaining notes by one position. Tresillo at `1|1, 1|2.5, 1|4` becomes notes at `1|2.5, 1|4, 2|1` (and warning for 1 buffered pitch never emitted).

## Reproduction

Tested live against Ableton Live 12.3.7:

```
adj-generate(algorithm=euclidean, pattern=tresillo, pitch=C1, bars=2)
→ noteCount: 5 (expected 6)
→ WARNING: Time position 1|1 has no pitches
→ WARNING: 1 pitch(es) buffered but no time position to emit them
```

## Fix

Switch output to grouped per-bar format that emits properties + pitch once at the start and relies on parser state for subsequent positions:

```
v100 t/8 C1 1|1,2.5,4 2|1,2.5,4
```

This produces all 6 notes at the correct positions and is also more compact than the old line-per-note format.

## Test plan

- [x] Existing unit tests updated for new format — all green
- [x] `npm run check` passes — 99.28% coverage
- [x] Manual test with live Ableton: generated tresillo plays at 1|1, 1|2.5, 1|4 of each bar as expected

## Caveats

The deferred `phase-shift` algorithm in issue #34 returns two note streams. When that lands it'll need a multi-pitch variant of the formatter — separate concern.


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Introduces `adj-generate` tool for algorithmic note patterns.

- Implements Euclidean rhythm generation and named patterns.

- Corrects `adj-generate` note output format.

- Updates internal version numbers to `1.8.0`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[adj-generate Tool] --> B{Resolve Pattern};
  B -- "Named Pattern" --> C[NAMED_PATTERNS];
  B -- "Euclidean Algorithm" --> D[euclidean(pulses, steps)];
  C --> E[Base Pattern];
  D --> E;
  E --> F[rotate(pattern, rotation)];
  F --> G[formatPatternToBarbeat];
  G --> H[Bar|Beat Notes String];
  H --> A;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>notes-formatter.ts</strong><dd><code>Refactor `formatPatternToBarbeat` for grouped bar|beat notation</code></dd></summary>
<hr>

src/tools/generative/helpers/notes-formatter.ts

<ul><li>Refactored <code>formatPatternToBarbeat</code> to output notes in a single-line, <br>grouped bar|beat notation.<br> <li> Added comments explaining the parser's stateful requirement for pitch <br>before time positions.<br> <li> Changed the return type from a multiline string to a single-line <br>string.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/84/files#diff-00701c620d3b9cef5260948e727d8b5aed6c2817552d8b86208fcf7feea6d986">+18/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate.test.ts</strong><dd><code>Update `adj-generate` tests for new note format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/generative/tests/generate.test.ts

<ul><li>Updated expected note output strings in unit tests to match the new <br>grouped bar|beat format.<br> <li> Removed assertions related to the number of lines in the output.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/84/files#diff-fbf7ba824614a0b3a6d2fc258dc1c5130e6e131f8f4118f4e43fab920ba5edb0">+3/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>notes-formatter.test.ts</strong><dd><code>Update `notes-formatter` tests for grouped output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/generative/tests/notes-formatter.test.ts

<ul><li>Updated test descriptions to reflect the new grouped bar|beat output <br>format.<br> <li> Modified expected output strings in tests to align with the <br>single-line, grouped notation.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/84/files#diff-92ecfa62e83bfe3980eea51b40258d4dcf81e7dcc345285fd09c1e7ce4b32713">+5/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ableton-dj-mcp-portal.js</strong><dd><code>Implement `adj-generate` tool and update version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dist/ableton-dj-mcp-portal.js

<ul><li>Bumped the internal version number from <code>1.6.0</code> to <code>1.8.0</code>.<br> <li> Added the <code>adj-generate</code> tool definition, including its <code>title</code>, <br><code>description</code>, <code>annotations</code>, and <code>inputSchema</code>.<br> <li> Integrated the <code>adj-generate</code> tool into the <code>STANDARD_TOOL_DEFS</code> list.<br> <li> Included compiled implementations of <code>euclidean</code>, <code>rotate</code>, <br><code>NAMED_PATTERNS</code>, <code>formatPatternToBarbeat</code>, <code>formatBeat</code>, <code>generate</code>, and <br><code>resolvePattern</code> functions.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/84/files#diff-09145fb3a1fb499bb649e61afeb792066e1cde2de87ab3e45036613cabacca3b">+55/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>live-api-adapter.js</strong><dd><code>Update version and include `adj-generate` compiled code</code>&nbsp; &nbsp; </dd></summary>
<hr>

dist/live-api-adapter.js

<ul><li>Bumped the internal version number from <code>1.6.0</code> to <code>1.8.0</code>.<br> <li> Renamed <code>DEFAULT_VELOCITY</code> to <code>DEFAULT_VELOCITY$1</code> to avoid naming <br>conflicts with the newly added <code>generate</code> module.<br> <li> Included compiled implementations of <code>euclidean</code>, <code>rotate</code>, <br><code>NAMED_PATTERNS</code>, <code>formatPatternToBarbeat</code>, <code>formatBeat</code>, <code>generate</code>, and <br><code>resolvePattern</code> functions.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/84/files#diff-0a025e0ebbef610cee32b3d48fc7a6c0a353cb908b47aa3d74137d68b4a4d6dc">+153/-5</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mcp-server.mjs</strong><dd><code>Implement `adj-generate` tool and update version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dist/mcp-server.mjs

<ul><li>Bumped the internal version number from <code>1.6.0</code> to <code>1.8.0</code>.<br> <li> Added the <code>adj-generate</code> tool definition, including its <code>title</code>, <br><code>description</code>, <code>annotations</code>, and <code>inputSchema</code>.<br> <li> Integrated the <code>adj-generate</code> tool into the <code>STANDARD_TOOL_DEFS</code> list.<br> <li> Included compiled implementations of <code>euclidean</code>, <code>rotate</code>, <br><code>NAMED_PATTERNS</code>, <code>formatPatternToBarbeat</code>, <code>formatBeat</code>, <code>generate</code>, and <br><code>resolvePattern</code> functions.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/84/files#diff-5723cdad2e31879af7515acf8d027626338c319a3b51a54a5e9b239e4b4e2a73">+55/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

