### PR TITLE
docs: add findings index for AI-readable knowledge capture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,24 @@ See `docs/PROJECT_INDEX.md` — full directory map, tool list, entry points, bui
 system, notation system. See `docs/` for deeper documentation on specific
 topics.
 
+## Findings — load before non-trivial work
+
+`docs/findings/INDEX.md` lists validated facts captured from prior sessions
+(format: `[slug](path) [glob,glob] — summary`). Read INDEX before:
+
+- Writing new code in `src/` (≥10 lines)
+- Fixing bugs that aren't single-line typos
+- Editing build / release / CI config
+- Generating notes/clips programmatically
+- Deploying or modifying the `.amxd` device
+
+For each INDEX line, match the bracketed globs against your task's file paths.
+Read the linked file ONLY if matched. Skip if no match — the INDEX line itself
+is the lookup key.
+
+To capture a new validated finding, run `/update-docs` (loads
+`docs/findings/HOW-TO-WRITE.md`).
+
 ## 22 Tools (all prefixed `adj-`)
 
 | Domain     | Tools                                           |

--- a/docs/findings/HOW-TO-WRITE.md
+++ b/docs/findings/HOW-TO-WRITE.md
@@ -79,15 +79,32 @@ evidence: <PR # | commit SHA | file:line | "user confirmed">
 
 ## INDEX rules
 
-`INDEX.md` is the only file always loaded. Keep it lean.
+`INDEX.md` is the only file always loaded. Keep it lean. Lines must encode enough routing signal that Claude can decide whether to load the linked file WITHOUT loading it.
 
 Format per line:
 
 ```
-- [<slug>](<domain>/<slug>.md) — <one-sentence-summary>
+- [<slug>](<domain>/<slug>.md) [<glob>,<glob>,<glob>] — <summary>
 ```
 
-- Summary ≤ 120 chars
+### Globs
+
+The bracketed glob list is the trigger. Claude matches each glob against the file paths being touched in the current task. If any glob matches → load the finding. If none match → skip without loading.
+
+- Use `**` for deep paths (`src/notation/**`)
+- Use `*` for filename patterns (`**/notes-formatter*`)
+- Comma-separated, no spaces inside brackets
+- 2-4 globs per line ideal; >5 = finding is too broad, split it
+- Globs MUST point to the files / dirs the finding actually applies to. Vague globs poison routing.
+
+### Summary
+
+- ≤ 120 chars
+- States the fact, not its cause: `pitch must precede time` not `bug in barbeat parser`
+- Reads as a complete sentence Claude can act on without opening the file
+
+### Other rules
+
 - Sort alphabetically within domain section
 - Empty domain sections kept (so consumers know the domain exists)
 - No file at root counts as a finding except INDEX and HOW-TO-WRITE

