### PR TITLE
fix: extract shared User Library path, unblock CI on main

### DIFF
--- a/scripts/dev-hot.ts
+++ b/scripts/dev-hot.ts
@@ -16,10 +16,10 @@
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { copyFileSync, existsSync } from "node:fs";
-import { homedir, platform } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import chokidar from "chokidar";
+import { resolveUserLibraryDir } from "./shared/user-library-path.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..");
@@ -97,7 +97,10 @@ function deploy(): void {
 
   const targets: string[] = [deviceDir];
 
-  if (userLibraryDir !== null && existsSync(join(userLibraryDir, "Ableton_DJ_MCP.amxd"))) {
+  if (
+    userLibraryDir !== null &&
+    existsSync(join(userLibraryDir, "Ableton_DJ_MCP.amxd"))
+  ) {
     targets.push(userLibraryDir);
   }
 
@@ -171,40 +174,6 @@ function killProcessOn3350(): void {
       );
     });
   });
-}
-
-/**
- * Resolve Live's User Library Max MIDI Effect dir. Mirrors the logic in
- * scripts/install-device.ts. Returns null on unsupported platforms.
- * @returns Absolute path or null
- */
-function resolveUserLibraryDir(): string | null {
-  const home = homedir();
-
-  switch (platform()) {
-    case "darwin":
-      return join(
-        home,
-        "Music",
-        "Ableton",
-        "User Library",
-        "Presets",
-        "MIDI Effects",
-        "Max MIDI Effect",
-      );
-    case "win32":
-      return join(
-        home,
-        "Documents",
-        "Ableton",
-        "User Library",
-        "Presets",
-        "MIDI Effects",
-        "Max MIDI Effect",
-      );
-    default:
-      return null;
-  }
 }
 
 /**

--- a/scripts/install-device.ts
+++ b/scripts/install-device.ts
@@ -12,9 +12,10 @@
 
 import { createHash } from "node:crypto";
 import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
-import { homedir, platform } from "node:os";
+import { platform } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveUserLibraryDir } from "./shared/user-library-path.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..");
@@ -30,43 +31,6 @@ const DEVICE_FILES = [
   "tab-context.maxpat",
   "tab-setup.maxpat",
 ] as const;
-
-/**
- * Resolve the path to Live's per-user Max MIDI Effect preset directory.
- * @returns Absolute path on the current platform
- */
-function resolveUserLibraryDir(): string {
-  const home = homedir();
-
-  switch (platform()) {
-    case "darwin":
-      return join(
-        home,
-        "Music",
-        "Ableton",
-        "User Library",
-        "Presets",
-        "MIDI Effects",
-        "Max MIDI Effect",
-      );
-    case "win32":
-      return join(
-        home,
-        "Documents",
-        "Ableton",
-        "User Library",
-        "Presets",
-        "MIDI Effects",
-        "Max MIDI Effect",
-      );
-    default:
-      console.error(
-        `install-device: unsupported platform '${platform()}'. ` +
-          `Ableton Live runs on macOS or Windows only.`,
-      );
-      process.exit(1);
-  }
-}
 
 /**
  * Verify the source files exist and warn if dist/ has drifted from
@@ -117,6 +81,14 @@ function hashFile(path: string): string {
 assertSourceFresh();
 
 const targetDir = resolveUserLibraryDir();
+
+if (targetDir === null) {
+  console.error(
+    `install-device: unsupported platform '${platform()}'. ` +
+      `Ableton Live runs on macOS or Windows only.`,
+  );
+  process.exit(1);
+}
 
 if (!existsSync(targetDir)) {
   mkdirSync(targetDir, { recursive: true });

--- a/scripts/shared/user-library-path.ts
+++ b/scripts/shared/user-library-path.ts
@@ -1,0 +1,44 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Shared resolver for the Live User Library Max MIDI Effect dir. Used by
+// scripts/install-device.ts and scripts/dev-hot.ts so both target the same
+// path on every platform.
+
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Resolve Live's per-user Max MIDI Effect preset directory for the current
+ * platform.
+ * @returns Absolute path on macOS/Windows, null on unsupported platforms
+ */
+export function resolveUserLibraryDir(): string | null {
+  const home = homedir();
+
+  switch (platform()) {
+    case "darwin":
+      return join(
+        home,
+        "Music",
+        "Ableton",
+        "User Library",
+        "Presets",
+        "MIDI Effects",
+        "Max MIDI Effect",
+      );
+    case "win32":
+      return join(
+        home,
+        "Documents",
+        "Ableton",
+        "User Library",
+        "Presets",
+        "MIDI Effects",
+        "Max MIDI Effect",
+      );
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
### **User description**
## Summary

Hotfix for two CI breakages on \`main\` after #115 merged:

1. **Format check failed** — the multi-line \`if\` in \`deploy()\` wasn't run through Prettier before commit.
2. **Scripts duplication failed** (1.66% > 0.7% threshold) — the ~25-line User Library path resolver was copy-pasted between \`install-device.ts\` and \`dev-hot.ts\`.

## Fix

- Extract \`resolveUserLibraryDir\` into \`scripts/shared/user-library-path.ts\`. Both scripts import from there.
- Run \`npm run format\` to fix the dev-hot.ts formatting.

\`install-device.ts\` previously exited inline on unsupported platforms; it now treats \`null\` from the shared resolver as the unsupported case and exits with the same message.

Duplication drops to 0.28%. Format check passes.

## Test plan

- [x] \`npm run check\` — all pass (lint + typecheck + format + duplication + coverage)
- [x] \`npm run install:device\` still works (re-installs to User Library)
- [x] \`scripts/dev-hot.ts\` still resolves User Library dir correctly


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Extracted `resolveUserLibraryDir` to a shared utility.

- Eliminated code duplication, resolving CI failure.

- Improved `install-device.ts` platform error handling.

- Applied Prettier formatting to `dev-hot.ts`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["scripts/dev-hot.ts"]
  B["scripts/install-device.ts"]
  C["scripts/shared/user-library-path.ts"]

  A -- "Previously duplicated logic" --> D["resolveUserLibraryDir()"]
  B -- "Previously duplicated logic" --> D

  A -- "Now imports" --> C
  B -- "Now imports" --> C
  C -- "Exports shared" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dev-hot.ts</strong><dd><code>Refactor `dev-hot.ts` to use shared user library path resolver</code></dd></summary>
<hr>

scripts/dev-hot.ts

<ul><li>Removed the duplicated <code>resolveUserLibraryDir</code> function.<br> <li> Imported the shared <code>resolveUserLibraryDir</code> from <br><code>scripts/shared/user-library-path.ts</code>.<br> <li> Applied Prettier formatting to the <code>deploy()</code> function's conditional <br>statement.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/116/files#diff-86b36c6503c80f510862472b0f4c826233753089264505a82bfa524daa323239">+5/-36</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>install-device.ts</strong><dd><code>Refactor <code>install-device.ts</code> to use shared path resolver and improve <br>error handling</code></dd></summary>
<hr>

scripts/install-device.ts

<ul><li>Removed the duplicated <code>resolveUserLibraryDir</code> function.<br> <li> Imported the shared <code>resolveUserLibraryDir</code> from <br><code>scripts/shared/user-library-path.ts</code>.<br> <li> Updated platform error handling to check for <code>null</code> return from the <br>shared resolver.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/116/files#diff-b47b1b5fa1aba56dc50320b663e7e53218d50b5822a1cb24e5eede35d044ba43">+10/-38</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>New feature</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user-library-path.ts</strong><dd><code>Introduce shared utility for resolving User Library path</code>&nbsp; </dd></summary>
<hr>

scripts/shared/user-library-path.ts

<ul><li>Added a new shared utility file <code>user-library-path.ts</code>.<br> <li> Extracted the <code>resolveUserLibraryDir</code> function into this file.<br> <li> The function resolves the Ableton Live User Library path for macOS and <br>Windows, returning <code>null</code> for unsupported platforms.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/116/files#diff-a3ec262d7673e23c40bd9dc3e8bd008811302781266bc9d56fe6bfc1f168f029">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

