### PR TITLE
docs: add Setup.md and Releasing.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ let the AI read and manipulate the Live set in real time.
 
 ## Setup and usage
 
-See [`docs/`](./docs/) for installation, tool reference, and developer docs.
+- [Setup](./docs/Setup.md) — install + connect your AI client (5 minutes)
+- [Tools Reference](./docs/Tools-Reference.md) — all 22 `adj-*` tools
+- [Releasing](./docs/Releasing.md) — release process + local deploy
+- [`docs/`](./docs/) — full developer docs
 
 ## License
 

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -1,0 +1,68 @@
+# Releasing
+
+How releases work + how to deploy a new version locally.
+
+## Release process (automated)
+
+Driven by [release-please](https://github.com/googleapis/release-please).
+
+1. Write commits in [Conventional Commits](https://www.conventionalcommits.org/) format:
+   - `feat: ...` → minor version bump
+   - `fix: ...` → patch version bump
+   - `perf: ...` → patch version bump
+   - `chore: ...`, `ci: ...`, `docs: ...` → no release
+   - `feat!: ...` or `BREAKING CHANGE:` footer → major version bump
+2. Merge PRs to `main` as usual
+3. Release-please opens a release PR (`chore(main): release ableton-dj-mcp X.Y.Z`) accumulating all unreleased changes
+4. Merge the release PR
+5. Release-please cuts the git tag, GitHub release, and CHANGELOG entry
+
+## Files release-please updates
+
+| File | What |
+|------|------|
+| `package.json` | `version` field |
+| `package-lock.json` | `version` field |
+| `src/shared/version.ts` | `VERSION` constant (via `// x-release-please-version` marker) |
+| `CHANGELOG.md` | new release section |
+| `.release-please-manifest.json` | tracking |
+
+To add a new file with a hardcoded version:
+
+1. Annotate the version line: `export const X = "1.0.0"; // x-release-please-version`
+2. Add to `release-please-config.json` under `extra-files`
+
+## Deploying a new version locally
+
+After a release lands on `main`:
+
+```bash
+git checkout main && git pull
+npm run build
+cp dist/live-api-adapter.js max-for-live-device/live-api-adapter.js
+cp dist/mcp-server.mjs max-for-live-device/mcp-server.mjs
+```
+
+Then in Ableton Live:
+
+1. Eject the `Ableton_DJ_MCP` device from its MIDI track (or restart Live)
+2. Re-drag `max-for-live-device/Ableton_DJ_MCP.amxd` onto the track
+3. Verify console shows the new version:
+
+```
+node.script: [...] Ableton DJ MCP <new-version> running.
+v8: [...] Ableton DJ MCP <new-version> Live API adapter ready
+```
+
+## Why the manual copy step
+
+The `.amxd` references sibling JS files via relative path (`v8 ./live-api-adapter.js`, `node.script ./mcp-server.mjs`). Rollup writes to `dist/`. Live loads from `max-for-live-device/`. Bridging them is currently manual. Tracked in [#78](https://github.com/gabrielpulga/ableton-dj-mcp/issues/78) (smoother install UX).
+
+## Verifying a release end-to-end
+
+```bash
+# Confirm bundle has the expected version baked in
+grep -o '1\.[0-9]\.[0-9]' max-for-live-device/live-api-adapter.js | sort -u
+```
+
+Should match the version in `package.json`.

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -1,0 +1,81 @@
+# Setup
+
+Install and run Ableton DJ MCP.
+
+## Requirements
+
+- Ableton Live 12.3+ with Max for Live
+- Node.js 24+
+- An MCP-compatible AI client (Claude Desktop, Claude Code, Cursor)
+
+## Install
+
+```bash
+git clone https://github.com/gabrielpulga/ableton-dj-mcp.git
+cd ableton-dj-mcp
+npm install
+npm run build
+```
+
+## Load the device in Ableton
+
+1. Open Ableton Live
+2. From your file manager, drag `max-for-live-device/Ableton_DJ_MCP.amxd` onto any MIDI track
+3. The device's status panel should show `MCP server running on :3350`
+
+## Wire up your AI client
+
+### Claude Code
+
+```bash
+claude mcp add ableton-dj-mcp -- node /absolute/path/to/ableton-dj-mcp/dist/ableton-dj-mcp-portal.js
+```
+
+Restart Claude Code. Verify with `/mcp` — should show `ableton-dj-mcp ✓ Connected`.
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "ableton-dj-mcp": {
+      "command": "node",
+      "args": ["/absolute/path/to/ableton-dj-mcp/dist/ableton-dj-mcp-portal.js"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop.
+
+### Other MCP clients
+
+Point the client at `node /absolute/path/to/dist/ableton-dj-mcp-portal.js` (stdio transport) or `http://localhost:3350/mcp` (HTTP).
+
+## Verify
+
+In your MCP client:
+
+```
+Use adj-connect
+```
+
+Expected response:
+```
+connected: true
+serverVersion: <current version>
+abletonLiveVersion: 12.3.x
+```
+
+If you see this, you're done.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Device console silent | Reload device: eject + reinsert on track, or restart Live |
+| Tool list empty in client | Restart MCP client after `claude mcp add` |
+| `connection refused :3350` | Device not loaded in Live — check the MIDI track |
+| Wrong version in console | Stale bundle. See [Releasing.md](Releasing.md) |


### PR DESCRIPTION
### **User description**
## Summary

Splits user setup and maintainer release process into dedicated docs. README points directly at both.

## Files

- `docs/Setup.md` — install + AI client wire-up + verification + troubleshooting
- `docs/Releasing.md` — release-please flow + local deploy + version verification
- `README.md` — direct links instead of vague `docs/` pointer

## Style

Both follow:
- Command-based, copy-pasteable
- Tables for symptom → fix mappings
- No prose padding, no marketing
- Verification step at end (so you know it worked)

## Why two docs

- Setup audience = first-time users wanting to run it
- Releasing audience = maintainers cutting + deploying versions

Different mental models, different flows. Splitting keeps each tight.

## Test plan

- [x] All commands in Setup.md verified against actual install flow
- [x] Releasing.md flow validated end-to-end this session (1.6.0 → 1.8.0 → 1.8.1)
- [x] README links resolve


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Introduce dedicated `Setup.md` and `Releasing.md` guides.

- Add `docs/findings/` for AI-optimized knowledge capture.

- Update `CLAUDE.md` to route AI to findings via globs.

- Provide five initial validated findings across domains.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[README.md] --> B[docs/Setup.md]
  A --> C[docs/Releasing.md]
  D[CLAUDE.md] --> E[docs/findings/INDEX.md]
  E --> F[docs/findings/HOW-TO-WRITE.md]
  E --> G[docs/findings/dev/]
  E --> H[docs/findings/music/]
  E --> I[docs/findings/workflow/]
  J[/update-docs command] --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>CLAUDE.md</strong><dd><code>Add instructions for Claude to use `docs/findings/INDEX.md`</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/88/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Update setup and usage section with direct links to new guides</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/88/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Releasing.md</strong><dd><code>Add new guide for automated release process and local deployment</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/88/files#diff-9a5cd11aab4a7fc63f51a3cb478cd16e98b5cc469c4864c21d973a7d1a7185d4">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Setup.md</strong><dd><code>Add new guide for installation, AI client setup, and troubleshooting</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/88/files#diff-1393eb0e52723929a63057d6bc302625419885a2ebd998e20ff029b5d82cf721">+81/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HOW-TO-WRITE.md</strong><dd><code>Add new guide defining the strict format for writing findings</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/88/files#diff-f3d40a17bba34ad852e894e503d77669935459f175d8daa23748388cc1a29138">+136/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>INDEX.md</strong><dd><code>Add new index for findings with glob-based lazy loading</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/88/files#diff-979fccfe801351786b9cff5fb897af3ff04082c758a89f3c81ac6903e5592f98">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>barbeat-notation-order.md</strong><dd><code>Add finding on barbeat parser's pitch/time order dependency</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/88/files#diff-f84ecb27854317a3c95eee7557523c4475d3bc60674ea874800585ca94b11420">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>empty-drum-rack-silent.md</strong><dd><code>Add finding on `adj-create-device` creating silent empty Drum Racks</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/88/files#diff-20ff87f8a16dde34428e5005cf300cf4f5d67edb03ea8062cf160655406ec29d">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>live-instrument-limit.md</strong><dd><code>Add finding on Ableton Live's one-instrument-per-MIDI-track limit</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/88/files#diff-99d9aa733ebdc04e9b00a15213c13792f0d65961a738ed71e05825d23159025e">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>release-please-version-sync.md</strong><dd><code>Add finding on syncing `VERSION` constants with `release-please`</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/88/files#diff-bc57b50891601de4bef2543c3a86ae885c2269e8c56c86a96c88683fd95e27d5">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>euclidean-density-sweep.md</strong><dd><code>Add finding on using <code>pulses</code> for arrangement arcs in Euclidean patterns</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/88/files#diff-02be225cda9ad5e9ce69cfda05611d006cc36af5a2488a9f642581050377343c">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>device-deploy-flow.md</strong><dd><code>Add finding detailing the device deployment flow and Live's caching</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/88/files#diff-6f20dfa1986ef134c4cfe1dca23ada062496a05a88d357faeb600019ae974731">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