--- a/docs/findings/HOW-TO-WRITE.md
+++ b/docs/findings/HOW-TO-WRITE.md
@@ -1,0 +1,119 @@
+# How to Write a Finding
+
+Format spec for `docs/findings/`. Loaded by `/update-docs` skill before scanning conversations. AI-optimized for reading, writing, and lazy loading.
+
+## What goes here
+
+Validated facts discovered during work. Each finding is one fact with one piece of concrete evidence. Two unrelated facts = two files.
+
+## What does NOT go here
+
+- Anything in `CLAUDE.md`, `docs/PROJECT_INDEX.md`, or `docs/contributing/`
+- Code conventions (live in `Coding-Standards.md`)
+- Architecture (live in `Architecture.md`)
+- Git history (`git log`)
+- Bug fix recipes (commit message has it)
+- Speculation, "should be true", "probably", "might also affect"
+- General programming knowledge
+
+If unsure → skip. Capturing nothing beats capturing noise.
+
+## Validation bar
+
+A finding is valid only if proven in the source conversation by ONE of:
+
+- A passing test (cite test name + file)
+- A successful tool call (cite tool name + result)
+- A grep / read result (cite file:line)
+- A working build / deploy (cite version + observed behavior)
+- An error message + reproduction
+- The user's explicit confirmation ("yes", "confirmed", "works")
+
+No other source counts. Inference, "common knowledge", and "we should remember" are rejected.
+
+## File layout
+
+```
+docs/findings/
+├── INDEX.md                   ← always loaded, one line per finding
+├── HOW-TO-WRITE.md            ← this file (loaded by /update-docs skill)
+├── dev/                       ← code, tooling, build, infra
+├── music/                     ← production techniques, sound design
+└── workflow/                  ← process, deploys, dev loop
+```
+
+## Filename rules
+
+- Path: `<domain>/<slug>.md`
+- Slug: kebab-case, ≤ 5 words, ≤ 35 chars
+- Slug names the fact, not the symptom: `barbeat-notation-order` not `barbeat-bug-fix`
+- Lowercase only
+
+## Strict file template
+
+```markdown
+---
+title: <slug-matches-filename>
+domain: <dev|music|workflow>
+validated: <YYYY-MM-DD>
+evidence: <PR # | commit SHA | file:line | "user confirmed">
+---
+
+## Fact
+<one or two sentences. The claim itself. No buildup, no preamble.>
+
+## Evidence
+<concrete proof. Code block, command output, or test name. Reproducible.>
+
+## Apply when
+<condition that triggers relevance. "Touching X", "Generating Y", "Debugging Z".>
+```
+
+### Section rules
+
+- Exactly 3 sections: Fact, Evidence, Apply when. No more, no less.
+- No "Background", "Why", "History", "Notes", "See also" — these rot
+- No links to PRs in body text — frontmatter `evidence` field only
+- Code blocks ≤ 10 lines. If you need more, you're documenting wrong thing.
+- No marketing, no "magic", no hedging
+
+## INDEX rules
+
+`INDEX.md` is the only file always loaded. Keep it lean.
+
+Format per line:
+
+```
+- [<slug>](<domain>/<slug>.md) — <one-sentence-summary>
+```
+
+- Summary ≤ 120 chars
+- Sort alphabetically within domain section
+- Empty domain sections kept (so consumers know the domain exists)
+- No file at root counts as a finding except INDEX and HOW-TO-WRITE
+
+## Deduplication
+
+Before writing a new file:
+
+1. Read INDEX
+2. grep INDEX for keywords from the candidate finding
+3. If match: read the existing file
+   - Same fact → skip, do not write
+   - Adjacent / extending fact → edit existing file's Evidence section, do not create new file
+   - Genuinely different angle → new file with disambiguating slug
+4. If no match: create new file
+
+## Anti-patterns
+
+- ❌ Two files for the same fact
+- ❌ Restating something the code, grammar, or test already documents
+- ❌ "This was discovered when…" — frontmatter has the date
+- ❌ "Note that…" — just state it
+- ❌ Stuffing multiple findings into one file to save count
+- ❌ Adding a finding because the conversation was interesting (interesting ≠ validated)
+- ❌ Documenting the bug instead of the underlying invariant ("don't do X" → "X breaks because Y")
+
+## Worked examples
+
+Look at existing files in `dev/`, `music/`, `workflow/` for canonical examples. Match their shape exactly.

--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -1,15 +1,17 @@
 # Findings Index
 
-One line per finding. Domain prefix indicates load priority. Read individual files only when working in matching context.
+One line per finding. Always loaded. Individual files load on demand only when the bracketed globs match the current task's file paths.
+
+Line format: `- [<slug>](<domain>/<slug>.md) [<glob>,<glob>] — <summary>`
 
 ## dev
-- [barbeat-notation-order](dev/barbeat-notation-order.md) — pitch must precede time pos in barbeat or first note drops + warning
-- [empty-drum-rack-silent](dev/empty-drum-rack-silent.md) — adj-create-device "Drum Rack" returns success but rack has no samples = no sound
-- [live-instrument-limit](dev/live-instrument-limit.md) — Live blocks 2nd instrument per track with vague error; delete first
-- [release-please-version-sync](dev/release-please-version-sync.md) — VERSION constants need extra-files entry + marker comment
+- [barbeat-notation-order](dev/barbeat-notation-order.md) [src/notation/barbeat/**, src/tools/generative/**, **/notes-formatter*] — pitch must precede time pos in barbeat or first note drops + warning
+- [empty-drum-rack-silent](dev/empty-drum-rack-silent.md) [src/tools/device/**, **/adj-create-device*] — adj-create-device "Drum Rack" returns success but rack has no samples = no sound
+- [live-instrument-limit](dev/live-instrument-limit.md) [src/tools/device/**, src/tools/track/**] — Live blocks 2nd instrument per track with vague error; delete first
+- [release-please-version-sync](dev/release-please-version-sync.md) [release-please-config.json, src/shared/version.ts, package.json] — VERSION constants need extra-files entry + marker comment
 
 ## music
-- [euclidean-density-sweep](music/euclidean-density-sweep.md) — vary `pulses` per section (3→5→7→11) for arrangement arc with one algorithm
+- [euclidean-density-sweep](music/euclidean-density-sweep.md) [src/tools/generative/**, **/named-patterns*] — vary `pulses` per section (3→5→7→11) for arrangement arc with one algorithm
 
 ## workflow
