### PR TITLE
feat: add install:device script for Live User Library install

### DIFF
--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -45,12 +45,14 @@ git checkout main && git pull
 npm run build
 cp dist/live-api-adapter.js max-for-live-device/live-api-adapter.js
 cp dist/mcp-server.mjs max-for-live-device/mcp-server.mjs
+npm run install:device   # refresh the copy in your Live User Library
 ```
 
 Then in Ableton Live:
 
 1. Eject the `Ableton_DJ_MCP` device from its MIDI track (or restart Live)
-2. Re-drag `max-for-live-device/Ableton_DJ_MCP.amxd` onto the track
+2. Re-drag the device onto the track (from User Library if installed via
+   `npm run install:device`, otherwise from `max-for-live-device/`)
 3. Verify console shows the new version:
 
 ```

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -15,12 +15,34 @@ npm install
 npm run build
 ```
 
-## Load the device in Ableton
+## Install the device in Ableton's User Library
 
-1. Open Ableton Live
-2. From your file manager, drag `max-for-live-device/Ableton_DJ_MCP.amxd` onto
-   any MIDI track
-3. The device's status panel should show `MCP server running on :3350`
+```bash
+npm run install:device
+```
+
+Copies the device + bundled JS into your User Library so it shows up in Live's
+browser permanently. Cross-platform (macOS + Windows). Idempotent — re-run after
+every `npm run build` to refresh.
+
+After running:
+
+1. Open Ableton Live (or refresh the User Library in the browser)
+2. Browser → Categories → Max for Live → Max MIDI Effect → **Ableton DJ MCP**
+3. Drag onto any MIDI track. The status panel should show
+   `MCP server running on :3350`.
+
+To make the device load automatically in every new Live set:
+
+1. Drop the device onto a return or master track
+2. File → Save Live Set as Default Set
+3. Every new Live set will now auto-load the device
+
+### Manual install (alternative)
+
+If you'd rather skip the script, drag `max-for-live-device/Ableton_DJ_MCP.amxd`
+onto any MIDI track from your file manager. The device only persists in that one
+Live set — for permanent install, use `npm run install:device`.
 
 ## Wire up your AI client
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "duplication:verbose": "jscpd -c config/.jscpd.json && jscpd -c config/.jscpd-tests.json && jscpd -c config/.jscpd-scripts.json && jscpd -c config/.jscpd-e2e.json",
     "loc": "node scripts/loc/loc.ts",
     "init:workspace": "node scripts/init-workspace.ts",
+    "install:device": "node scripts/install-device.ts",
     "tc": "npm run typecheck",
     "typecheck": "echo 'Typechecking...' && node scripts/run-parallel.ts typecheck:src typecheck:scripts typecheck:e2e && echo 'No typecheck violations.\n'",
     "typecheck:src": "tsc --project src/tsconfig.json",

--- a/scripts/install-device.ts
+++ b/scripts/install-device.ts
@@ -1,0 +1,145 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Installs the Max for Live device into Ableton's User Library so it shows up
+// in the browser permanently. Eliminates the per-session Finder drag.
+//
+// Source:  max-for-live-device/Ableton_DJ_MCP.amxd (+ sibling JS bundles)
+// Dest:    <Live User Library>/Presets/MIDI Effects/Max MIDI Effect/
+//
+// Idempotent: overwrites existing files of the same name.
+
+import { createHash } from "node:crypto";
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..");
+const sourceDir = join(repoRoot, "max-for-live-device");
+const distDir = join(repoRoot, "dist");
+
+const DEVICE_FILES = [
+  "Ableton_DJ_MCP.amxd",
+  "live-api-adapter.js",
+  "mcp-server.mjs",
+] as const;
+
+/**
+ * Resolve the path to Live's per-user Max MIDI Effect preset directory.
+ * @returns Absolute path on the current platform
+ */
+function resolveUserLibraryDir(): string {
+  const home = homedir();
+
+  switch (platform()) {
+    case "darwin":
+      return join(
+        home,
+        "Music",
+        "Ableton",
+        "User Library",
+        "Presets",
+        "MIDI Effects",
+        "Max MIDI Effect",
+      );
+    case "win32":
+      return join(
+        home,
+        "Documents",
+        "Ableton",
+        "User Library",
+        "Presets",
+        "MIDI Effects",
+        "Max MIDI Effect",
+      );
+    default:
+      console.error(
+        `install-device: unsupported platform '${platform()}'. ` +
+          `Ableton Live runs on macOS or Windows only.`,
+      );
+      process.exit(1);
+  }
+}
+
+/**
+ * Verify the source files exist and warn if dist/ has drifted from
+ * max-for-live-device/ (which would mean we're about to install stale code).
+ */
+function assertSourceFresh(): void {
+  for (const file of DEVICE_FILES) {
+    const sourcePath = join(sourceDir, file);
+
+    if (!existsSync(sourcePath)) {
+      console.error(`install-device failed: missing ${sourcePath}`);
+      console.error("Run `npm run build` first.");
+      process.exit(1);
+    }
+  }
+
+  for (const file of ["live-api-adapter.js", "mcp-server.mjs"]) {
+    const distPath = join(distDir, file);
+    const sourcePath = join(sourceDir, file);
+
+    if (!existsSync(distPath)) {
+      continue;
+    }
+
+    if (hashFile(distPath) !== hashFile(sourcePath)) {
+      console.warn(
+        `install-device: WARNING — dist/${file} differs from ` +
+          `max-for-live-device/${file}. The device will install with stale code.`,
+      );
+      console.warn(
+        "  Run: cp dist/live-api-adapter.js dist/mcp-server.mjs " +
+          "max-for-live-device/",
+      );
+      console.warn("  Then re-run this script.");
+    }
+  }
+}
+
+/**
+ * Hash a file's contents (sha256) for cheap drift detection.
+ * @param path - Absolute path to the file
+ * @returns Hex-encoded sha256 digest
+ */
+function hashFile(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+assertSourceFresh();
+
+const targetDir = resolveUserLibraryDir();
+
+if (!existsSync(targetDir)) {
+  mkdirSync(targetDir, { recursive: true });
+  console.log(`install-device: created ${targetDir}`);
+}
+
+for (const file of DEVICE_FILES) {
+  const sourcePath = join(sourceDir, file);
+  const targetPath = join(targetDir, file);
+
+  copyFileSync(sourcePath, targetPath);
+  console.log(`  copied ${file}`);
+}
+
+console.log("");
+console.log(`Installed to: ${targetDir}`);
+console.log("");
+console.log("Next steps:");
+console.log("  1. Restart Ableton Live (or refresh User Library in Browser)");
+console.log("  2. In Live's browser: Categories → Max for Live → Max MIDI");
+console.log("     Effect → 'Ableton DJ MCP' should appear");
+console.log("  3. Drag onto any MIDI track to load");
+console.log("");
+console.log(
+  "Optional: open a Live set with the device on a return track, then",
+);
+console.log(
+  "File → Save Live Set as Default Set. Every new Live set will then",
+);
+console.log("auto-load the device.");


### PR DESCRIPTION
### **User description**
## Summary

Adds `npm run install:device` — copies the Max for Live device + sibling JS bundles into Ableton's User Library so it shows up in Live's browser permanently. Eliminates the per-Live-set Finder drag.

This is **Phase 1** of #78. Phases 2 (default `.als` template) and 3 (.alp Live Pack) remain as follow-ups.

## What changed

- `scripts/install-device.ts` — cross-platform installer (macOS + Windows). Idempotent. SHA-256 drift check warns when `dist/` and `max-for-live-device/` are out of sync.
- `package.json` — wires `npm run install:device`.
- `docs/Setup.md` — promotes `install:device` to the primary install path, keeps manual drag as a fallback.
- `docs/Releasing.md` — adds `install:device` to the local-deploy workflow so the User Library copy stays in sync with each release.

## How it works

```bash
npm run build           # produce dist/
npm run install:device  # copy .amxd + bundles into User Library
```

Installs to:
- macOS: `~/Music/Ableton/User Library/Presets/MIDI Effects/Max MIDI Effect/`
- Windows: `%USERPROFILE%\Documents\Ableton\User Library\Presets\MIDI Effects\Max MIDI Effect\`

After running, refresh Live's browser → device shows under Categories → Max for Live → Max MIDI Effect → **Ableton DJ MCP**. Drag onto any MIDI track. To make it auto-load in every new set: drop on a return track, then `File → Save Live Set as Default Set`.

## Test plan

- [x] `npm run check` (lint + typecheck + format + duplication + coverage) — all pass
- [x] `npm run install:device` on macOS — files land in correct path
- [x] Drift check: SHA-256 hash compares dist vs max-for-live-device, warns only when content actually differs (not just mtime)
- [ ] Manual: refresh Live's browser, verify device appears under User Library
- [ ] Manual: drag from User Library onto MIDI track, verify it loads cleanly
- [ ] Windows path verification (path resolution only — covered by the OS branch in `resolveUserLibraryDir`)

Closes phase 1 of #78.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds `install:device` script for setup.

- Copies device to Ableton's User Library.

- Enables permanent device access in Live.

- Updates setup and release documentation.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User"] -- "Runs `npm run install:device`" --> B["scripts/install-device.ts"];
  B -- "Copies device files" --> C["Ableton User Library"];
  C -- "Device appears permanently" --> D["Ableton Live Browser"];
  D -- "Optional: Save as Default Set" --> E["Auto-loads in new sets"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install-device.ts</strong><dd><code>Add cross-platform device installation script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/install-device.ts

<ul><li>Implements a cross-platform script to copy the Max for Live device and <br>its JavaScript bundles.<br> <li> Resolves Ableton User Library paths for macOS and Windows.<br> <li> Includes drift detection using SHA-256 hashes to warn about stale <br>code.<br> <li> Provides clear post-installation instructions to the user.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/107/files#diff-b47b1b5fa1aba56dc50320b663e7e53218d50b5822a1cb24e5eede35d044ba43">+145/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Releasing.md</strong><dd><code>Update release docs with `install:device` script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/Releasing.md

<ul><li>Integrates <code>npm run install:device</code> into the local deployment workflow.<br> <li> Updates instructions for re-dragging the device, suggesting the User <br>Library path.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/107/files#diff-9a5cd11aab4a7fc63f51a3cb478cd16e98b5cc469c4864c21d973a7d1a7185d4">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Setup.md</strong><dd><code>Revise setup documentation for script-based installation</code>&nbsp; </dd></summary>
<hr>

docs/Setup.md

<ul><li>Promotes <code>npm run install:device</code> as the primary installation method.<br> <li> Provides detailed steps for permanent installation and auto-loading <br>the device.<br> <li> Relegates the manual drag-and-drop method to an alternative.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/107/files#diff-1393eb0e52723929a63057d6bc302625419885a2ebd998e20ff029b5d82cf721">+27/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add `install:device` command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Adds a new script entry <code>"install:device": "node </code><br><code>scripts/install-device.ts"</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/107/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

