### PR TITLE
docs: sync tool list across CLAUDE.md, PROJECT_INDEX.md, Tools-Reference.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ To capture a new validated finding, run `/update-docs` (loads
 
 | Domain     | Tools                                           |
 | ---------- | ----------------------------------------------- |
-| Workflow   | `connect`, `context`, `read-samples`            |
+| Workflow   | `connect`, `context`                            |
 | Live Set   | `read-live-set`, `update-live-set`              |
 | Track      | `read-track`, `create-track`, `update-track`    |
 | Scene      | `read-scene`, `create-scene`, `update-scene`    |

--- a/docs/PROJECT_INDEX.md
+++ b/docs/PROJECT_INDEX.md
@@ -20,7 +20,7 @@ All prefixed `adj-`.
 
 | Domain     | Tools                                                |
 | ---------- | ---------------------------------------------------- |
-| Workflow   | `connect`, `context`, `read-samples`                 |
+| Workflow   | `connect`, `context`                                 |
 | Live Set   | `read-live-set`, `update-live-set`                   |
 | Track      | `read-track`, `create-track`, `update-track`         |
 | Scene      | `read-scene`, `create-scene`, `update-scene`         |

--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-Quick reference for all 21 `adj-*` tools. Read the `.def.ts` files for the full
+Quick reference for all 22 `adj-*` tools. Read the `.def.ts` files for the full
 Zod schemas.
 
 ---
@@ -14,16 +14,14 @@ Connect to Ableton Live. Call this first before any other tool. No parameters.
 ### `adj-context`
 
 Read and write a persistent memory string visible to the AI across tool calls.
-Useful for storing project state, musical decisions, or notes.
+Useful for storing project state, musical decisions, or notes. Also browses the
+configured sample folder.
 
 - `read` — return current context
 - `write` — overwrite context with new content
 - `append` — add to existing context
-
-### `adj-read-samples`
-
-List audio samples available in the configured sample folder. Returns a tree of
-files with metadata. Set `sampleFolder` in config first.
+- `search` — list audio samples in the configured `sampleFolder` (set in config)
+  as a tree with metadata
 
 ---
 
@@ -180,6 +178,21 @@ Control transport, session clips, and Live set history.
 - Response includes `playing`, `currentTime`, optional `arrangementLoop`.
 - For `"undo"` / `"redo"` / `"save"`, response also includes `canUndo` and
   `canRedo` booleans — check these before calling undo/redo to avoid no-ops.
+
+---
+
+## Generative
+
+### `adj-generate`
+
+Generate algorithmic note patterns. Returns notes in bar|beat notation that plug
+directly into `adj-create-clip`'s `notes` param. Pure computation, no Live API
+calls.
+
+- `algorithm`: `"euclidean"` — Bjorklund even-distribution of pulses
+- `pattern` — named pattern overriding `steps` / `pulses` / `rotation`
+  (tresillo, cinquillo, etc.)
+- `pitch`, `steps`, `pulses`, `rotation`, `bars`, `velocity`, `duration`
 
 ---
 


### PR DESCRIPTION
### **User description**
## Summary

The three doc surfaces that enumerate the MCP tool list had drifted apart:

| Surface | Tool count | Notes |
| --- | --- | --- |
| `docs/Tools-Reference.md` | "21 tools" | missing `adj-generate` section |
| `CLAUDE.md` | "22 Tools" | listed phantom `read-samples` |
| `docs/PROJECT_INDEX.md` | "22 MCP Tools" | listed phantom `read-samples` |

Verified against `src/mcp-server/create-mcp-server.ts` — there are 22 registered MCP tools. `read-samples` is a helper consumed by `adj-context` (action=`search`), not a separate tool. `adj-generate` is registered but Tools-Reference never documented it.

## Changes

- `docs/Tools-Reference.md`
  - Header: "21 tools" -> "22 tools"
  - Remove standalone `adj-read-samples` heading; document the same capability as `adj-context` action `search`
  - Add the missing `adj-generate` section under a new `## Generative` heading
- `CLAUDE.md` — drop `read-samples` from the Workflow row so the row matches the registered tools
- `docs/PROJECT_INDEX.md` — same Workflow-row fix

Source of truth for the action catalog stays `docs/Tools-Reference.md`; `CLAUDE.md` and `docs/PROJECT_INDEX.md` are domain-level summaries that link out, not full enumerations.

## Test plan

- [x] `npm run lint` — clean
- [x] Sanity-grep tool count: `grep -c '^### \`adj-' docs/Tools-Reference.md` returns 22 (matches `find src/tools -name '*.def.ts' | wc -l`)
- [x] No code changes; nothing to test at runtime

## Follow-ups (not in this PR)

- `docs/contributing/Architecture.md` references a Chat UI bundle that doesn't exist in this repo (no `webui/`, no Vite config). Out of scope here; will be cleaned up in the broader docs-hierarchy refactor.


___

### **PR Type**
Documentation


___

### **Description**
- Synchronize tool lists across documentation files.

- Update `Tools-Reference.md` tool count to 22.

- Integrate `read-samples` into `adj-context` `search` action.

- Add `adj-generate` tool documentation.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Remove `read-samples` from Workflow tools list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Removed <code>read-samples</code> from the <code>Workflow</code> tools list.<br> <li> Corrected the list of workflow tools to match registered MCP tools.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/101/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PROJECT_INDEX.md</strong><dd><code>Remove `read-samples` from Workflow tools list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/PROJECT_INDEX.md

<ul><li>Removed <code>read-samples</code> from the <code>Workflow</code> tools list.<br> <li> Corrected the list of workflow tools to match registered MCP tools.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/101/files#diff-6b62521c254cc758592c5074ff3eb506453d30d7d0fa720b6c0ff948e3b54120">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Tools-Reference.md</strong><dd><code>Update tool count, integrate <code>read-samples</code>, and add <code>adj-generate</code> <br>documentation</code></dd></summary>
<hr>

docs/Tools-Reference.md

<ul><li>Updated the total <code>adj-*</code> tool count from 21 to 22.<br> <li> Modified <code>adj-context</code> to include a <code>search</code> action for listing audio <br>samples, integrating <code>adj-read-samples</code> functionality.<br> <li> Removed the standalone <code>adj-read-samples</code> section.<br> <li> Added a new <code>## Generative</code> heading and a detailed section for the <br><code>adj-generate</code> tool.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/101/files#diff-1144a39ffd998b6c8832a8e6e38fae79a98231f8e64046307c61134a0b297194">+20/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

