### PR TITLE
docs: consolidate facts to one canonical source-of-truth file each

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,28 +17,17 @@ docker compose run check  # same as npm run check, in isolation
 
 ## Architecture
 
-```
-AI Client (Claude Desktop, etc.)
-    ↓ stdio
-src/portal/ableton-dj-mcp-portal.ts   ← bridges stdio to HTTP
-    ↓ HTTP :3350
-src/mcp-server/                        ← Express server + MCP protocol handler
-    ↓ internal dispatch
-src/tools/                             ← 21 MCP tool implementations (adj-*)
-    ↓ HTTP to Max
-src/live-api-adapter/                  ← runs in Max's V8 inside .amxd
-    ↓ LiveAPI globals
-Ableton Live
-```
-
 The server runs **inside a Max for Live device** (the `.amxd`). The portal runs
-externally as a standalone Node process.
+externally as a standalone Node process bridging the MCP client over stdio to
+the in-device server on `:3350`.
+
+Full diagram, language choices, build system, message protocol:
+[`docs/contributing/Architecture.md`](docs/contributing/Architecture.md).
 
 ## Project map
 
-See `docs/PROJECT_INDEX.md` — full directory map, tool list, entry points, build
-system, notation system. See `docs/` for deeper documentation on specific
-topics.
+[`docs/PROJECT_INDEX.md`](docs/PROJECT_INDEX.md) — directory map, entry points,
+constants, env flags. [`docs/`](docs/) has deeper docs on specific topics.
 
 ## Music vs dev context
 
@@ -80,48 +69,32 @@ is the lookup key.
 To capture a new validated finding, run `/update-docs` (loads
 `docs/findings/HOW-TO-WRITE.md`).
 
-## 22 Tools (all prefixed `adj-`)
+## Tools
 
-| Domain     | Tools                                           |
-| ---------- | ----------------------------------------------- |
-| Workflow   | `connect`, `context`                            |
-| Live Set   | `read-live-set`, `update-live-set`              |
-| Track      | `read-track`, `create-track`, `update-track`    |
-| Scene      | `read-scene`, `create-scene`, `update-scene`    |
-| Clip       | `read-clip`, `create-clip`, `update-clip`       |
-| Device     | `read-device`, `create-device`, `update-device` |
-| Operations | `delete`, `duplicate`                           |
-| Control    | `select`, `playback`                            |
-| Generative | `generate` (Euclidean rhythms, no Live API)     |
-| Dev-only   | `raw-live-api` (env flag required)              |
-
-Each tool has a `.def.ts` (Zod schema) and a `.ts` (implementation).
+22 tools, all prefixed `adj-`. Each tool has a `.def.ts` (Zod schema) and a
+`.ts` (implementation). Full catalog with action lists and parameters:
+[`docs/Tools-Reference.md`](docs/Tools-Reference.md).
 
 ## Coding rules
 