-- [device-deploy-flow](workflow/device-deploy-flow.md) — build → copy bundles to max-for-live-device → restart Live to load new version
+- [device-deploy-flow](workflow/device-deploy-flow.md) [max-for-live-device/**, dist/**, package.json] — build → copy bundles to max-for-live-device → restart Live to load new version

--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -1,0 +1,15 @@
+# Findings Index
+
+One line per finding. Domain prefix indicates load priority. Read individual files only when working in matching context.
+
+## dev
+- [barbeat-notation-order](dev/barbeat-notation-order.md) — pitch must precede time pos in barbeat or first note drops + warning
+- [empty-drum-rack-silent](dev/empty-drum-rack-silent.md) — adj-create-device "Drum Rack" returns success but rack has no samples = no sound
+- [live-instrument-limit](dev/live-instrument-limit.md) — Live blocks 2nd instrument per track with vague error; delete first
+- [release-please-version-sync](dev/release-please-version-sync.md) — VERSION constants need extra-files entry + marker comment
+
+## music
+- [euclidean-density-sweep](music/euclidean-density-sweep.md) — vary `pulses` per section (3→5→7→11) for arrangement arc with one algorithm
+
+## workflow
+- [device-deploy-flow](workflow/device-deploy-flow.md) — build → copy bundles to max-for-live-device → restart Live to load new version

--- a/docs/findings/dev/barbeat-notation-order.md
+++ b/docs/findings/dev/barbeat-notation-order.md
@@ -1,0 +1,25 @@
+---
+title: barbeat-notation-order
+domain: dev
+validated: 2026-04-25
+evidence: PR #84 (commit 11fb180c)
+---
+
+## Fact
+Barbeat parser is stateful. Pitch token must appear BEFORE time position in the same note expression. Reverse order silently buffers pitch for the NEXT emission, dropping the first note and shifting all subsequent positions by one.
+
+## Evidence
+Tested live against Ableton Live 12.3.7 via `adj-generate(pattern=tresillo, bars=2)` → `adj-create-clip`:
+
+```
+WRONG: "1|1 v100 t/8 C1\n1|2.5 v100 t/8 C1\n..."
+→ noteCount: 5 (expected 6)
+→ WARNING: Time position 1|1 has no pitches
+→ WARNING: 1 pitch(es) buffered but no time position to emit them
+
+RIGHT: "v100 t/8 C1 1|1,2.5,4 2|1,2.5,4"
+→ noteCount: 6, no warnings
+```
+
+## Apply when
+Generating bar|beat notation strings programmatically. Touching `src/notation/barbeat/` or anything emitting `notes` strings for `adj-create-clip` / `adj-update-clip`.

--- a/docs/findings/dev/empty-drum-rack-silent.md
+++ b/docs/findings/dev/empty-drum-rack-silent.md
@@ -1,0 +1,21 @@
+---
+title: empty-drum-rack-silent
+domain: dev
+validated: 2026-04-25
+evidence: live tool call in conversation 2026-04-25
+---
+
+## Fact
+`adj-create-device(deviceName="Drum Rack")` returns success but creates an empty rack with no samples loaded into pads. MIDI notes routed to it produce silence. There is no error or warning indicating the rack is empty.
+
+## Evidence
+```
+adj-create-device(path=t0, deviceName="Drum Rack")
+→ {id: "26", deviceIndex: 1}
+
+# Subsequent adj-playback play-session-clips on a clip with C1 notes
+# produced no audible output. Switched to Operator (default sine) → audible.
+```
+
+## Apply when
+Using `adj-create-device` for testing audio. Use synth-style instruments (Operator, Drift, Simpler) for quick audible tests. Drum Rack requires sample-loading workflow not covered by current adj-* tools.

--- a/docs/findings/dev/live-instrument-limit.md
+++ b/docs/findings/dev/live-instrument-limit.md
@@ -1,0 +1,30 @@
+---
+title: live-instrument-limit
+domain: dev
+validated: 2026-04-25
+evidence: live tool calls in conversation 2026-04-25
+---
+
+## Fact
+Ableton Live allows only one instrument device per MIDI track. Attempting to insert a second instrument via `adj-create-device` fails with vague error message that does not name the cause.
+
+## Evidence
+After successful `adj-create-device(path=t0, deviceName="Drum Rack")`:
+
+```
+adj-create-device(path=t0, deviceName="Operator")
+→ Error: createDevice failed: could not insert "Operator" at end in path "t0"
+
+adj-create-device(path=t0, deviceName="Drift")
+→ Error: createDevice failed: could not insert "Drift" at end in path "t0"
+```
+
+After `adj-delete(type=device, path=t0/d1)`:
+
+```
+adj-create-device(path=t0, deviceName="Operator")
+→ {id: "27", deviceIndex: 1}  # success
+```
+
+## Apply when
+Diagnosing "could not insert at end" errors from `adj-create-device`. Check existing devices on the track first; delete the existing instrument before adding a new one. Also relevant when designing tools that swap instruments.

--- a/docs/findings/dev/release-please-version-sync.md
+++ b/docs/findings/dev/release-please-version-sync.md
@@ -1,0 +1,37 @@
+---
+title: release-please-version-sync
+domain: dev
+validated: 2026-04-25
+evidence: PR #82 (commit 322f2080)
+---
+
+## Fact
+Release-please bumps `package.json` but ignores other files unless explicitly listed in `extra-files`. Hardcoded `VERSION` constants drift across releases — dist bundles ship with stale version strings.
+
+## Evidence
+v1.7.0 and v1.8.0 dist bundles both reported `Ableton DJ MCP 1.6.0 Live API adapter ready` because `src/shared/version.ts` was hardcoded `"1.6.0"`. Release-please bumped `package.json` only.
+
+Fix in `release-please-config.json`:
+
+```json
+{
+  "packages": {
+    ".": {
+      "extra-files": [
+        { "type": "generic", "path": "src/shared/version.ts" }
+      ]
+    }
+  }
+}
+```
+
+Marker required in target file (release-please scans for it):
+
+```ts
+export const VERSION = "1.8.1"; // x-release-please-version
+```
+
+Verified: v1.8.1 release auto-bumped both files.
+
+## Apply when
+Adding any new hardcoded version string outside `package.json`. Add the file to `extra-files` and annotate the line with `// x-release-please-version`.

--- a/docs/findings/music/euclidean-density-sweep.md
+++ b/docs/findings/music/euclidean-density-sweep.md
@@ -1,0 +1,21 @@
+---
+title: euclidean-density-sweep
+domain: music
+validated: 2026-04-25
+evidence: live demo in Ableton 12.3.7, conversation 2026-04-25
+---
+
+## Fact
+Sweeping `pulses` across (3, 5, 7, 11) at fixed `steps=16` produces a section-by-section arrangement arc using a single algorithm. Density evolution alone drives perceived energy without changing tempo, pitch, or timbre.
+
+## Evidence
+4-bar test clip via `adj-generate(steps=16, pulses=N, pitch=C3)`:
+- Bar 1, pulses=3 → `1|1, 2.5, 3.75` (sparse stabs)
+- Bar 2, pulses=5 → `1|1, 2, 2.75, 3.5, 4.25` (cinquillo density)
+- Bar 3, pulses=7 → `1|1, 1.75, 2.25, 2.75, 3.5, 4, 4.5` (full groove)
+- Bar 4, pulses=11 → 11 hits across 16 (dense psy stutter)
+
+Same root, same instrument, only `pulses` parameter changes. Audible energy ramp.
+
+## Apply when
+Generating section transitions in tech house / techno / psy. Use `pulses=3-5` for intros and breakdowns, `pulses=7-9` for main groove, `pulses=11+` for peaks. Stays inside the bar grid — no rhythmic chaos, just density curve.

--- a/docs/findings/workflow/device-deploy-flow.md
+++ b/docs/findings/workflow/device-deploy-flow.md
@@ -1,0 +1,38 @@
+---
+title: device-deploy-flow
+domain: workflow
+validated: 2026-04-25
+evidence: live deploy 1.6.0 → 1.8.0 → 1.8.1 in conversation 2026-04-25
+---
+
+## Fact
+The `.amxd` device references sibling JS files via relative path. Build artefacts must be copied from `dist/` into `max-for-live-device/` for new code to take effect. Live caches V8 bytecode per session — restart Live (or eject + reinsert device) to load updated JS.
+
+## Evidence
+`.amxd` patcher contains:
+
+```
+"text" : "v8 ./live-api-adapter.js"
+"text" : "node.script ./mcp-server.mjs @watch 1"
+```
+
+`@watch 1` auto-reloads node.script on file change. V8 does NOT auto-reload — requires device reload or Live restart.
+
+Deploy commands:
+
+```bash
+git checkout main && git pull
+npm run build
+cp dist/live-api-adapter.js max-for-live-device/live-api-adapter.js
+cp dist/mcp-server.mjs max-for-live-device/mcp-server.mjs
+# Then restart Live OR eject + reinsert .amxd
+```
+
+Verify in Live console:
+```
+node.script: [...] Ableton DJ MCP <expected-version> running.
+v8: [...] Ableton DJ MCP <expected-version> Live API adapter ready
+```
+
+## Apply when
+Deploying any code change that needs to run inside the `.amxd`. Both V8 and node.script versions must match the expected version string after restart.


### PR DESCRIPTION
## Summary

Adds `docs/findings/` — a strict, AI-optimized knowledge base for validated learnings from working sessions. Includes 3-layer routing system so Claude reliably loads the right facts at the right time.

## Structure

```
docs/findings/
├── INDEX.md              ← always loaded; one line per finding with glob hints
├── HOW-TO-WRITE.md       ← format spec (loaded by /update-docs skill)
├── dev/                  ← code, tooling, build, infra
├── music/                ← production techniques, sound design
└── workflow/             ← process, deploys, dev loop
```

## Routing system

**Layer 1 — CLAUDE.md instruction (always loaded)**
A new `## Findings — load before non-trivial work` section in `CLAUDE.md` tells Claude to read INDEX before: writing new code in src/, fixing non-trivial bugs, editing build/release config, generating notes/clips programmatically, deploying or modifying the .amxd device.

**Layer 2 — Glob hints in INDEX**
Each INDEX line now carries a bracketed glob list: `[<glob>,<glob>] — <summary>`. Claude matches globs against the current task's file paths to decide whether to load the linked file. No glob match → skip without loading. This routes context spending precisely.

Example:
```
- [barbeat-notation-order](dev/barbeat-notation-order.md) [src/notation/barbeat/**, src/tools/generative/**, **/notes-formatter*] — pitch must precede time pos in barbeat or first note drops + warning
```

**Layer 3 — PreToolUse hook auto-injection** (tracked in #87)
Future work: bash hook intercepts Edit/Write tool calls and injects matching findings as system reminders before the edit happens. Eliminates dependence on Claude remembering to check INDEX. Worth shipping once findings count > 20.

## Format

`HOW-TO-WRITE.md` defines the strict template: 3 sections only (Fact / Evidence / Apply when), one fact per file, validation bar (must cite PR/commit/tool output/file:line/explicit user confirmation). No boilerplate, no rot-prone references.

The format spec lives in the repo (not in the user-global `/update-docs` skill) so the spec evolves with the docs. Skill stays a thin entrypoint.

## Seeded findings

Six entries validated during the v1.8.x release cycle:

| File | Validation source |
|------|-------------------|
| `dev/barbeat-notation-order.md` | PR #84 (commit 11fb180c) |
| `dev/empty-drum-rack-silent.md` | live tool call output |
| `dev/live-instrument-limit.md` | live tool call output |
| `dev/release-please-version-sync.md` | PR #82 (commit 322f2080) |
| `music/euclidean-density-sweep.md` | live demo in Ableton 12.3.7 |
| `workflow/device-deploy-flow.md` | live deploy 1.6.0 → 1.8.0 → 1.8.1 |

## Out of scope

- The `/update-docs` Claude command itself lives in `~/.claude/commands/update-docs.md` (user-global). Not in this repo. PR only adds the in-repo format spec the command loads.
- PreToolUse hook for auto-injection (Layer 3) tracked separately in #87.

## Test plan

- [x] All seeded findings follow the strict template
- [x] INDEX entries match filenames + summaries fit ≤120 chars
- [x] Glob hints present on every INDEX entry
- [x] CLAUDE.md routing block instructs Claude to read INDEX before non-trivial work
- [ ] Run `/update-docs` in a future session and verify it correctly skips already-documented facts