### PR TITLE
feat: add 5 standalone playback workflow actions

### DIFF
--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -175,9 +175,16 @@ Control transport, session clips, and Live set history.
   - `"undo"` — undo last Live set action
   - `"redo"` — redo last undone action
   - `"save"` — save Live set to disk
+  - `"back-to-arranger"` — clear session override so arrangement resumes
+  - `"capture-midi"` — capture buffered MIDI into a clip retroactively
+  - `"capture-scene"` — snapshot playing session clips into a new scene
+  - `"record"` — toggle arrangement record mode
+  - `"re-enable-automation"` — re-engage automation overridden by manual edits
 - Response includes `playing`, `currentTime`, optional `arrangementLoop`.
 - For `"undo"` / `"redo"` / `"save"`, response also includes `canUndo` and
   `canRedo` booleans — check these before calling undo/redo to avoid no-ops.
+- For `"record"`, response includes `recording: boolean` reflecting the new
+  record-mode state.
 
 ---
 

--- a/docs/gap-analysis.md
+++ b/docs/gap-analysis.md
@@ -429,6 +429,9 @@ control.
 
 ## Gap 11: Capture MIDI
 
+**Status:** Shipped — `capture-midi` and `capture-scene` actions on
+`adj-playback`.
+
 **What it is:** Trigger Live's "Capture MIDI" feature — retroactively captures
 notes you just played from Live's MIDI buffer, even before you hit record. Also
 `capture_and_insert_scene` — captures all currently playing clips and creates a
@@ -621,6 +624,9 @@ was set. Verify if our read-device already returns them.
 ---
 
 ## Gap 15: `back_to_arranger` / Record
