### PR TITLE
feat: opt-in portal lazy-boot for Ableton Live

### DIFF
--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -60,6 +60,38 @@ This is the foundation for self-bootstrap: an MCP-aware AI client can call
 `start:live` to bring up Live in the right state without the human having to
 drag anything.
 
+## Self-bootstrap (opt-in)
+
+Set `ADJ_AUTO_BOOT=true` in your MCP client config to let the portal launch Live
+automatically when it can't reach `:3350`. macOS only for now.
+
+Behavior:
+
+- **Live closed** → portal launches Live (`open -b com.ableton.live`), polls
+  `:3350` for up to 30 seconds, then forwards your tool call.
+- **Live open with device** → noop, business as usual.
+- **Live open without device** → portal does **not** auto-relaunch (would
+  destroy unsaved work). Returns the standard setup error.
+- **Single attempt per portal lifetime** — if boot fails, subsequent calls
+  return the standard error.
+
+Example for Claude Desktop (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "ableton-dj-mcp": {
+      "command": "node",
+      "args": ["/absolute/path/to/dist/ableton-dj-mcp-portal.js"],
+      "env": { "ADJ_AUTO_BOOT": "true" }
+    }
+  }
+}
+```
+
+For Claude Code, set the env var in the shell that launches it, or pass it
+through `claude mcp add` configuration.
+
 ## Wire up your AI client
 
 ### Claude Code

--- a/src/portal/lazy-boot.test.ts
+++ b/src/portal/lazy-boot.test.ts
@@ -1,0 +1,218 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { EventEmitter } from "node:events";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+
+const spawnMock = vi.fn();
+
+vi.mock(import("node:child_process"), () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+const fetchMock = vi.fn();
+
+vi.stubGlobal("fetch", fetchMock);
+
+const { LazyBoot } = await import("./lazy-boot.ts");
+
+interface FakeChild extends EventEmitter {
+  unref: Mock;
+  stdout?: EventEmitter;
+}
+
+function makeChild({
+  exitCode = 0,
+  stdout,
+}: { exitCode?: number; stdout?: string } = {}): FakeChild {
+  const emitter = new EventEmitter() as FakeChild;
+
+  emitter.unref = vi.fn();
+
+  if (stdout !== undefined) {
+    const stdoutEmitter = new EventEmitter();
+
+    emitter.stdout = stdoutEmitter;
+    queueMicrotask(() => {
+      stdoutEmitter.emit("data", Buffer.from(stdout));
+      emitter.emit("close", exitCode);
+    });
+  } else {
+    queueMicrotask(() => {
+      emitter.emit("close", exitCode);
+    });
+  }
+
+  return emitter;
+}
+
+describe("LazyBoot", () => {
+  const originalAutoBoot = process.env.ADJ_AUTO_BOOT;
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalAutoBoot === undefined) {
+      delete process.env.ADJ_AUTO_BOOT;
+    } else {
+      process.env.ADJ_AUTO_BOOT = originalAutoBoot;
+    }
+
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  });
+
+  it("does nothing when ADJ_AUTO_BOOT is not set", async () => {
+    delete process.env.ADJ_AUTO_BOOT;
+    const boot = new LazyBoot({ serverOrigin: "http://localhost:3350" });
+
+    const result = await boot.tryBoot();
+
+    expect(result).toStrictEqual({
+      attempted: false,
+      succeeded: false,
+      reason: "disabled",
+    });
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing on second call within the same instance", async () => {
+    process.env.ADJ_AUTO_BOOT = "true";
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    spawnMock.mockImplementation((cmd: string) => {
+      if (cmd === "pgrep") {
+        return makeChild({ exitCode: 1 });
+      }
+
+      return makeChild();
+    });
+    fetchMock.mockResolvedValue({ status: 200 });
+
+    const boot = new LazyBoot({
+      serverOrigin: "http://localhost:3350",
+      timeoutMs: 1000,
+      pollIntervalMs: 10,
+    });
+
+    await boot.tryBoot();
+    const result = await boot.tryBoot();
+
+    expect(result.reason).toBe("already-attempted");
+  });
+
+  it("skips boot when Live is already running (state 3)", async () => {
+    process.env.ADJ_AUTO_BOOT = "true";
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    spawnMock.mockImplementationOnce(() => makeChild({ exitCode: 0 }));
+
+    const boot = new LazyBoot({ serverOrigin: "http://localhost:3350" });
+    const result = await boot.tryBoot();
+
+    expect(result).toStrictEqual({
+      attempted: true,
+      succeeded: false,
+      reason: "live-running-without-device",
+    });
+    // pgrep was called, but `open` was not.
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock.mock.calls[0]?.[0]).toBe("pgrep");
+  });
+
+  it("launches Live and returns succeeded when server becomes reachable", async () => {
+    process.env.ADJ_AUTO_BOOT = "true";
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    let pgrepCalled = false;
+    let openCalled = false;
+
+    spawnMock.mockImplementation((cmd: string) => {
+      if (cmd === "pgrep") {
+        pgrepCalled = true;
+
+        return makeChild({ exitCode: 1 });
+      }
+
+      if (cmd === "open") {
+        openCalled = true;
+
+        return makeChild();
+      }
+
+      return makeChild();
+    });
+
+    fetchMock
+      .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+      .mockResolvedValue({ status: 200 });
+
+    const boot = new LazyBoot({
+      serverOrigin: "http://localhost:3350",
+      timeoutMs: 5000,
+      pollIntervalMs: 10,
+    });
+
+    const result = await boot.tryBoot();
+
+    expect(pgrepCalled).toBe(true);
+    expect(openCalled).toBe(true);
+    expect(result).toStrictEqual({ attempted: true, succeeded: true });
+  });
+
+  it("times out when the server never comes up", async () => {
+    process.env.ADJ_AUTO_BOOT = "true";
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    spawnMock.mockImplementation((cmd: string) => {
+      if (cmd === "pgrep") {
+        return makeChild({ exitCode: 1 });
+      }
+
+      return makeChild();
+    });
+
+    fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const boot = new LazyBoot({
+      serverOrigin: "http://localhost:3350",
+      timeoutMs: 30,
+      pollIntervalMs: 10,
+    });
+
+    const result = await boot.tryBoot();
+
+    expect(result).toStrictEqual({
+      attempted: true,
+      succeeded: false,
+      reason: "timeout",
+    });
+  });
+
+  it("rejects unsupported platforms", async () => {
+    process.env.ADJ_AUTO_BOOT = "true";
+    Object.defineProperty(process, "platform", { value: "linux" });
+
+    const boot = new LazyBoot({ serverOrigin: "http://localhost:3350" });
+    const result = await boot.tryBoot();
+
+    expect(result).toStrictEqual({
+      attempted: true,
+      succeeded: false,
+      reason: "unsupported-platform-linux",
+    });
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/portal/lazy-boot.ts
+++ b/src/portal/lazy-boot.ts
@@ -1,0 +1,203 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Opt-in self-bootstrap: when ADJ_AUTO_BOOT=true and the portal can't reach
+// :3350, attempt to launch Ableton Live (macOS only for now) and poll until
+// the device's HTTP server comes up. Bounded by timeout. Single attempt per
+// portal lifetime to avoid loops if Live fails to load the device.
+
+import { spawn } from "node:child_process";
+import { errorMessage } from "#src/shared/error-utils.ts";
+import { logger } from "./file-logger.ts";
+
+const ABLETON_BUNDLE_ID = "com.ableton.live";
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_POLL_INTERVAL_MS = 500;
+
+export interface LazyBootOptions {
+  serverOrigin: string;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+export interface LazyBootResult {
+  attempted: boolean;
+  succeeded: boolean;
+  reason?: string;
+}
+
+export class LazyBoot {
+  private hasAttempted = false;
+
+  constructor(private readonly options: LazyBootOptions) {}
+
+  /**
+   * True when ADJ_AUTO_BOOT=true. Read at call time so tests can flip it.
+   * @returns Whether opt-in flag is set
+   */
+  isEnabled(): boolean {
+    return process.env.ADJ_AUTO_BOOT === "true";
+  }
+
+  /**
+   * Single-attempt self-bootstrap. Returns immediately if disabled, already
+   * attempted, or Live is already running (state 3 — can't inject device).
+   * Otherwise launches Live and polls the server origin until it responds
+   * or the timeout elapses.
+   * @returns Outcome with reason for skips/failures
+   */
+  async tryBoot(): Promise<LazyBootResult> {
+    if (!this.isEnabled()) {
+      return { attempted: false, succeeded: false, reason: "disabled" };
+    }
+
+    if (this.hasAttempted) {
+      return {
+        attempted: false,
+        succeeded: false,
+        reason: "already-attempted",
+      };
+    }
+
+    this.hasAttempted = true;
+
+    if (await this.isLiveRunning()) {
+      logger.info(
+        "[LazyBoot] Live is running but :3350 is unreachable — device not loaded. Skipping auto-boot to preserve user state.",
+      );
+
+      return {
+        attempted: true,
+        succeeded: false,
+        reason: "live-running-without-device",
+      };
+    }
+
+    if (!this.canLaunch()) {
+      return {
+        attempted: true,
+        succeeded: false,
+        reason: `unsupported-platform-${process.platform}`,
+      };
+    }
+
+    logger.info("[LazyBoot] Launching Ableton Live");
+    this.launchLive();
+
+    const reachable = await this.waitForServer();
+
+    return reachable
+      ? { attempted: true, succeeded: true }
+      : { attempted: true, succeeded: false, reason: "timeout" };
+  }
+
+  /**
+   * Detect a running Ableton Live process via OS-native process listing.
+   * @returns True when Live is currently running
+   */
+  private async isLiveRunning(): Promise<boolean> {
+    if (process.platform === "darwin") {
+      return await new Promise<boolean>((resolve) => {
+        const child = spawn("pgrep", ["-if", "Ableton Live"], {
+          stdio: "ignore",
+        });
+
+        child.on("close", (code) => {
+          resolve(code === 0);
+        });
+        child.on("error", () => {
+          resolve(false);
+        });
+      });
+    }
+
+    if (process.platform === "win32") {
+      return await new Promise<boolean>((resolve) => {
+        const child = spawn("tasklist", ["/FI", "IMAGENAME eq Ableton Live*"], {
+          stdio: ["ignore", "pipe", "ignore"],
+        });
+
+        let output = "";
+
+        child.stdout.on("data", (chunk: Buffer) => {
+          output += chunk.toString();
+        });
+        child.on("close", () => {
+          resolve(output.toLowerCase().includes("ableton live"));
+        });
+        child.on("error", () => {
+          resolve(false);
+        });
+      });
+    }
+
+    return false;
+  }
+
+  /**
+   * Whether we know how to spawn Live on this platform.
+   * @returns True for macOS (Windows boot deferred to a follow-up)
+   */
+  private canLaunch(): boolean {
+    return process.platform === "darwin";
+  }
+
+  /**
+   * Spawn a detached `open -b com.ableton.live` and immediately unref so the
+   * portal doesn't keep Live's lifetime tied to its own.
+   */
+  private launchLive(): void {
+    try {
+      const child = spawn("open", ["-b", ABLETON_BUNDLE_ID], {
+        detached: true,
+        stdio: "ignore",
+      });
+
+      child.on("error", (error) => {
+        logger.error(`[LazyBoot] Failed to spawn Live: ${errorMessage(error)}`);
+      });
+
+      child.unref();
+    } catch (error) {
+      logger.error(`[LazyBoot] Spawn threw: ${errorMessage(error)}`);
+    }
+  }
+
+  /**
+   * Poll the server origin until it responds with any HTTP status, or the
+   * timeout elapses. Network errors and connection refusals continue polling.
+   * @returns True when the server became reachable, false on timeout
+   */
+  private async waitForServer(): Promise<boolean> {
+    const timeoutMs = this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const intervalMs = this.options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch(this.options.serverOrigin, {
+          method: "GET",
+        });
+
+        if (response.status < 500) {
+          logger.info(
+            `[LazyBoot] Server reachable at ${this.options.serverOrigin}`,
+          );
+
+          return true;
+        }
+      } catch {
+        // Connection refused / DNS failure — keep polling.
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+
+    logger.error(
+      `[LazyBoot] Server did not become reachable within ${String(timeoutMs)}ms`,
+    );
+
+    return false;
+  }
+}

--- a/src/portal/stdio-http-bridge.ts
+++ b/src/portal/stdio-http-bridge.ts
@@ -19,6 +19,7 @@ import { errorMessage } from "#src/shared/error-utils.ts";
 import { formatErrorResponse } from "#src/shared/mcp-response-utils.ts";
 import { VERSION } from "#src/shared/version.ts";
 import { logger } from "./file-logger.ts";
+import { LazyBoot } from "./lazy-boot.ts";
 
 const SETUP_URL = "https://ableton-dj-mcp.org/installation";
 
@@ -59,11 +60,15 @@ export class StdioHttpBridge {
   private isConnected = false;
   private fallbackTools: { tools: FallbackTool[] };
   private smallModelMode: boolean;
+  private lazyBoot: LazyBoot;
 
   constructor(httpUrl: string, options: BridgeOptions = {}) {
     this.httpUrl = httpUrl;
     this.smallModelMode = options.smallModelMode ?? false;
     this.fallbackTools = this._generateFallbackTools();
+    this.lazyBoot = new LazyBoot({
+      serverOrigin: httpUrl.replace(/\/mcp$/, ""),
+    });
   }
 
   private _generateFallbackTools(): { tools: FallbackTool[] } {
@@ -168,6 +173,21 @@ Tell the user to check ${SETUP_URL} for configuration help.
         }
 
         this.httpClient = null;
+      }
+
+      const bootResult = await this.lazyBoot.tryBoot();
+
+      if (bootResult.succeeded) {
+        logger.info("[Bridge] Lazy-boot succeeded, retrying HTTP connection");
+        await this._ensureHttpConnection();
+
+        return;
+      }
+
+      if (bootResult.attempted) {
+        logger.error(
+          `[Bridge] Lazy-boot attempted but did not recover: ${bootResult.reason ?? "unknown"}`,
+        );
       }
 
       throw new Error(


### PR DESCRIPTION
## Summary

Self-bootstrap for the AI-driven workflow. When `ADJ_AUTO_BOOT=true` is set in the MCP client config, the portal launches Ableton Live automatically when it can't reach `:3350`, polls until the device server comes up, and forwards the original tool call.

Default off so existing Claude Code sessions don't trigger Live launches unintentionally. macOS only for this PR (Windows can be added later).

Final part of #78. Companion to #107 (User Library install) and #108 (`start:live` launcher).

## State machine

| Live status | Portal action |
|---|---|
| closed | `open -b com.ableton.live` -> poll `:3350` (30s) -> retry connection |
| open with device loaded | noop, business as usual |
| open without device loaded | skip auto-relaunch (would destroy unsaved work), return standard setup error |
| unsupported platform | skip, return standard setup error |

Single attempt per portal lifetime to avoid relaunch loops if Live fails to load the device.

## What changed

- `src/portal/lazy-boot.ts` (new) - encapsulates detect-launch-poll. Reads `ADJ_AUTO_BOOT` at call time so tests can flip it. Mockable spawn + fetch.
- `src/portal/lazy-boot.test.ts` (new) - 6 cases: disabled, second-call gating, state-3 skip, happy path, timeout, unsupported platform.
- `src/portal/stdio-http-bridge.ts` - calls `lazyBoot.tryBoot()` in the `_ensureHttpConnection` catch path; on success, retries the connection.
- `docs/Setup.md` - documents the env flag with a Claude Desktop config example.

## Usage

Add to MCP client config:

```json
{
  "mcpServers": {
    "ableton-dj-mcp": {
      "command": "node",
      "args": ["/abs/path/dist/ableton-dj-mcp-portal.js"],
      "env": { "ADJ_AUTO_BOOT": "true" }
    }
  }
}
```

User says "use Ableton" -> AI calls `adj-connect` -> portal launches Live -> first call succeeds transparently. First call may take ~5-15s while Live boots.

## Test plan

- [x] `npm run check` (lint + typecheck + format + duplication + coverage) - all pass
- [x] `npm run test src/portal/lazy-boot.test.ts` - 6/6 pass
- [ ] Manual: `ADJ_AUTO_BOOT=true` + Live closed -> first MCP call boots Live
- [ ] Manual: `ADJ_AUTO_BOOT=true` + Live open without device -> standard setup error (no relaunch)
- [ ] Manual: `ADJ_AUTO_BOOT` unset -> behavior unchanged
- [ ] Manual: timeout path - rename device temporarily so Live starts but `:3350` never comes up

Closes #78 (with caveat: Windows lazy-boot deferred; template.als deferred).