### PR TITLE
feat: add start:live launcher script

### DIFF
--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -44,6 +44,22 @@ If you'd rather skip the script, drag `max-for-live-device/Ableton_DJ_MCP.amxd`
 onto any MIDI track from your file manager. The device only persists in that one
 Live set — for permanent install, use `npm run install:device`.
 
+## Launch Live from the terminal
+
+```bash
+npm run start:live                 # launch Live (whatever the OS opens by default)
+npm run start:live -- path.als     # launch Live with a specific .als file
+npm run start:live -- --template   # launch Live with the bundled template.als
+```
+
+The `--template` flag opens a bundled `template.als` (a Live set with the device
+pre-loaded on a return track). The template ships separately from this PR — if
+the file doesn't exist yet, the script errors clearly.
+
+This is the foundation for self-bootstrap: an MCP-aware AI client can call
+`start:live` to bring up Live in the right state without the human having to
+drag anything.
+
 ## Wire up your AI client
 
 ### Claude Code

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "loc": "node scripts/loc/loc.ts",
     "init:workspace": "node scripts/init-workspace.ts",
     "install:device": "node scripts/install-device.ts",
+    "start:live": "node scripts/start-live.ts",
     "tc": "npm run typecheck",
     "typecheck": "echo 'Typechecking...' && node scripts/run-parallel.ts typecheck:src typecheck:scripts typecheck:e2e && echo 'No typecheck violations.\n'",
     "typecheck:src": "tsc --project src/tsconfig.json",

