### PR TITLE
fix: unwrap array return from get_version_string Live API call

### DIFF
--- a/dist/ableton-dj-mcp-portal.js
+++ b/dist/ableton-dj-mcp-portal.js
@@ -29287,7 +29287,7 @@ const EMPTY_COMPLETION_RESULT = {
   }
 };
 
-const VERSION = "1.8.0";
+const VERSION = "1.9.0";
 
 const MAX_SPLIT_POINTS = 32;
 

--- a/dist/live-api-adapter.js
+++ b/dist/live-api-adapter.js
@@ -1090,7 +1090,7 @@ function hasPreReleaseSuffix(version) {
   return cleaned.includes("-");
 }
 
-const VERSION = "1.8.0";
+const VERSION = "1.9.0";
 
 const MIN_LIVE_VERSION = "12.3.0";
 
@@ -19154,7 +19154,8 @@ function connect(_params = {}, context = {}) {
   const trackIds = liveSet.getChildIds("tracks");
   const returnTrackIds = liveSet.getChildIds("return_tracks");
   const sceneIds = liveSet.getChildIds("scenes");
-  const abletonLiveVersion = liveApp.call("get_version_string");
+  const rawVersion = liveApp.call("get_version_string");
+  const abletonLiveVersion = Array.isArray(rawVersion) ? String(rawVersion[0]) : String(rawVersion);
   const liveSetName = liveSet.getProperty("name");
   const liveSetInfo = {
     ...liveSetName ? {
@@ -19438,7 +19439,8 @@ log(`[${now()}] Ableton DJ MCP ${VERSION} Live API adapter ready`);
 outlet(0, "started");
 
 function checkLiveVersion() {
-  const liveVersion = LiveAPI.from("live_app").call("get_version_string");
+  const raw = LiveAPI.from("live_app").call("get_version_string");
+  const liveVersion = Array.isArray(raw) ? String(raw[0]) : String(raw);
   if (isNewerVersion(liveVersion, MIN_LIVE_VERSION)) {
     outlet(0, "min_live_version_not_met", liveVersion, MIN_LIVE_VERSION);
   }

--- a/dist/mcp-server.mjs
+++ b/dist/mcp-server.mjs
@@ -795,7 +795,7 @@ function hasPreReleaseSuffix(version) {
   return cleaned.includes("-");
 }
 
-const VERSION = "1.8.0";
+const VERSION = "1.9.0";
 
 var RequestError = class extends Error {
   constructor(message, options) {

--- a/src/live-api-adapter/live-api-adapter.ts
+++ b/src/live-api-adapter/live-api-adapter.ts
@@ -321,9 +321,8 @@ outlet(0, "started");
  * Called by the Max patch after the device is fully loaded (LiveAPI is not available at top-level).
  */
 export function checkLiveVersion(): void {
-  const liveVersion = LiveAPI.from("live_app").call(
-    "get_version_string",
-  ) as string;
+  const raw = LiveAPI.from("live_app").call("get_version_string");
+  const liveVersion = Array.isArray(raw) ? String(raw[0]) : String(raw);
 
   if (isNewerVersion(liveVersion, MIN_LIVE_VERSION)) {
     outlet(0, "min_live_version_not_met", liveVersion, MIN_LIVE_VERSION);

--- a/src/tools/workflow/connect.ts
+++ b/src/tools/workflow/connect.ts
@@ -49,7 +49,10 @@ export function connect(
   const returnTrackIds = liveSet.getChildIds("return_tracks");
   const sceneIds = liveSet.getChildIds("scenes");
 
-  const abletonLiveVersion = liveApp.call("get_version_string") as string;
+  const rawVersion = liveApp.call("get_version_string");
+  const abletonLiveVersion = Array.isArray(rawVersion)
+    ? String(rawVersion[0])
+    : String(rawVersion);
 
   // Build liveSet overview matching readLiveSet default response
   const liveSetName = liveSet.getProperty("name");

--- a/src/tools/workflow/tests/connect-core.test.ts
+++ b/src/tools/workflow/tests/connect-core.test.ts
@@ -392,4 +392,18 @@ describe("connect", () => {
     expect(result.liveSet.name).toBeUndefined();
     expect(result.liveSet).not.toHaveProperty("name");
   });
+
+  it("unwraps array return from get_version_string", () => {
+    setupConnectScenario(createLiveSetConfig());
+    vi.mocked(getHostTrackIndex).mockReturnValue(0);
+    registerMockObject("live_app", {
+      path: "live_app",
+      type: "Application",
+      methods: {
+        get_version_string: () => ["12.4b7"],
+      },
+    });
+
+    expect(connect().abletonLiveVersion).toBe("12.4b7");
+  });
 });


### PR DESCRIPTION
### **User description**
## Summary
- `LiveAPI.call("get_version_string")` returns an array (e.g. `["12.4b7"]`) in real Max v8, but our mocks returned a plain string — hiding the type mismatch.
- Result: `TypeError: version.trim is not a function` in `parseVersionParts` when the device loads against a real Live instance (caught during smoke test on Live 12.x).
- Defensively unwrap at both call sites (`checkLiveVersion`, `connect`) with `Array.isArray(raw) ? String(raw[0]) : String(raw)`.
- Added a regression test in `connect-core.test.ts` covering the array return shape.

## Test plan
- [x] `npm run check` passes (3737 tests, lint/typecheck/format/duplication clean, 99.28% coverage)
- [x] New test asserts `connect()` unwraps `["12.4b7"]` to `"12.4b7"`
- [ ] Verify warning gone on Live device load after redeploying `.amxd`


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Unwraps `get_version_string` array return.

- Prevents `TypeError` in version parsing.

- Adds regression test for array handling.

- Bumps project version to `1.9.0`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["LiveAPI.call('get_version_string')"] --> B{"Unwrap Array Logic"};
    B --> C["checkLiveVersion()"];
    B --> D["connect()"];
    E["connect-core.test.ts"] --> F["Mocks 'get_version_string' array return"];
    F --> B;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>live-api-adapter.ts</strong><dd><code>Defensively unwrap `get_version_string` in `checkLiveVersion`.</code></dd></summary>
<hr>

src/live-api-adapter/live-api-adapter.ts

<ul><li>Modifies the <code>checkLiveVersion</code> function to defensively unwrap the <br>result of <code>LiveAPI.from("live_app").call("get_version_string")</code>.<br> <li> Ensures the version string is correctly extracted, handling cases <br>where the API returns an array (e.g., <code>["12.4b7"]</code>) instead of a plain <br>string.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/104/files#diff-c3a24f2d8f92d74167cb7edd9f305472348b32e132e241b7f654f7d993292a4d">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>connect.ts</strong><dd><code>Unwraps `get_version_string` result in `connect` function.</code></dd></summary>
<hr>

src/tools/workflow/connect.ts

<ul><li>Updates the <code>connect</code> function to defensively unwrap the <br><code>abletonLiveVersion</code> obtained from <code>liveApp.call("get_version_string")</code>.<br> <li> Adds logic to convert a potential array return (e.g., <code>["12.4b7"]</code>) into <br>a single string.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/104/files#diff-614078c4f8f3a1ab3b8f2bb580aeae91bebee49a9265971dca221306d4f54354">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>live-api-adapter.js</strong><dd><code>Bumps version and applies `get_version_string` unwrapping.</code></dd></summary>
<hr>

dist/live-api-adapter.js

<ul><li>Updates the internal <code>VERSION</code> constant from <code>1.8.0</code> to <code>1.9.0</code>.<br> <li> Reflects the defensive unwrapping logic for <code>get_version_string</code> calls <br>in <code>checkLiveVersion</code> and <code>connect</code> functions.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/104/files#diff-0a025e0ebbef610cee32b3d48fc7a6c0a353cb908b47aa3d74137d68b4a4d6dc">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>connect-core.test.ts</strong><dd><code>Adds regression test for `get_version_string` array unwrapping.</code></dd></summary>
<hr>

src/tools/workflow/tests/connect-core.test.ts

<ul><li>Adds a new regression test case within the <code>connect</code> describe block.<br> <li> Mocks the <code>get_version_string</code> method of <code>live_app</code> to return an array <br>(e.g., <code>["12.4b7"]</code>).<br> <li> Asserts that the <code>connect()</code> function correctly unwraps this array to a <br>plain string.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/104/files#diff-0e9eea84c0c17e03f0da2c3a4b2ef66d54bbcadf8ee3faaf8b81e33568b4518a">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ableton-dj-mcp-portal.js</strong><dd><code>Bumps project version.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dist/ableton-dj-mcp-portal.js

- Updates the internal `VERSION` constant from `1.8.0` to `1.9.0`.


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/104/files#diff-09145fb3a1fb499bb649e61afeb792066e1cde2de87ab3e45036613cabacca3b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mcp-server.mjs</strong><dd><code>Bumps project version.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dist/mcp-server.mjs

- Updates the internal `VERSION` constant from `1.8.0` to `1.9.0`.


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/104/files#diff-5723cdad2e31879af7515acf8d027626338c319a3b51a54a5e9b239e4b4e2a73">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

