### PR TITLE
fix: install:device must copy .maxpat files too

### DIFF
--- a/scripts/install-device.ts
+++ b/scripts/install-device.ts
@@ -25,6 +25,10 @@ const DEVICE_FILES = [
   "Ableton_DJ_MCP.amxd",
   "live-api-adapter.js",
   "mcp-server.mjs",
+  "server-status.maxpat",
+  "tab-main.maxpat",
+  "tab-context.maxpat",
+  "tab-setup.maxpat",
 ] as const;
 
 /**


### PR DESCRIPTION
### **User description**
## Summary

PR #107 only copied the .amxd + 2 JS bundles into the User Library, missing the four sibling .maxpat patcher files. The .amxd embeds bpatcher references to those patches by relative path.

## Symptom

Loading the User-Library-installed device produced:

\`\`\`
bpatcher: error loading patcher tab-main.maxpat
bpatcher: error loading patcher tab-context.maxpat
bpatcher: error loading patcher tab-setup.maxpat
\`\`\`

Device booted (\`:3350\` came up) but the entire UI was missing. Looks broken to anyone testing PR3 (#109)'s lazy-boot path end-to-end.

## Fix

Add \`server-status.maxpat\`, \`tab-main.maxpat\`, \`tab-context.maxpat\`, \`tab-setup.maxpat\` to \`DEVICE_FILES\` in \`scripts/install-device.ts\`.

## Test plan

- [x] \`npm run check\` — all pass
- [x] Verified locally: re-running \`npm run install:device\` copies all 7 files; re-loading device in Live shows clean console + working UI tabs


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes missing `.maxpat` files.

- Resolves Max for Live device UI errors.

- Ensures complete device installation.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install-device.ts</strong><dd><code>Include all required .maxpat files for device installation</code></dd></summary>
<hr>

scripts/install-device.ts

<ul><li>Added <code>server-status.maxpat</code>, <code>tab-main.maxpat</code>, <code>tab-context.maxpat</code>, and <br><code>tab-setup.maxpat</code> to the <code>DEVICE_FILES</code> array.<br> <li> Ensures all necessary Max for Live patcher files are copied during the <br><code>install:device</code> script execution.<br> <li> Resolves UI loading errors that occurred when the device was installed <br>from the Ableton User Library.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/110/files#diff-b47b1b5fa1aba56dc50320b663e7e53218d50b5822a1cb24e5eede35d044ba43">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