+
+**Status:** Shipped — `back-to-arranger`, `record`, `re-enable-automation`
+actions on `adj-playback`.
 
 **What it is:** `back_to_arranger` dismisses session view override (red "Back to
 Arrangement" button in Live). `start_recording` / `stop_recording` arm

--- a/src/tools/control/helpers/playback-helpers.ts
+++ b/src/tools/control/helpers/playback-helpers.ts
@@ -294,6 +294,82 @@ interface LiveSetHistoryResult {
 
 export type LiveSetHistoryAction = "undo" | "redo" | "save";
 
+export type StandalonePlaybackAction =
+  | "back-to-arranger"
+  | "capture-midi"
+  | "capture-scene"
+  | "record"
+  | "re-enable-automation";
+
+interface StandalonePlaybackResult {
+  playing: boolean;
+  currentTime: string;
+  recording?: boolean;
+}
+
+/**
+ * Handle standalone Live set workflow actions that don't take transport or
+ * loop params (back-to-arranger, capture-midi, capture-scene, record,
+ * re-enable-automation).
+ *
+ * @param action - The standalone action to perform
+ * @returns Current transport state plus optional recording flag for record
+ */
+export function handleStandalonePlaybackAction(
+  action: StandalonePlaybackAction,
+): StandalonePlaybackResult {
+  const liveSet = LiveAPI.from(livePath.liveSet);
+  let recording: boolean | undefined;
+
+  switch (action) {
+    case "back-to-arranger":
+      liveSet.set("back_to_arranger", 0);
+      break;
+    case "capture-midi":
+      liveSet.call("capture_midi");
+      break;
+    case "capture-scene":
+      liveSet.call("capture_and_insert_scene");
+      break;
+
+    case "record": {
+      const current = (liveSet.getProperty("record_mode") as number) > 0;
+      const next = !current;
+
+      liveSet.set("record_mode", next ? 1 : 0);
+      recording = next;
+      break;
+    }
+
+    case "re-enable-automation":
+      liveSet.call("re_enable_automation");
+      break;
+    default:
+      throw new Error(
+        `playback failed: unknown standalone action "${String(action)}"`,
+      );
+  }
+
+  const numerator = liveSet.getProperty("signature_numerator") as number;
+  const denominator = liveSet.getProperty("signature_denominator") as number;
+  const currentTimeBeats = liveSet.getProperty("current_song_time") as number;
+
+  const result: StandalonePlaybackResult = {
+    playing: (liveSet.getProperty("is_playing") as number) > 0,
+    currentTime: abletonBeatsToBarBeat(
+      currentTimeBeats,
+      numerator,
+      denominator,
+    ),
+  };
+
+  if (recording != null) {
+    result.recording = recording;
+  }
+
+  return result;
+}
+
 /**
  * Handle undo/redo/save on the Live set.
  *

--- a/src/tools/control/playback.def.ts
+++ b/src/tools/control/playback.def.ts
@@ -27,6 +27,11 @@ export const toolDefPlayback = defineTool("adj-playback", {
         "undo",
         "redo",
         "save",
+        "back-to-arranger",
+        "capture-midi",
+        "capture-scene",
+        "record",
+        "re-enable-automation",
       ])
       .describe(
         `play-arrangement: from startTime
@@ -38,7 +43,12 @@ stop-all-session-clips: all
 stop: session and arrangement
 undo: undo last Live set action (check canUndo before)
 redo: redo last undone action (check canRedo before)
-save: save the Live set to disk`,
+save: save the Live set to disk
+back-to-arranger: clear session override so arrangement resumes
+capture-midi: retroactively capture buffered MIDI into a clip
+capture-scene: capture currently playing session clips into a new scene
+record: toggle arrangement record mode (returns recording state)
+re-enable-automation: re-engage automation overridden by manual changes`,
       ),
     startTime: z
       .string()

--- a/src/tools/control/playback.ts
+++ b/src/tools/control/playback.ts
@@ -12,11 +12,13 @@ import {
   handleLiveSetHistory,
   handlePlayArrangement,
   handlePlayScene,
+  handleStandalonePlaybackAction,
   resolveLoopEnd,
   resolveLoopStart,
   resolveStartTime,
   validateLocatorOrTime,
   type PlaybackState,
+  type StandalonePlaybackAction,
 } from "./helpers/playback-helpers.ts";
 import { select } from "./select.ts";
 
@@ -50,6 +52,21 @@ interface PlaybackResult {
   arrangementLoop?: { start: string; end: string };
   canUndo?: boolean;
   canRedo?: boolean;
+  recording?: boolean;
+}
+
+const STANDALONE_ACTIONS = new Set<StandalonePlaybackAction>([
+  "back-to-arranger",
+  "capture-midi",
+  "capture-scene",
+  "record",
+  "re-enable-automation",
+]);
+
+function isStandaloneAction(
+  action: string,
+): action is StandalonePlaybackAction {
+  return STANDALONE_ACTIONS.has(action as StandalonePlaybackAction);
 }
 
 interface BuildPlaybackResultParams {
@@ -105,6 +122,12 @@ export function playback(
   // undo/redo/save don't interact with transport or loop params
   if (action === "undo" || action === "redo" || action === "save") {
     return handleLiveSetHistory(action);
+  }
+
+  // back-to-arranger, capture-midi, capture-scene, record, re-enable-automation
+  // are standalone workflow actions that bypass transport/loop param handling
+  if (isStandaloneAction(action)) {
+    return handleStandalonePlaybackAction(action);
   }
 
   if (ids != null && slots != null) {

--- a/src/tools/control/tests/playback-basic.test.ts
+++ b/src/tools/control/tests/playback-basic.test.ts
@@ -624,4 +624,120 @@ describe("transport", () => {
     );
     expect(liveSet.set).not.toHaveBeenCalledWith("loop", expect.anything());
   });
+
+  it("should handle back-to-arranger action", () => {
+    liveSet = setupPlaybackLiveSet({
+      is_playing: 1,
+      current_song_time: 8,
+    });
+
+    const result = playback({ action: "back-to-arranger" });
+
+    expectLiveSetProperty(liveSet, "back_to_arranger", 0);
+    expect(result).toStrictEqual({
+      playing: true,
+      currentTime: "3|1",
+    });
+  });
+
+  it("should handle capture-midi action", () => {
+    liveSet = setupPlaybackLiveSet({
+      is_playing: 1,
+      current_song_time: 4,
+    });
+
+    const result = playback({ action: "capture-midi" });
+
+    expect(liveSet.call).toHaveBeenCalledWith("capture_midi");
+    expect(result).toStrictEqual({
+      playing: true,
+      currentTime: "2|1",
+    });
+  });
+
+  it("should handle capture-scene action", () => {
+    liveSet = setupPlaybackLiveSet({
+      is_playing: 1,
+      current_song_time: 0,
+    });
+
+    const result = playback({ action: "capture-scene" });
+
+    expect(liveSet.call).toHaveBeenCalledWith("capture_and_insert_scene");
+    expect(result).toStrictEqual({
+      playing: true,
+      currentTime: "1|1",
+    });
+  });
+
+  it("should toggle record on when record_mode is off", () => {
+    liveSet = setupPlaybackLiveSet({
+      is_playing: 0,
+      current_song_time: 0,
+      record_mode: 0,
+    });
+
+    const result = playback({ action: "record" });
+
+    expectLiveSetProperty(liveSet, "record_mode", 1);
+    expect(result).toStrictEqual({
+      playing: false,
+      currentTime: "1|1",
+      recording: true,
+    });
+  });
+
+  it("should toggle record off when record_mode is on", () => {
+    liveSet = setupPlaybackLiveSet({
+      is_playing: 1,
+      current_song_time: 0,
+      record_mode: 1,
+    });
+
+    const result = playback({ action: "record" });
+
+    expectLiveSetProperty(liveSet, "record_mode", 0);
+    expect(result).toStrictEqual({
+      playing: true,
+      currentTime: "1|1",
+      recording: false,
+    });
+  });
+
+  it("should handle re-enable-automation action", () => {
+    liveSet = setupPlaybackLiveSet({
+      is_playing: 1,
+      current_song_time: 0,
+    });
+
+    const result = playback({ action: "re-enable-automation" });
+
+    expect(liveSet.call).toHaveBeenCalledWith("re_enable_automation");
+    expect(result).toStrictEqual({
+      playing: true,
+      currentTime: "1|1",
+    });
+  });
+
+  it("should not touch transport or loop params for standalone actions", () => {
+    liveSet = setupPlaybackLiveSet({
+      is_playing: 0,
+      current_song_time: 0,
+    });
+
+    playback({
+      action: "back-to-arranger",
+      startTime: "5|1",
+      loop: true,
+      loopStart: "1|1",
+      loopEnd: "3|1",
+    });
+
+    expectLiveSetProperty(liveSet, "back_to_arranger", 0);
+    expect(liveSet.set).not.toHaveBeenCalledWith(
+      "start_time",
+      expect.anything(),
+    );
+    expect(liveSet.set).not.toHaveBeenCalledWith("loop", expect.anything());
+  });
 });


### PR DESCRIPTION
### **User description**
Closes #28.

## Summary

Adds five standalone workflow actions to `adj-playback`, all single Live API calls that close common workflow gaps the AI hits today.

| Action | Live API | Purpose |
| --- | --- | --- |
| `back-to-arranger` | `set("back_to_arranger", 0)` | Clear session override so arrangement resumes |
| `capture-midi` | `call("capture_midi")` | Retroactively capture buffered MIDI into a clip |
| `capture-scene` | `call("capture_and_insert_scene")` | Snapshot playing session clips into a new scene |
| `record` | toggle `record_mode` | Toggle arrangement record mode; returns `recording` |
| `re-enable-automation` | `call("re_enable_automation")` | Re-engage automation overridden by manual edits |

These five actions all bypass transport/loop param handling — same early-return pattern as the existing `undo` / `redo` / `save` actions. New helper `handleStandalonePlaybackAction` mirrors `handleLiveSetHistory`.

## Files changed

- `src/tools/control/playback.def.ts` — extend action enum + describe lines
- `src/tools/control/playback.ts` — early-return for new actions, add `recording?` to `PlaybackResult`
- `src/tools/control/helpers/playback-helpers.ts` — new `handleStandalonePlaybackAction`
- `src/tools/control/tests/playback-basic.test.ts` — 7 new tests (one per action + the toggle-on/toggle-off pair for record + a transport-bypass test)
- `docs/Tools-Reference.md` — document the five new action enum values
- `docs/gap-analysis.md` — mark Gap 11 (Capture MIDI) and Gap 15 (back_to_arranger / Record) as shipped

## Test plan

- [x] `npm run check` — lint, typecheck, format, duplication, coverage all green (3743 tests pass)
- [ ] Smoke-test in a Live session: arm record via `record`, verify red ring; play session clip then call `back-to-arranger` and verify arrangement resumes; ad-hoc-play notes and call `capture-midi` to confirm a clip is created


___

### **PR Type**
Enhancement


___

### **Description**
- Adds five new standalone playback actions.

- Introduces `back-to-arranger` to clear session overrides.

- Implements `capture-midi` and `capture-scene` for recording.

- Adds `record` to toggle arrangement recording mode.

- Includes `re-enable-automation` to restore automation.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[User Request] --> B{Playback Action};
  B -- "Is Standalone Action?" --> C{handleStandalonePlaybackAction};
  C -- "back-to-arranger" --> D[Clear Session Override];
  C -- "capture-midi" --> E[Capture MIDI Buffer];
  C -- "capture-scene" --> F[Capture Playing Clips to Scene];
  C -- "record" --> G[Toggle Arrangement Record Mode];
  C -- "re-enable-automation" --> H[Re-enable Automation];
  D & E & F & G & H --> I[Return Playback State];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>playback-helpers.ts</strong><dd><code>Implement standalone playback action handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/control/helpers/playback-helpers.ts

<ul><li>Defined <code>StandalonePlaybackAction</code> type for new actions.<br> <li> Implemented <code>handleStandalonePlaybackAction</code> to process these actions.<br> <li> Added logic for <code>record</code> action to toggle <code>record_mode</code> and return its <br>state.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/100/files#diff-05ab9cf559b1d3b4ed898c4131a96323572affe458c672ba9e61b975e146abab">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>playback.def.ts</strong><dd><code>Extend playback action enum with new actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/control/playback.def.ts

<ul><li>Extended the <code>action</code> enum with five new standalone playback actions.<br> <li> Added descriptions for each new action in the tool definition.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/100/files#diff-2bcfb6c4203d965090006ce841963f029354eb6a1f34c06cab68450faf4ebbe0">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>playback.ts</strong><dd><code>Integrate new standalone playback actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/control/playback.ts

<ul><li>Imported <code>handleStandalonePlaybackAction</code> and related types.<br> <li> Extended <code>PlaybackResult</code> interface with an optional <code>recording</code> property.<br> <li> Added a check to route standalone actions to <br><code>handleStandalonePlaybackAction</code>, bypassing transport/loop parameters.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/100/files#diff-d57c15906519423ad1c1e4baf933a94f6dc25f5f7ee2a2a42411a60931cb09b8">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>playback-basic.test.ts</strong><dd><code>Add tests for new standalone playback actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/control/tests/playback-basic.test.ts

<ul><li>Added new tests for each of the five standalone playback actions.<br> <li> Included specific tests for <code>record</code> toggling on and off.<br> <li> Verified that standalone actions correctly bypass transport and loop <br>parameters.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/100/files#diff-2d8f54b27de5dc015c8e2be551e61f38b93d09b5e4159f43d6e006c66f7d1384">+116/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Tools-Reference.md</strong><dd><code>Document new playback actions in Tools Reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/Tools-Reference.md

<ul><li>Documented the five new <code>adj-playback</code> actions: <code>back-to-arranger</code>, <br><code>capture-midi</code>, <code>capture-scene</code>, <code>record</code>, and <code>re-enable-automation</code>.<br> <li> Noted the <code>recording</code> boolean in the response for the <code>record</code> action.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/100/files#diff-1144a39ffd998b6c8832a8e6e38fae79a98231f8e64046307c61134a0b297194">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gap-analysis.md</strong><dd><code>Update gap analysis for shipped playback features</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/gap-analysis.md

<ul><li>Updated "Gap 11: Capture MIDI" and "Gap 15: <code>back_to_arranger</code> / Record" <br>to "Shipped" status.<br> <li> Referenced the newly added <code>adj-playback</code> actions.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/100/files#diff-d623ae36c7f1b69b24d6abfb0f3d1e21f857c0a1276159c8ea6ebe3864bf567d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

