### PR TITLE
feat(workspace): add findings system + mandatory capture rule

### DIFF
--- a/workspace.template/AI.md
+++ b/workspace.template/AI.md
@@ -13,8 +13,18 @@ Your personal music context, gitignored, alongside the Ableton DJ MCP tooling.
 Holds:
 
 - `projects/` — active songs you're working on
-- `genres/` — genre-specific production patterns you've distilled
-- `techniques/` — cross-genre techniques and reference notes
+- `findings/` — validated music knowledge from sessions (strict format,
+  AI-routed)
+- `genres/` — freeform notes per genre (long-form analysis, reference dumps)
+- `techniques/` — freeform technique writeups
+
+`findings/` vs `genres/` + `techniques/`:
+
+- **findings/** = atomic, validated, indexed for AI routing. One fact per file.
+  Used by AI to look up specific knowledge fast. See `findings/HOW-TO-WRITE.md`.
+- **genres/ + techniques/** = freeform long-form notes you write for yourself.
+  Reference dumps, deep analyses, brain dumps. AI reads them when relevant but
+  they're not strictly formatted.
 
 Edit freely. Nothing here is pushed to the public repo.
 
@@ -81,6 +91,68 @@ Each project in `projects/<name>/` should have `<name>.md` summarizing:
 - Last session's progress
 
 Keep it short. The file is the AI's memory of your project.
+
+## Findings — load before non-trivial music work
+
+`findings/INDEX.md` lists validated music techniques captured from prior
+sessions (format: `[slug](path) [glob,glob] — summary`). Read INDEX before:
+
+- Generating clips for a new section
+- Picking sounds (instrument selection, velocity ranges)
+- Designing arrangement structure
+- Working in a specific genre for the first time in the session
+
+For each INDEX line, match the bracketed globs against your task's keywords
+(genre, section, instrument). Read the linked file ONLY if matched. Skip if no
+match — the INDEX line itself is the lookup key.
+
+## ALWAYS capture findings during sessions
+
+This is the rule, not optional. Every music session produces knowledge — capture
+it or lose it.
+
+### What to capture
+
+| Discovery type                                      | Where to capture                                         |
+| --------------------------------------------------- | -------------------------------------------------------- |
+| MCP tool bug, missing feature, or workflow friction | **File a GitHub issue** in `gabrielpulga/ableton-dj-mcp` |
+| Tool quirk that changes how you use the tool        | Skip — covered by `docs/findings/` in the repo           |
+| Music technique that worked in this session         | `workspace/findings/technique/<slug>.md`                 |
+| Genre-specific pattern from reference analysis      | `workspace/findings/genre/<slug>.md`                     |
+| Sound design recipe (pad, lead, bass, kick)         | `workspace/findings/sound-design/<slug>.md`              |
+
+### When to capture
+
+- After a clip you generated sounds clearly right (or clearly wrong, with the
+  lesson)
+- After you analyze a reference track and extract a pattern
+- After an A/B test where one approach won
+- After hitting friction with the tool that you'd want fixed
+
+Don't wait until end of session. Capture immediately when validated — memory
+fades, sessions get long.
+
+### How to capture
+
+Run `/update-docs` in your AI client. It loads
+`workspace/findings/HOW-TO-WRITE.md` for the format spec, then scans the
+conversation, dedups against INDEX, and writes only validated findings.
+
+For tool issues: ask the AI to file a GitHub issue with concrete reproduction
+steps.
+
+### Why this matters
+
+You are the only user and primary source of music knowledge for this workspace.
+The AI is the developer/executor, but cannot remember across sessions without
+captured findings. This is the feedback loop:
+
+```
+session → discovery → captured finding → loaded next session → better output
+session → tool friction → GitHub issue → tool improvement → smoother sessions
+```
+
+Without capture, every session starts from zero.
 
 ## Customize this file
 

--- a/workspace.template/findings/HOW-TO-WRITE.md
+++ b/workspace.template/findings/HOW-TO-WRITE.md
@@ -1,0 +1,154 @@
+# How to Write a Music Finding
+
+Format spec for `workspace/findings/`. Loaded by `/update-docs` skill before
+writing. AI-optimized: lazy loading, no duplicates, no boilerplate.
+
+Mirror of `docs/findings/HOW-TO-WRITE.md` (the tool/dev findings spec) but tuned
+for music production knowledge.
+
+## What goes here
+
+Validated music production knowledge captured during real sessions. Each finding
+is one technique, one observation, or one rule with concrete evidence from your
+own work.
+
+## What does NOT go here
+
+- Tool bugs or feature requests → file as a GitHub issue in
+  `gabrielpulga/ableton-dj-mcp` instead
+- Generic music theory available anywhere on the web
+- Things from a tutorial or article (unless you tested them yourself and it
+  worked)
+- Speculation: "I think X would sound good"
+- Restating what's already in `AI.md`
+
+## Validation bar
+
+A music finding is valid only if proven in a real session by ONE of:
+
+- A clip you generated that sounded right (cite project + clip name)
+- A reference track analysis you completed (cite track + timestamp)
+- An A/B test where one approach clearly worked better (cite both)
+- A failure that taught you what NOT to do (cite the symptom)
+- A technique you applied across multiple projects with consistent results
+
+If you can't point to a specific session, project, or audio output → don't write
+the finding.
+
+## File layout
+
+```
+workspace/findings/
+├── INDEX.md                 ← always loaded, one line per finding
+├── HOW-TO-WRITE.md          ← this file
+├── genre/                   ← genre-specific patterns (techno, house, psy, etc.)
+├── technique/               ← cross-genre techniques (mixing, arrangement, sound design)
+└── sound-design/            ← specific sound recipes (pads, leads, kicks, basses)
+```
+
+Add new domains as needed. Mirror the routing-by-glob pattern.
+
+## Filename rules
+
+- Path: `<domain>/<slug>.md`
+- Slug: kebab-case, ≤ 5 words
+- Slug names the technique, not the symptom: `bass-off-beat-rule` not
+  `bass-sounds-bad-fix`
+- Lowercase only
+
+## Strict file template
+
+```markdown
+---
+title: <slug-matches-filename>
+domain: <genre|technique|sound-design>
+genre: <house|techno|melodic-techno|psy|indie-dance|all>
+validated: <YYYY-MM-DD>
+evidence: <project name | reference track | session description>
+---
+
+## Fact
+
+<one or two sentences. The technique itself. No buildup.>
+
+## Evidence
+
+<concrete proof: project where it worked, reference track that uses it, A/B
+comparison, or failed attempt that taught the lesson.>
+
+## Apply when
+
+<condition that triggers relevance: genre, section type, instrument, or
+production stage.>
+```
+
+### Section rules
+
+- Exactly 3 sections: Fact, Evidence, Apply when
+- No "Background", "Why", "History" — they rot
+- No marketing language ("warm", "punchy", "magic") without explaining HOW
+- Code blocks for exact parameters only — bar|beat notation, velocity, BPM
+- Reference real artists/tracks if the technique came from analysis
+
+## INDEX rules
+
+`INDEX.md` is always loaded by AI sessions in `workspace/`. Keep it lean.
+
+Format per line:
+
+```
+- [<slug>](<domain>/<slug>.md) [<glob>,<glob>] — <summary>
+```
+
+Globs match against:
+
+- Genre keywords in your prompt (`techno`, `psy`, `melodic`)
+- Section keywords (`intro`, `breakdown`, `peak`, `outro`)
+- Instrument keywords (`bass`, `kick`, `lead`, `pad`)
+- Project file paths (`projects/melodic-track/**`)
+
+Examples:
+
+```
+- [bass-off-beat-rule](technique/bass-off-beat-rule.md) [bass*, melodic*, techno*] — first bass hit at 1.25 not 1, creates pump against kick
+- [psy-acid-bassline](genre/psy-acid-bassline.md) [psy*, acid*, bass*] — 16th-note pattern with filter env, root + b2 + root within bar
+```
+
+Summary ≤ 120 chars. Sort alphabetically within domain.
+
+## Deduplication
+
+Before writing:
+
+1. Read INDEX
+2. grep for keywords from the candidate finding
+3. If match → read existing file → extend or skip
+4. If no match → new file
+
+Two files for same fact = wasted context.
+
+## Anti-patterns
+
+- ❌ "Tried X, didn't work, will try Y" — not validated yet, save when Y works
+- ❌ "Generic minor key sounds emotional" — too generic, not actionable
+- ❌ Multiple findings stuffed in one file
+- ❌ "Use this for any genre" — too broad, hurts routing
+- ❌ Documenting a one-off accident as a rule
+
+## When in doubt, skip
+
+Better to capture nothing than to capture noise. Bad findings rot the knowledge
+base faster than good ones grow it.
+
+## Tool vs music findings
+
+| Discovery type                             | Where to capture                                   |
+| ------------------------------------------ | -------------------------------------------------- |
+| MCP tool bug or missing feature            | GitHub issue in `gabrielpulga/ableton-dj-mcp`      |
+| MCP tool quirk that affects how you use it | `docs/findings/dev/` (in tool repo, public)        |
+| Music technique that worked                | `workspace/findings/technique/` (here, private)    |
+| Genre-specific pattern from analysis       | `workspace/findings/genre/` (here, private)        |
+| Sound design recipe                        | `workspace/findings/sound-design/` (here, private) |
+
+When unsure: if it's about HOW to use the tool, it's tool. If it's about WHAT to
+make musically, it's music.

--- a/workspace.template/findings/INDEX.md
+++ b/workspace.template/findings/INDEX.md
@@ -1,0 +1,26 @@
+# Music Findings Index
+
+One line per finding. Always loaded in `workspace/` sessions. Individual files
+load on demand only when bracketed globs match the current task's context
+(genre, section, instrument, or file path).
+
+Line format: `- [<slug>](<domain>/<slug>.md) [<glob>,<glob>] — <summary>`
+
+## genre
+
+## technique
+
+## sound-design
+
+<!-- Examples (delete or replace with your real findings):
+
+## technique
+- [bass-off-beat-rule](technique/bass-off-beat-rule.md) [bass*, melodic*, techno*] — first bass hit at 1.25 not 1, creates pump against kick
+
+## genre
+- [psy-acid-bassline](genre/psy-acid-bassline.md) [psy*, acid*, bass*] — 16th-note pattern with filter env, root + b2 + root within bar
+
+## sound-design
+- [innellea-pluck-velocity](sound-design/innellea-pluck-velocity.md) [pluck*, melodic*, arp*] — root v94, 3rd v45, 5th v59, octave v72 — velocity shapes the arp
+
+-->


### PR DESCRIPTION
### **User description**
Follow-up to #90 (workspace scaffold). Adds a music-findings knowledge base mirroring `docs/findings/` but gitignored and tuned for music production.

## What's new

### `workspace.template/findings/`

Atomic, AI-routed knowledge base. Same philosophy as `docs/findings/`:

- `HOW-TO-WRITE.md` — strict format spec (Fact / Evidence / Apply when), validation bar tuned for music (clip generated, reference analyzed, A/B test, applied across projects)
- `INDEX.md` — always loaded, glob-routed lookup
- `genre/`, `technique/`, `sound-design/` — domain dirs

### Updated `AI.md`

**Distinguishes two knowledge layers:**

- `findings/` — atomic, validated, AI-routed (one fact per file)
- `genres/` + `techniques/` — freeform long-form notes (brain dumps, deep analysis)

**Mandates capture during every session.** Not optional. Routing table:

| Discovery | Where |
|---|---|
| Tool bug or feature request | GitHub issue in `gabrielpulga/ableton-dj-mcp` |
| Tool quirk you have to work around | `docs/findings/dev/` in tool repo |
| Music technique that worked | `workspace/findings/technique/` |
| Genre pattern from analysis | `workspace/findings/genre/` |
| Sound design recipe | `workspace/findings/sound-design/` |

**Documents the feedback loop:**

```
session → discovery → captured finding → loaded next session → better output
session → tool friction → GitHub issue → tool improvement → smoother sessions
```

## Why two knowledge tiers (findings vs freeform)

- Findings: AI lookup, fast routing, tight format, hurts when bloated
- Freeform: human-writeable references, room for nuance, consumed when AI needs deep context

Both serve different purposes. Trying to use one for both = either too rigid or too noisy.

## Out of scope

The `/update-docs` skill at `~/.claude/commands/update-docs.md` (user-global) needs updating to detect cwd and route to the right findings dir. Already done locally for me — but it's user config, not in the repo.

## Test plan

- [x] `npm run init:workspace` after this PR creates `findings/` with HOW-TO-WRITE + INDEX + 3 domain dirs
- [x] AI.md lints clean (`npm run check`)
- [ ] Run a real music session, capture a finding via `/update-docs`, verify it lands in `workspace/findings/` (deferred to actual use)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduces a `findings/` system for validated music knowledge.

- Defines strict format and validation rules for findings.

- Updates `AI.md` to mandate finding capture.

- Provides a clear routing table for different discovery types.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[User Session] --> B{Discovery};
  B -- guides capture --> C[workspace.template/AI.md];
  C -- instructs to run --> D[/update-docs skill];
  D -- uses format from --> E[workspace.template/findings/HOW-TO-WRITE.md];
  E -- writes to --> F[workspace.template/findings/<domain>/<slug>.md];
  F -- updates --> G[workspace.template/findings/INDEX.md];
  G -- loaded by AI in --> A;
  B -- if tool issue --> H[GitHub Issue];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AI.md</strong><dd><code>Update AI guidance for music findings and capture rules</code>&nbsp; &nbsp; </dd></summary>
<hr>

workspace.template/AI.md

<ul><li>Defines <code>findings/</code> as a new, validated knowledge layer, distinguishing <br>it from <code>genres/</code> and <code>techniques/</code>.<br> <li> Mandates capturing findings during sessions and provides a routing <br>table for different discovery types.<br> <li> Explains the feedback loop between sessions, discoveries, captured <br>findings, and improved AI output.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/92/files#diff-c65c867b8a8e0071898da41ae32e6196ca07924457b7a0d3bb51f6b2841aafcf">+74/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HOW-TO-WRITE.md</strong><dd><code>Define strict format for music findings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspace.template/findings/HOW-TO-WRITE.md

<ul><li>Creates a new file establishing a strict format specification for <br>music findings.<br> <li> Outlines validation criteria, file layout, naming rules, and section <br>rules for findings.<br> <li> Differentiates between tool-related findings (public) and <br>music-related findings (private).</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/92/files#diff-9b87c4906ecf1552ebfc6d2f77899400b665c18d8ed563faabc8e9a2f7b8b807">+154/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>INDEX.md</strong><dd><code>Create index for music findings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspace.template/findings/INDEX.md

<ul><li>Creates a new file to serve as an index for music findings.<br> <li> Details the line format for findings, including slug, domain, globs, <br>and summary.<br> <li> Provides commented-out examples to guide users on how to add new <br>entries.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/92/files#diff-25459d374ae9c2a72ee77fd4c7fd048c6f1873dc1963aac53826152832f5270e">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