-- `.js` extensions in all imports (`import x from './foo.js'`)
-- Path alias `#src/*` instead of `../` imports in `src/`
-- Zod schemas: primitives and enums only — no `.object()` nesting in tool params
-- `== null` over `=== null` (catches both null and undefined)
-- Optimistic results for playback operations (don't wait for Live to confirm)
-- Tool functions receive args object: `(args) => fn(args)` not destructured
+Full standards:
+[`docs/contributing/Coding-Standards.md`](docs/contributing/Coding-Standards.md).
 
 ## Notation
 
-- **Bar|beat positions**: `17|1` (bar 17, beat 1). Grammar:
-  `src/notation/barbeat/`
-- **Transform expressions**: `velocity += rand(-5, 5)`. Grammar:
-  `src/notation/transform/`
-- Parsers are Peggy-generated — run `npm run parser:build` after changing
-  `.peggy` files
+Two DSLs, both Peggy-generated. Run `npm run parser:build` after changing
+`.peggy` files.
 
-## Build outputs (`dist/`)
+- **Bar|beat positions** (`17|1`) —
+  [`docs/specs/BarBeat-Spec.md`](docs/specs/BarBeat-Spec.md)
+- **Transform expressions** (`velocity += rand(-5, 5)`) —
+  [`docs/specs/Transforms-Spec.md`](docs/specs/Transforms-Spec.md)
 
-| File                            | Destination                           |
-| ------------------------------- | ------------------------------------- |
-| `dist/live-api-adapter.js`      | Copy into .amxd (runs in Max V8)      |
-| `dist/mcp-server.mjs`           | Copy into .amxd (runs in Node.js)     |
-| `dist/ableton-dj-mcp-portal.js` | Run directly — bridges stdio to :3350 |
+## Build outputs
+
+Three bundles in `dist/`. Full table (entries, targets, purposes) in
+[`docs/contributing/Architecture.md`](docs/contributing/Architecture.md). Deploy
+steps: [`docs/Releasing.md`](docs/Releasing.md).
 
 ## Branching
 

--- a/docs/PROJECT_INDEX.md
+++ b/docs/PROJECT_INDEX.md
@@ -1,35 +1,40 @@
 # Project Index
 
-Quick reference for the entire codebase. Use this to orient before any task.
+Pure index for the codebase. Each line points to a source-of-truth file. Use
+this to orient before any task; load the linked file when relevant.
 
-## Architecture
+## Architecture and build
 
-```
-AI Client (Claude Desktop, etc.)
-  -> MCP protocol (stdio or HTTP)
-    -> Portal bridge (src/portal/) converts stdio <-> HTTP
-      -> Express server on port 3350
-        -> MCP Server (src/mcp-server/) dispatches tool calls
-          -> Tool implementations (src/tools/ + src/live-api-adapter/)
-            -> Ableton Live JS API
-```
+- [contributing/Architecture.md](contributing/Architecture.md) — dataflow
+  diagram, language choices, three rollup bundles, message protocol, Live API
+  interface
+- [Releasing.md](Releasing.md) — release-please flow, local deploy steps
+  (`dist/` → `max-for-live-device/`), version verification
 
-## 22 MCP Tools
+## Tools
 
-All prefixed `adj-`.
+- [Tools-Reference.md](Tools-Reference.md) — canonical catalog of all 22 `adj-*`
+  tools, with actions and parameters
+- [contributing/Read-Tool-Includes.md](contributing/Read-Tool-Includes.md) —
+  `include` parameter conventions for all read tools
+- [contributing/Arrangement-Operations.md](contributing/Arrangement-Operations.md)
+  — Live API constraints driving arrangement clip algorithms
 
-| Domain     | Tools                                                |
-| ---------- | ---------------------------------------------------- |
-| Workflow   | `connect`, `context`                                 |
-| Live Set   | `read-live-set`, `update-live-set`                   |
-| Track      | `read-track`, `create-track`, `update-track`         |
-| Scene      | `read-scene`, `create-scene`, `update-scene`         |
-| Clip       | `read-clip`, `create-clip`, `update-clip`            |
-| Device     | `read-device`, `create-device`, `update-device`      |
-| Operations | `delete`, `duplicate`                                |
-| Control    | `select`, `playback`                                 |
-| Generative | `generate` (algorithmic patterns, no Live API)       |
-| Dev-only   | `raw-live-api` (requires `ENABLE_RAW_LIVE_API=true`) |
+## Notation systems
+
+- [specs/BarBeat-Spec.md](specs/BarBeat-Spec.md) — bar|beat MIDI notation
+  (`src/notation/barbeat/`)
+- [specs/Transforms-Spec.md](specs/Transforms-Spec.md) — transform DSL
+  (`src/notation/transform/`)
+
+## Code conventions and dev workflow
+
+- [contributing/Coding-Standards.md](contributing/Coding-Standards.md) — file
+  naming, imports, style, Zod, `livePath` builders, coverage rules, testing
+- [contributing/Development-Tools.md](contributing/Development-Tools.md) —
+  `adj-client.ts`, raw Live API tool, MCP Inspector, debug builds, log files
+- [findings/INDEX.md](findings/INDEX.md) — validated facts from prior sessions
+  (load before non-trivial work)
 
 ## Code Layers
 
@@ -44,36 +49,28 @@ Each tool has 3 layers:
 
 ## Key Directories
 
-| Dir                     | Purpose                                                |
-| ----------------------- | ------------------------------------------------------ | -------------------------------------------- |
-| `src/mcp-server/`       | MCP server creation, Express app, Max API adapter      |
-| `src/tools/`            | All tool definitions + implementations                 |
-| `src/live-api-adapter/` | Tool dispatch to Ableton Live API (runs in Max V8)     |
-| `src/portal/`           | Node CLI bridge (stdio to HTTP)                        |
-| `src/notation/`         | Bar                                                    | beat parser + transform expression evaluator |
-| `src/skills/`           | Tool set definitions (basic/standard/electronic-music) |
-| `src/shared/`           | Version, pitch, errors, serialization utils            |
-| `e2e/`                  | End-to-end tests against live Ableton instance         |
-| `config/`               | Rollup, Vitest, ESLint, jscpd configs                  |
-| `scripts/`              | Dev utilities: adj-client, loc counter, open-live-set  |
-| `dist/`                 | Build output (git-ignored)                             |
+| Dir                     | Purpose                                                    |
+| ----------------------- | ---------------------------------------------------------- |
+| `src/mcp-server/`       | MCP server creation, Express app, Max API adapter          |
+| `src/tools/`            | All tool definitions + implementations                     |
+| `src/live-api-adapter/` | Tool dispatch to Ableton Live API (runs in Max V8)         |
+| `src/portal/`           | Node CLI bridge (stdio to HTTP)                            |
+| `src/notation/`         | bar\|beat parser + transform expression evaluator          |
+| `src/skills/`           | Tool set definitions (basic / standard / electronic-music) |
+| `src/shared/`           | Version, pitch, errors, serialization, `livePath` builders |
+| `e2e/`                  | End-to-end tests against a live Ableton instance           |
+| `config/`               | Rollup, Vitest, ESLint, jscpd configs                      |
+| `scripts/`              | Dev utilities: `adj-client.ts`, loc counter, open-live-set |
+| `dist/`                 | Build output (git-ignored)                                 |
+| `max-for-live-device/`  | `.amxd` device + sibling JS bundles loaded by Max          |
 
 ## Entry Points
 
 | Method       | Entry                           | What Happens                                          |
 | ------------ | ------------------------------- | ----------------------------------------------------- |
-| Max for Live | `.amxd` device (from dist/)     | Hosts Express on :3350, runs MCP server in Max's Node |
+| Max for Live | `.amxd` device (from `dist/`)   | Hosts Express on :3350, runs MCP server in Max's Node |
 | Portal       | `dist/ableton-dj-mcp-portal.js` | Runs standalone, bridges stdio to :3350               |
 | Dev portal   | `npm run dev`                   | Rollup watch + portal in dev mode                     |
-
-## Notation Systems
-
-- **Bar|Beat**: `17|1` = bar 17, beat 1. Grammar:
-  `src/notation/barbeat/parser/barbeat-grammar.peggy`
-- **Transforms**: `velocity += rand(-5, 5)`. Grammar:
-  `src/notation/transform/parser/transform-grammar.peggy`
-- Both parsers generated by Peggy into `generated-*-parser.js` — run
-  `npm run parser:build`
 
 ## Constants (`src/tools/constants.ts`)
 
@@ -91,14 +88,6 @@ Each tool has 3 layers:
 | `ENABLE_CODE_EXEC`    | Allow code execution in clips   |
 | `ENABLE_DEV_CORS`     | CORS for external MCP Inspector |
 | `ENABLE_WARP_MARKERS` | Enable warp marker read/write   |
-
-## Build Pipeline
-
-```
-npm run build =
-  parser:build  (Peggy -> JS parsers)
-  + rollup      (-> dist/live-api-adapter.js, dist/mcp-server.mjs, dist/ableton-dj-mcp-portal.js)
-```
 
 ## Ports
 

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -4,9 +4,7 @@ Install and run Ableton DJ MCP.
 
 ## Requirements
 
-- Ableton Live 12.3+ with Max for Live
-- Node.js 24+
-- An MCP-compatible AI client (Claude Desktop, Claude Code, Cursor)
+See [Requirements](../README.md#requirements) in the README.
 
 ## Install
 

--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -1,7 +1,7 @@
 # Tools Reference
 
-Quick reference for all 22 `adj-*` tools. Read the `.def.ts` files for the full
-Zod schemas.
+Canonical catalog of all 22 `adj-*` tools. Other docs link here instead of
+duplicating. Read the `.def.ts` files for the full Zod schemas.
 
 ---
 

--- a/docs/contributing/Architecture.md
+++ b/docs/contributing/Architecture.md
@@ -1,17 +1,18 @@
 # Architecture
 
+Canonical reference for the system architecture, dataflow diagram, and build
+outputs. Other docs link here instead of duplicating.
+
 ## System Overview
 
 Ableton DJ MCP integrates with Ableton Live through a Max for Live device using
 the Model Context Protocol (MCP) to enable AI assistants to manipulate music.
 
-## Architecture Diagrams
+## Architecture Diagram
 
-### MCP Host with stdio Transport
-
-This shows how MCP hosts like Claude Desktop or LM Studio connect via the
-Ableton DJ MCP Portal (stdio-to-HTTP adapter). It's also possible to run LLMs
-locally with no online dependencies.
+MCP hosts like Claude Desktop, Claude Code, or LM Studio connect via the Ableton
+DJ MCP Portal (stdio-to-HTTP adapter). Locally hosted LLMs are also supported
+with no online dependencies.
 
 ```
   +-----------------------+
@@ -25,14 +26,14 @@ locally with no online dependencies.
      | Claude Desktop)|
      +----------------+
              ↑
-             | MCP stdio transport (via Claude Desktop extension)
+             | MCP stdio transport
              ↓
   +-------------------------+
-  |   Ableton DJ MCP Portal   |
+  |  Ableton DJ MCP Portal  |
   | (stdio-to-http adapter) |
   +-------------------------+
              ↑
-             | MCP streamable HTTP transport
+             | MCP streamable HTTP transport (port 3350)
              ↓
 +-----------------------------+
 |        Ableton Live         |
@@ -53,56 +54,15 @@ locally with no online dependencies.
 +-----------------------------+
 ```
 
-### Built-in Chat UI
-
-This shows how things work with the built-in chat UI. The browser loads the chat
-UI from the MCP server's Express app and connects directly to the LLM API.
-
-```
- +-----------------------+
- | LLM Cloud / Local LLM |
- +-----------------------+
-             ↑
-             | LLM API (streaming)
-             ↓
-     +---------------+
-     |    Browser    |
-     |   (Chat UI)   |
-     +---------------+
-         ↑       ↑
-         |       | MCP streamable HTTP transport
-         |       ↓
-         |   +-----------------------------+
-   serves|   |        Ableton Live         |
-   HTML  |   |  +-----------------------+  |
-         |   |  |  Max for Live Device  |  |
-         |   |  |  +---------------+    |  |
-         +---|--|--| Node for Max  |    |  |
-             |  |  | (MCP Server + |    |  |
-             |  |  |  Express app) |    |  |
-             |  |  +---------------+    |  |
-             |  |         ↑             |  |
-             |  |         | Max message |  |
-             |  |         ↓             |  |
-             |  |  +---------------+    |  |
-             |  |  |      v8       |    |  |
-             |  |  |  (Live API)   |    |  |
-             |  |  +---------------+    |  |
-             |  +-----------------------+  |
-             +-----------------------------+
-```
-
 ## Language Choices
 
-The entire codebase uses TypeScript (`src/`, `scripts/`, and `webui/`).
+The entire codebase is TypeScript (`src/` and `scripts/`).
 
 **Benefits of TypeScript:**
 
 - Static typing catches errors at compile time
-- Complex React component state and props benefit from type safety
-- Integrates the Vercel AI SDK with multiple provider packages
-- Complex response mapping to normalized UI format requires type safety
-- Streaming protocols and message parsing have many edge cases
+- Streaming protocols and message parsing have many edge cases worth typing
+- Tool definitions stay self-documenting via Zod schemas
 
 **Runtime validation:**
 
@@ -149,59 +109,26 @@ point for the V8 Max object.
 - Makes Live API calls
 - Returns results to Node.js
 
-### 5. bar|beat Notation (`src/notation/barbeat/*`)
+### 5. Notation Parsers (`src/notation/`)
 
-Musical notation parser and utilities for creating and manipulating MIDI clips.
+Two Peggy-generated DSLs for clip authoring:
 
-**Grammar:** `src/notation/barbeat/barbeat-grammar.peggy`
+- bar|beat MIDI notation — see [BarBeat-Spec.md](../specs/BarBeat-Spec.md)
+- transform expression DSL — see
+  [Transforms-Spec.md](../specs/Transforms-Spec.md)
 
 ## Build System
 
-Four separate bundles built with rollup.js (MCP server, V8, Portal) and Vite
-(Chat UI):
+Three separate bundles built with rollup (`config/rollup.config.mjs`). Run
+`npm run build` to produce all three in `dist/`. Deploying the device to Live
+requires a manual copy step from `dist/` into `max-for-live-device/`; see
+[Releasing.md](../Releasing.md).
 
-### MCP Server Bundle
-
-- **Entry:** `src/mcp-server/mcp-server.ts`
-- **Output:** `max-for-live-device/mcp-server.mjs`
-- **Target:** Node.js (Node for Max)
-- **Dependencies:** Bundled for distribution
-
-### V8 Bundle
-
-- **Entry:** `src/live-api-adapter/live-api-adapter.ts`
-- **Output:** `max-for-live-device/live-api-adapter.js`
-- **Target:** V8 engine (Max v8 object)
-- **Dependencies:** None (uses Max built-ins)
-
-### Portal Bundle
-
-- **Entry:** `src/portal/ableton-dj-mcp-portal.ts`
-- **Output:** `release/ableton-dj-mcp-portal.js`
-- **Target:** Node.js (standalone process)
-- **Dependencies:** Bundled for distribution (zero runtime dependencies)
-- **Purpose:** stdio-to-HTTP adapter for Claude Desktop Extension
-- **Features:**
-  - Converts MCP stdio transport to streamable HTTP
-  - Graceful degradation when Live isn't running
-  - Returns setup instructions when offline
-
-### Chat UI Bundle
-
-- **Entry:** `webui/src/main.tsx`
-- **Output:** `max-for-live-device/chat-ui.html`
-- **Target:** Browser (served at `http://localhost:3350/chat`, opened via Max)
-- **Build Tool:** Vite with custom plugins
-- **Dependencies:** Bundled into single self-contained HTML file
-- **Purpose:** Preact-based chat interface with multi-provider AI + MCP
-  integration
-- **Features:**
-  - Served from MCP server's Express app
-  - Opened in system default browser (avoids Max jweb keyboard issues)
-  - Uses Vercel AI SDK (`streamText()`) for all providers (Anthropic, Google,
-    OpenAI, Mistral, OpenRouter, Ollama)
-  - Real-time streaming chat interface with automatic MCP tool calling
-  - Settings persistence via localStorage
+| Bundle        | Entry                                      | Output (`dist/`)           | Target                       | Purpose                                                                              |
+| ------------- | ------------------------------------------ | -------------------------- | ---------------------------- | ------------------------------------------------------------------------------------ |
+| MCP server    | `src/mcp-server/mcp-server.ts`             | `mcp-server.mjs`           | Node.js (Node for Max)       | HTTP MCP endpoint inside the .amxd. All deps bundled.                                |
+| V8 (Live API) | `src/live-api-adapter/live-api-adapter.ts` | `live-api-adapter.js`      | V8 engine (Max v8 object)    | Receives messages from Node for Max and calls the Live API. No deps (Max built-ins). |
+| Portal        | `src/portal/ableton-dj-mcp-portal.ts`      | `ableton-dj-mcp-portal.js` | Node.js (standalone process) | stdio-to-HTTP adapter for MCP clients. Zero runtime deps; graceful offline fallback. |
 
 ## Message Protocol
 

--- a/docs/contributing/Development-Tools.md
+++ b/docs/contributing/Development-Tools.md
@@ -155,11 +155,15 @@ These come from the MCP SDK's dependencies and don't affect functionality.
 
 ### Build Validation
 
-After building, verify:
+After `npm run build`, verify all three bundles exist in `dist/`:
 
-1. `max-for-live-device/mcp-server.mjs` exists and is > 1MB
-2. `max-for-live-device/main.js` exists
-3. No unexpected errors in build output
+1. `dist/mcp-server.mjs` (large — bundles @modelcontextprotocol/sdk + express)
+2. `dist/live-api-adapter.js`
+3. `dist/ableton-dj-mcp-portal.js`
+4. No unexpected errors in build output
+
+Deploying these to Live requires copying them into `max-for-live-device/`. See
+[Releasing.md](../Releasing.md).
 
 ## Testing Workflows
 


### PR DESCRIPTION
## Summary

- Refactors docs so each enumerated fact has exactly **one canonical file**; other files cross-reference it via markdown link instead of duplicating content.
- Stops the drift seen in PR #101 where the tool list, architecture diagram, and build outputs had to be hand-synced across `CLAUDE.md`, `docs/PROJECT_INDEX.md`, and `docs/contributing/Architecture.md`.
- Fixes stale facts in canonical files (notably the phantom Chat UI / `webui/` / Vite bundle in `Architecture.md` — the directory and tooling do not exist in the repo).

## Single-source-of-truth assignments

| Fact                              | Canonical file                                                                |
| --------------------------------- | ----------------------------------------------------------------------------- |
| Tool list / catalog               | `docs/Tools-Reference.md`                                                     |
| Architecture flow diagram         | `docs/contributing/Architecture.md`                                           |
| Build outputs / bundles           | `docs/contributing/Architecture.md`                                           |
| Coding rules                      | `docs/contributing/Coding-Standards.md`                                       |
| Notation systems (bar\|beat, DSL) | `docs/specs/BarBeat-Spec.md`, `docs/specs/Transforms-Spec.md`                 |
| npm scripts (working ref)         | `CLAUDE.md` Quick start                                                       |
| Requirements (Node, Live, MCP)    | `README.md`                                                                   |

## What changed

**Stale facts corrected (in canonical files):**
- Removed the entire "Built-in Chat UI" section + diagram from `Architecture.md`. There is no `webui/` directory, no Vite config, no `chat-ui.html` output. Verified with `find . -name webui -o -name "vite.config*"` (zero matches outside `node_modules/`) and `package.json` scripts (rollup-only).
- Bundle count corrected from four to three. Outputs now show real `dist/` paths; the `dist/` -> `max-for-live-device/` copy step is delegated to `Releasing.md` instead of being misrepresented as a direct rollup output.
- "Codebase uses TypeScript (`src/`, `scripts/`, and `webui/`)" -> drop `webui/`.
- `Tools-Reference.md` opening said "all 21 tools"; now correctly 22.
- `Development-Tools.md` build validation referenced `max-for-live-device/main.js` which does not exist; replaced with the three real `dist/` bundles.

**Thinned-out duplicates:**
- `CLAUDE.md`: tool table, architecture diagram, build outputs table, full coding-rules list, and notation grammar paths -> one-line pointers to the canonical files. Quick start, findings policy, project map, music vs dev context, branching, PR rules, commit style, license retained (these are CLAUDE.md's job).
- `docs/PROJECT_INDEX.md`: now a pure index of source-of-truth files with one-line hooks. Architecture diagram, tool table, notation duplication, and build pipeline diagram all replaced with links. Code Layers, Key Directories, Entry Points, Constants, Env Flags, Ports retained because no other file owns them.
- `docs/Setup.md`: requirements list replaced with link to README's `## Requirements`.

## Test plan

- [x] `npm run check` passes (lint + typecheck + format + duplication + coverage 100% functions, 99.28% statements)
- [x] Confirm no remaining `webui` / `Chat UI` / `chat-ui` references outside `docs/plans/` (those are working plans, out of scope per task brief)
- [x] Confirm tool count is "22" everywhere it appears
- [x] Confirm architecture diagram appears in only one file (`Architecture.md`)
- [x] All inbound references (`grep CLAUDE.md|PROJECT_INDEX.md|Tools-Reference.md` across `docs/`, `src/`, `README.md`) verified — no broken links

## Out of scope

- `workspace/` (gitignored), `docs/findings/`, `docs/plans/`, `docs/gap-analysis.md` per task brief.
- Code structure / actual implementation — docs only.