### PR TITLE
docs: capture install:device + lazy-boot findings

### DIFF
--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -13,6 +13,9 @@ Line format: `- [<slug>](<domain>/<slug>.md) [<glob>,<glob>] — <summary>`
 - [empty-drum-rack-silent](dev/empty-drum-rack-silent.md) [src/tools/device/**,
   **/adj-create-device*] — adj-create-device "Drum Rack" returns success but
   rack has no samples = no sound
+- [install-device-file-list](dev/install-device-file-list.md)
+  [scripts/install-device.ts, max-for-live-device/**] — User Library install
+  needs all 7 files (.amxd + 2 JS + 4 .maxpat); missing .maxpat = blank UI
 - [live-instrument-limit](dev/live-instrument-limit.md) [src/tools/device/**,
   src/tools/track/**] — Live blocks 2nd instrument per track with vague error;
   delete first
@@ -31,3 +34,7 @@ Line format: `- [<slug>](<domain>/<slug>.md) [<glob>,<glob>] — <summary>`
 - [device-deploy-flow](workflow/device-deploy-flow.md) [max-for-live-device/**,
   dist/**, package.json] — build → copy bundles to max-for-live-device → restart
   Live to load new version
+- [self-bootstrap-prereq](workflow/self-bootstrap-prereq.md)
+  [src/portal/lazy-boot*, scripts/start-live.ts, docs/Setup.md] — lazy-boot only
+  opens Live; device load needs "Save Live Set as Default Set" with device on
+  track

--- a/docs/findings/dev/install-device-file-list.md
+++ b/docs/findings/dev/install-device-file-list.md
@@ -1,0 +1,43 @@
+---
+title: install-device-file-list
+domain: dev
+validated: 2026-05-06
+evidence: PR #110, Live console "bpatcher: error loading patcher tab-main.maxpat"
+---
+
+## Fact
+
+`scripts/install-device.ts` must copy 7 files into the User Library Max MIDI
+Effect dir, not 3. The `.amxd` embeds bpatcher references to four sibling
+`.maxpat` files by relative path; missing them leaves the device half-loaded
+(server runs, UI tabs blank).
+
+## Evidence
+
+Required files (all from `max-for-live-device/`):
+
+```
+Ableton_DJ_MCP.amxd
+live-api-adapter.js
+mcp-server.mjs
+server-status.maxpat
+tab-main.maxpat
+tab-context.maxpat
+tab-setup.maxpat
+```
+
+Symptom when `.maxpat` missing (PR #107 bug, fixed in #110):
+
+```
+bpatcher: error loading patcher tab-main.maxpat
+bpatcher: error loading patcher tab-context.maxpat
+bpatcher: error loading patcher tab-setup.maxpat
+```
+
+Device still booted (`:3350` came up) but UI was empty.
+
+## Apply when
+
+Editing `scripts/install-device.ts`, adding any new `.maxpat` patcher under
+`max-for-live-device/`, or debugging missing tabs / empty UI in a User Library
+install.

--- a/docs/findings/workflow/self-bootstrap-prereq.md
+++ b/docs/findings/workflow/self-bootstrap-prereq.md
@@ -1,0 +1,39 @@
+---
+title: self-bootstrap-prereq
+domain: workflow
+validated: 2026-05-06
+evidence:
+  user confirmed "doesnt really work" on first lazy-boot test until default-set
+  fixed
+---
+
+## Fact
+
+Portal lazy-boot (`ADJ_AUTO_BOOT=true`) only launches Live. It does NOT load the
+device. The device only auto-loads if the user has done **File → Save Live Set
+as Default Set** with the device on a return/master track. Without that,
+lazy-boot opens an empty Live, `:3350` never comes up, and the original tool
+call still fails.
+
+## Evidence
+
+End-to-end test in conversation 2026-05-06:
+
+1. `ADJ_AUTO_BOOT=true` set in Claude Code MCP config.
+2. Live closed.
+3. AI tool call → portal launched Live (verified: Live appeared on screen).
+4. `curl http://localhost:3350/mcp` →
+   `Failed to connect ... Couldn't connect to server`. State 4 from the
+   lazy-boot state machine.
+5. After dragging device on track + Save Live Set as Default Set + restart Live:
+   `:3350` came up immediately, lazy-boot path worked end-to-end.
+
+State 3 in `src/portal/lazy-boot.ts` (Live open without device) returns
+`live-running-without-device` and skips relaunch to preserve unsaved work —
+correct, but the underlying problem is the absent default set.
+
+## Apply when
+
+Debugging `:3350` down after lazy-boot launches Live, writing setup/install docs
+that promise self-bootstrap, or designing a `template.als` ship as a fallback
+when no default set is configured.


### PR DESCRIPTION
### **User description**
## Summary

Two validated findings from the issue #78 self-bootstrap rollout — captured so future sessions don't re-discover the same traps.

## Findings

### dev/install-device-file-list

User Library install needs all 7 device files (`.amxd` + 2 JS bundles + 4 `.maxpat` patches). Missing the `.maxpat` files leaves the device half-loaded — server runs, UI tabs blank. Triggers on edits to `scripts/install-device.ts` or new `.maxpat` files under `max-for-live-device/`.

### workflow/self-bootstrap-prereq

`ADJ_AUTO_BOOT=true` lazy-boot only launches Live. Device load depends on the user having saved a default Live set with the device on a return/master track. Without that, lazy-boot opens an empty Live and `:3350` never comes up. Triggers on lazy-boot debugging or `template.als` fallback design.

Both validated against this session's conversation:
- PR #110 + Live console `bpatcher: error loading patcher tab-*.maxpat` for the first
- User confirmation \"doesnt really work\" + `curl :3350` failing for the second

## Test plan

- [x] `npm run check` — all pass
- [x] INDEX globs verified to point at the actual files the findings apply to


___

### **PR Type**
Documentation


___

### **Description**
- Documented `install:device` script file requirements.

- Captured `lazy-boot` prerequisite for device loading.

- Added new findings to the `INDEX.md` file.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>INDEX.md</strong><dd><code>Updated findings index with new documentation entries</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/INDEX.md

<ul><li>Added a new entry for <code>install-device-file-list</code> under the <code>dev</code> domain.<br> <li> Added a new entry for <code>self-bootstrap-prereq</code> under the <code>workflow</code> domain.<br> <li> Included glob patterns and summaries for the newly added findings.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/112/files#diff-979fccfe801351786b9cff5fb897af3ff04082c758a89f3c81ac6903e5592f98">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>install-device-file-list.md</strong><dd><code>Documented `install:device` script's full file list requirement</code></dd></summary>
<hr>

docs/findings/dev/install-device-file-list.md

<ul><li>Documented that <code>scripts/install-device.ts</code> must copy 7 files, including <br><code>.maxpat</code> files, into the User Library.<br> <li> Explained that missing <code>.maxpat</code> files lead to a half-loaded device with <br>a blank UI.<br> <li> Provided evidence from PR #110 and Live console errors.<br> <li> Advised when to apply this finding, such as when editing <br><code>install-device.ts</code> or debugging UI issues.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/112/files#diff-b4551d7d5d0ef8e60441fd5886b3d5e3a2a4ed15c631ddb147b1d48f0af1857c">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>self-bootstrap-prereq.md</strong><dd><code>Documented `lazy-boot` prerequisite for device auto-loading</code></dd></summary>
<hr>

docs/findings/workflow/self-bootstrap-prereq.md

<ul><li>Documented that <code>ADJ_AUTO_BOOT=true</code> only launches Live, not the device <br>itself.<br> <li> Stated that device auto-loading requires the user to "Save Live Set as <br>Default Set" with the device on a track.<br> <li> Provided evidence from an end-to-end test where <code>curl</code> failed until the <br>default set was configured.<br> <li> Advised when to apply this finding, such as when debugging lazy-boot <br>issues or writing setup documentation.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/112/files#diff-0d60968f892993ba085309436ec9ecd5c4ebcfbc5db3d861bd872603839d7f6c">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