--- a/scripts/start-live.ts
+++ b/scripts/start-live.ts
@@ -1,0 +1,136 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Launches Ableton Live, optionally opening a specific .als file. Cross-platform.
+//
+// Usage:
+//   npm run start:live                  -> open Live with whatever the OS launches by default
+//   npm run start:live -- path.als      -> open Live with a specific .als
+//   npm run start:live -- --template    -> open Live with the bundled template.als (if present)
+//
+// macOS: uses `open -b com.ableton.live` (works across versions/editions) or
+//        `open <path.als>` when a file is supplied.
+// Windows: uses `start "" <path.als>` (relies on .als file association). Without
+//          a path, falls back to launching the registered .als handler with no
+//          file — Live must be installed and the user has done so before.
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { platform } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ABLETON_BUNDLE_ID = "com.ableton.live";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..");
+const bundledTemplate = join(repoRoot, "template.als");
+
+const filePath = resolveFileArg(process.argv.slice(2));
+
+if (filePath !== null && !existsSync(filePath)) {
+  console.error(`start-live failed: file not found at ${filePath}`);
+  process.exit(1);
+}
+
+launchLive(filePath);
+
+/**
+ * Resolve which .als file (if any) to open. Supports:
+ *   --template      -> bundled template.als at repo root (errors if missing)
+ *   <path>          -> any explicit path, resolved against cwd
+ *   (no args)       -> null, meaning launch Live with no file
+ * @param argv - process.argv.slice(2)
+ * @returns Absolute path to the .als file, or null
+ */
+function resolveFileArg(argv: string[]): string | null {
+  if (argv.length === 0) {
+    return null;
+  }
+
+  const first = argv[0];
+
+  if (first === undefined) {
+    return null;
+  }
+
+  if (first === "--template") {
+    if (!existsSync(bundledTemplate)) {
+      console.error(
+        `start-live failed: --template requested but ${bundledTemplate} not found.`,
+      );
+      console.error(
+        "The bundled template.als has not been added to this repo yet.",
+      );
+      process.exit(1);
+    }
+
+    return bundledTemplate;
+  }
+
+  // Relative paths resolve against INIT_CWD (the user's invocation dir, set by
+  // npm) when present, otherwise against the repo root. Avoids process.cwd()
+  // per the project's no-restricted-properties rule.
+  const baseDir = process.env.INIT_CWD ?? repoRoot;
+
+  return isAbsolute(first) ? first : resolve(baseDir, first);
+}
+
+/**
+ * Launch Ableton Live, optionally opening a .als file.
+ * Spawns detached and exits immediately — does not wait for Live to boot.
+ * @param file - Absolute path to a .als file, or null
+ */
+function launchLive(file: string | null): void {
+  const os = platform();
+
+  if (os === "darwin") {
+    const args = file === null ? ["-b", ABLETON_BUNDLE_ID] : [file];
+    const child = spawn("open", args, { detached: true, stdio: "ignore" });
+
+    child.on("error", (error) => {
+      console.error(`start-live: failed to launch Live — ${error.message}`);
+      process.exit(1);
+    });
+
+    child.unref();
+    console.log(
+      file === null
+        ? `Launched Ableton Live (bundle ${ABLETON_BUNDLE_ID}).`
+        : `Launched Ableton Live with ${file}.`,
+    );
+
+    return;
+  }
+
+  if (os === "win32") {
+    if (file === null) {
+      console.error(
+        "start-live: launching Live without a file is not supported on Windows.",
+      );
+      console.error("Pass a .als file path or use `--template`.");
+      process.exit(1);
+    }
+
+    const child = spawn("cmd.exe", ["/c", "start", "", file], {
+      detached: true,
+      stdio: "ignore",
+    });
+
+    child.on("error", (error) => {
+      console.error(`start-live: failed to launch Live — ${error.message}`);
+      process.exit(1);
+    });
+
+    child.unref();
+    console.log(`Launched Ableton Live with ${file}.`);
+
+    return;
+  }
+
+  console.error(
+    `start-live: unsupported platform '${os}'. Ableton Live runs on macOS or Windows only.`,
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
### **User description**
## Summary

Adds `npm run start:live` — a cross-platform Ableton Live launcher. Foundation for self-bootstrap: future portal-side lazy-boot logic will shell out to this when `:3350` is unreachable, so the AI client can bring Live up itself instead of asking the human to drag.

Part of #78. PR1 (#107) installed the device into the User Library. This PR adds the launcher. PR3 will wire portal lazy-boot.

## What changed

- `scripts/start-live.ts` — cross-platform launcher
  - macOS: `open -b com.ableton.live` (version/edition-agnostic)
  - Windows: `start "" path.als` (uses .als file association)
  - Optional `<path.als>` arg or `--template` flag
- `package.json` — wires `npm run start:live`
- `docs/Setup.md` — documents the new command + flags the upcoming `template.als`

## Usage

\`\`\`bash
npm run start:live                 # launch Live (whatever the OS opens by default)
npm run start:live -- path.als     # launch Live with a specific .als file
npm run start:live -- --template   # launch Live with the bundled template.als
\`\`\`

The `--template` flag references a `template.als` at the repo root. The file is **not** committed in this PR — it requires opening Live, dropping the device on a return track, and saving. Tracked as a follow-up. The script errors clearly if the file is missing.

## Test plan

- [x] \`npm run check\` (lint + typecheck + format + duplication + coverage) — all pass
- [x] Bundle ID confirmed: \`defaults read Ableton Live 12 Suite.app/Contents/Info CFBundleIdentifier\` returns \`com.ableton.live\`
- [ ] Manual: \`npm run start:live\` brings Live to foreground (or launches it)
- [ ] Manual: \`npm run start:live -- /some/file.als\` opens that file in Live
- [ ] Manual: \`npm run start:live -- --template\` errors cleanly until template.als is added
- [ ] Windows verification (left for whoever has a Windows box)

Part of #78.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds `start:live` script to launch Ableton Live.

- Supports opening specific `.als` files or a template.

- Implements cross-platform logic for macOS and Windows.

- Documents new command in `Setup.md` for users and AI clients.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User/AI Client"] -- "Runs `npm run start:live`" --> B["scripts/start-live.ts"];
  B -- "Parses arguments (e.g., `--template` or `path.als`)" --> C{OS Detection};
  C -- "macOS: `open -b com.ableton.live`" --> D["Ableton Live"];
  C -- "Windows: `start "" path.als`" --> D;
  D -- "Live launched" --> E["User Experience"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>start-live.ts</strong><dd><code>Add cross-platform Ableton Live launcher script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/start-live.ts

<ul><li>Implements a new cross-platform script to launch Ableton Live.<br> <li> Supports opening Live with no specific file, a provided <code>.als</code> path, or <br>a bundled <code>template.als</code>.<br> <li> Contains platform-specific logic for macOS (using <code>open -b</code>) and Windows <br>(using <code>start ""</code>).<br> <li> Includes argument parsing, file existence checks, and error handling <br>for missing files or unsupported platforms.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/108/files#diff-8b06b1be3fb2634101109189b48472e11346060e22102ebf422ffd3831b176d9">+136/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Setup.md</strong><dd><code>Document `start:live` command for launching Ableton Live</code>&nbsp; </dd></summary>
<hr>

docs/Setup.md

<ul><li>Adds a new section documenting the <code>npm run start:live</code> command.<br> <li> Explains how to use the script to launch Live, open specific <code>.als</code> <br>files, or use the <code>--template</code> flag.<br> <li> Highlights the script's role as a foundation for AI client <br>self-bootstrap.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/108/files#diff-1393eb0e52723929a63057d6bc302625419885a2ebd998e20ff029b5d82cf721">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add `start:live` npm script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Adds a new script entry <code>"start:live": "node scripts/start-live.ts"</code> to <br>the <code>scripts</code> section.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/108/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

