### PR TITLE
feat: Live Browser Bridge — adj-browse + browserUri loading via Python sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ src/notation/*/parser/generated-*-parser.js
 # Generated build-info (branch/sha/dirty/buildTime baked at build)
 src/generated/
 
+# Python bytecode caches (live_browser_bridge/ ships as plain source)
+__pycache__/
+*.pyc
+
 # Generated docs artifacts
 docs/_generated
 docs/public/markdown

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ To capture a new validated finding, run `/update-docs` (loads
 
 ## Tools
 
-22 tools, all prefixed `adj-`. Each tool has a `.def.ts` (Zod schema) and a
+23 tools, all prefixed `adj-`. Each tool has a `.def.ts` (Zod schema) and a
 `.ts` (implementation). Full catalog with action lists and parameters:
 [`docs/Tools-Reference.md`](docs/Tools-Reference.md).
 

--- a/dist/ableton-dj-mcp-portal.js
+++ b/dist/ableton-dj-mcp-portal.js
@@ -29578,14 +29578,6 @@ const EMPTY_COMPLETION_RESULT = {
 
 const VERSION = "1.10.0";
 
-const MAX_SPLIT_POINTS = 32;
-
-const MONITORING_STATE = {
-  IN: "in",
-  AUTO: "auto",
-  OFF: "off"
-};
-
 function filterSchemaForSmallModel(schema, excludeParams, descriptionOverrides, excludeEnumValues) {
   const hasExclusions = excludeParams && excludeParams.length > 0;
   const hasOverrides = descriptionOverrides && Object.keys(descriptionOverrides).length > 0;
@@ -29670,6 +29662,32 @@ function filterExcludedEnumValues(validated, excludeEnumValues) {
   }
   return result;
 }
+
+const CATEGORY_VALUES = [ "instruments", "audio_effects", "midi_effects", "drums", "sounds", "samples", "clips", "current_project", "user_library", "user_folders", "packs", "plugins", "max_for_live" ];
+
+const toolDefBrowse = defineTool("adj-browse", {
+  title: "Browse",
+  description: "Browse Ableton Live's Library and User Library tree. Returns category roots, folder children, and loadable items with their stable browser URIs. Pair the URI with adj-create-device to load by URI. Requires the Live Browser Bridge — install with `npm run install:bridge`.",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false
+  },
+  inputSchema: {
+    category: _enum$2(CATEGORY_VALUES).optional().describe("browser category root to enter; omit to list available categories"),
+    path: string$1().optional().describe("slash-separated names walked under the category root (e.g., 'Synths/Operator')"),
+    search: string$1().optional().describe("case-insensitive substring filter applied to children"),
+    depth: number$1().int().min(1).max(3).optional().describe("how many child levels to expand inline (default 1)"),
+    limit: number$1().int().min(1).max(500).optional().describe("maximum number of top-level items to return (default 100)")
+  }
+});
+
+const MAX_SPLIT_POINTS = 32;
+
+const MONITORING_STATE = {
+  IN: "in",
+  AUTO: "auto",
+  OFF: "off"
+};
 
 const toolDefCreateClip = defineTool("adj-create-clip", {
   title: "Create Clip",
@@ -29844,13 +29862,15 @@ const toolDefCreateDevice = defineTool("adj-create-device", {
   inputSchema: {
     deviceName: string$1().optional().describe("device name, omit to list available devices"),
     path: string$1().optional().describe("insertion path(s), required with deviceName, comma-separated for multiple (e.g., 't0' or 't0,t1,t0/d0/c0')"),
-    name: string$1().optional().describe("name for all, or comma-separated for each")
+    name: string$1().optional().describe("name for all, or comma-separated for each"),
+    browserUri: string$1().optional().describe("browser URI from adj-browse to load the exact item; pass with deviceName='Drum Rack' to load a kit into a freshly-inserted rack. Requires the Live Browser Bridge.")
   },
   smallModelModeConfig: {
     excludeParams: [],
     descriptionOverrides: {
       path: "insertion path, required with deviceName (e.g., 't0', 't0/d1', 't0/d0/c0')",
-      name: "display name"
+      name: "display name",
+      browserUri: "URI from adj-browse to load by browser"
     }
   }
 });
@@ -30237,7 +30257,7 @@ const toolDefContext = defineTool("adj-context", {
   }
 });
 
-const STANDARD_TOOL_DEFS = [ toolDefConnect, toolDefContext, toolDefReadLiveSet, toolDefUpdateLiveSet, toolDefReadTrack, toolDefCreateTrack, toolDefUpdateTrack, toolDefReadScene, toolDefCreateScene, toolDefUpdateScene, toolDefReadClip, toolDefCreateClip, toolDefUpdateClip, toolDefReadDevice, toolDefCreateDevice, toolDefUpdateDevice, toolDefDelete, toolDefDuplicate, toolDefSelect, toolDefPlayback, toolDefGenerate ];
+const STANDARD_TOOL_DEFS = [ toolDefConnect, toolDefContext, toolDefReadLiveSet, toolDefUpdateLiveSet, toolDefReadTrack, toolDefCreateTrack, toolDefUpdateTrack, toolDefReadScene, toolDefCreateScene, toolDefUpdateScene, toolDefReadClip, toolDefCreateClip, toolDefUpdateClip, toolDefReadDevice, toolDefCreateDevice, toolDefUpdateDevice, toolDefDelete, toolDefDuplicate, toolDefSelect, toolDefPlayback, toolDefGenerate, toolDefBrowse ];
 
 Object.freeze(STANDARD_TOOL_DEFS.map(td => td.toolName));
 

--- a/dist/live-api-adapter.js
+++ b/dist/live-api-adapter.js
@@ -970,10 +970,10 @@ if (!Array.prototype.with) {
 }
 
 const BUILD_INFO = {
-  branch: "gabriel/browser-api",
-  sha: "027a3947",
+  branch: "gabriel/browser-bridge",
+  sha: "724f3daf",
   dirty: false,
-  buildTime: "2026-05-07T16:52:49.948Z",
+  buildTime: "2026-05-07T17:33:46.740Z",
   source: "local"
 };
 

--- a/dist/mcp-server.mjs
+++ b/dist/mcp-server.mjs
@@ -735,14 +735,16 @@ import require$$7$1 from "node:buffer";
 
 import require$$1$5 from "node:net";
 
-import crypto$1 from "node:crypto";
+import crypto$1, { randomUUID } from "node:crypto";
+
+import { createSocket } from "node:dgram";
 
 import os from "node:os";
 
 const BUILD_INFO = {
-  branch: "gabriel/browser-api",
-  sha: "027a3947",
-  buildTime: "2026-05-07T16:52:49.948Z"
+  branch: "gabriel/browser-bridge",
+  sha: "724f3daf",
+  buildTime: "2026-05-07T17:33:46.740Z"
 };
 
 function buildIdentifier() {
@@ -30895,6 +30897,289 @@ function errorMessage(err) {
   return err instanceof Error ? err.message : String(err);
 }
 
+const MAX_ERROR_DELIMITER = "$$___MAX_ERRORS___$$";
+
+function formatErrorResponse(errorMessage) {
+  return {
+    content: [ {
+      type: "text",
+      text: errorMessage
+    } ],
+    isError: true
+  };
+}
+
+const DEFAULT_HOST = "127.0.0.1";
+
+const DEFAULT_PORT = 11077;
+
+const DEFAULT_BROWSE_TIMEOUT_MS = 1e4;
+
+const DEFAULT_LOAD_TIMEOUT_MS = 3e4;
+
+const DEFAULT_PING_TIMEOUT_MS = 1500;
+
+const PING_FRESHNESS_MS = 3e4;
+
+const CLIENT_CLOSED_MESSAGE = "client closed";
+
+class BrowserBridgeClient {
+  host;
+  port;
+  socketFactory;
+  socket=null;
+  socketReady=null;
+  pending=new Map;
+  lastPingOkAt=0;
+  closed=false;
+  constructor(options = {}) {
+    this.host = options.host ?? DEFAULT_HOST;
+    const envPort = Number.parseInt(process.env.ADJ_BRIDGE_PORT ?? "", 10);
+    this.port = options.port ?? (Number.isFinite(envPort) ? envPort : DEFAULT_PORT);
+    this.socketFactory = options.socketFactory ?? (() => createSocket("udp4"));
+  }
+  async ping(timeoutMs = DEFAULT_PING_TIMEOUT_MS) {
+    const reply = await this.send("ping", {}, timeoutMs);
+    this.lastPingOkAt = Date.now();
+    return reply;
+  }
+  async ensureAlive() {
+    if (Date.now() - this.lastPingOkAt < PING_FRESHNESS_MS) return true;
+    try {
+      await this.ping();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  async browse(args, timeoutMs = DEFAULT_BROWSE_TIMEOUT_MS) {
+    return await this.send("browse", {
+      ...args
+    }, timeoutMs);
+  }
+  async loadItem(args, timeoutMs = DEFAULT_LOAD_TIMEOUT_MS) {
+    return await this.send("load_item", {
+      ...args
+    }, timeoutMs);
+  }
+  close() {
+    this.closed = true;
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.resolve({
+        id: id,
+        ok: false,
+        error: {
+          code: "TIMEOUT_INTERNAL",
+          message: CLIENT_CLOSED_MESSAGE
+        }
+      });
+    }
+    this.pending.clear();
+    if (this.socket) {
+      try {
+        this.socket.close();
+      } catch {}
+      this.socket = null;
+      this.socketReady = null;
+    }
+  }
+  async send(op, args, timeoutMs) {
+    if (this.closed) {
+      throw new BridgeCallError({
+        code: "TIMEOUT_INTERNAL",
+        message: CLIENT_CLOSED_MESSAGE
+      });
+    }
+    await this.ensureSocket();
+    const closedNow = this.closed;
+    const socket = this.socket;
+    if (closedNow || !socket) {
+      throw new BridgeCallError({
+        code: closedNow ? "TIMEOUT_INTERNAL" : "BRIDGE_NOT_FOUND",
+        message: closedNow ? CLIENT_CLOSED_MESSAGE : "bridge socket unavailable"
+      });
+    }
+    const id = `req_${randomUUID()}`;
+    const request = {
+      id: id,
+      op: op,
+      args: args
+    };
+    const payload = Buffer.from(JSON.stringify(request), "utf8");
+    const replyPromise = new Promise(resolve => {
+      const timer = setTimeout(() => {
+        if (this.pending.delete(id)) {
+          resolve({
+            id: id,
+            ok: false,
+            error: {
+              code: "TIMEOUT_INTERNAL",
+              message: `bridge ${op} timed out after ${timeoutMs}ms`
+            }
+          });
+        }
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: resolve,
+        timer: timer
+      });
+    });
+    await new Promise((resolve, reject) => {
+      socket.send(payload, this.port, this.host, err => {
+        if (err) reject(err); else resolve();
+      });
+    }).catch(err => {
+      const pending = this.pending.get(id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        this.pending.delete(id);
+      }
+      throw new BridgeCallError({
+        code: "BRIDGE_NOT_FOUND",
+        message: `udp send failed: ${err.message}`
+      });
+    });
+    const reply = await replyPromise;
+    if (!reply.ok) {
+      this.lastPingOkAt = 0;
+      throw new BridgeCallError(reply.error);
+    }
+    return reply.result;
+  }
+  ensureSocket() {
+    if (this.socketReady) return this.socketReady;
+    this.socketReady = new Promise((resolve, reject) => {
+      const socket = this.socketFactory();
+      socket.on("message", (msg, _rinfo) => this.onMessage(msg));
+      socket.on("error", err => {
+        for (const [id, pending] of this.pending) {
+          clearTimeout(pending.timer);
+          pending.resolve({
+            id: id,
+            ok: false,
+            error: {
+              code: "BRIDGE_NOT_FOUND",
+              message: `socket error: ${err.message}`
+            }
+          });
+        }
+        this.pending.clear();
+      });
+      socket.bind(0, () => {
+        this.socket = socket;
+        resolve();
+      });
+      socket.once("error", err => {
+        if (!this.socket) reject(err);
+      });
+    });
+    return this.socketReady;
+  }
+  onMessage(buf) {
+    let parsed;
+    try {
+      parsed = JSON.parse(buf.toString("utf8"));
+    } catch {
+      return;
+    }
+    const pending = this.pending.get(parsed.id);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.pending.delete(parsed.id);
+    pending.resolve(parsed);
+  }
+}
+
+class BridgeCallError extends Error {
+  code;
+  constructor(error) {
+    super(error.message);
+    this.name = "BridgeCallError";
+    this.code = error.code;
+  }
+}
+
+const INSTALL_HINT = "Bridge unavailable. Run `npm run install:bridge`, then restart Live and enable AbletonDjMcp under Preferences → Link/Tempo/MIDI → Control Surface.";
+
+function makeBridgeDispatcher(next, bridge) {
+  return async (tool, args) => {
+    if (tool === "adj-browse") {
+      return await handleBrowse(bridge, args);
+    }
+    if (tool === "adj-create-device") {
+      const cdArgs = args;
+      if (cdArgs.browserUri) {
+        return await handleCreateDeviceBrowserUri(bridge, next, cdArgs);
+      }
+    }
+    return await next(tool, args);
+  };
+}
+
+async function handleBrowse(bridge, args) {
+  if (!await bridge.ensureAlive()) {
+    return formatErrorResponse(INSTALL_HINT);
+  }
+  try {
+    const result = await bridge.browse(args);
+    return successPayload(result);
+  } catch (err) {
+    return formatErrorResponse(formatBridgeError("browse", err));
+  }
+}
+
+async function handleCreateDeviceBrowserUri(bridge, next, args) {
+  if (!args.path) {
+    return formatErrorResponse("createDevice failed: path is required when using browserUri");
+  }
+  if (!await bridge.ensureAlive()) {
+    return formatErrorResponse(INSTALL_HINT);
+  }
+  const selectArgs = {
+    path: args.path,
+    detailView: "device"
+  };
+  const selectResult = await next("adj-select", selectArgs);
+  if (selectResult.isError) return selectResult;
+  if (args.deviceName) {
+    const insertArgs = {
+      deviceName: args.deviceName,
+      path: args.path
+    };
+    if (args.name != null) insertArgs.name = args.name;
+    const insertResult = await next("adj-create-device", insertArgs);
+    if (insertResult.isError) return insertResult;
+  }
+  try {
+    const result = await bridge.loadItem({
+      uri: args.browserUri ?? ""
+    });
+    return successPayload(result);
+  } catch (err) {
+    return formatErrorResponse(formatBridgeError("load_item", err));
+  }
+}
+
+function successPayload(value) {
+  return {
+    content: [ {
+      type: "text",
+      text: JSON.stringify(value)
+    } ]
+  };
+}
+
+function formatBridgeError(op, err) {
+  if (err instanceof BridgeCallError) {
+    return `Bridge ${op} failed [${err.code}]: ${err.message}`;
+  }
+  if (err instanceof Error) {
+    return `Bridge ${op} failed: ${err.message}`;
+  }
+  return `Bridge ${op} failed: ${String(err)}`;
+}
+
 var util$2;
 
 (function(util) {
@@ -51334,14 +51619,6 @@ const EMPTY_COMPLETION_RESULT = {
   }
 };
 
-const MAX_SPLIT_POINTS = 32;
-
-const MONITORING_STATE = {
-  IN: "in",
-  AUTO: "auto",
-  OFF: "off"
-};
-
 function filterSchemaForSmallModel(schema, excludeParams, descriptionOverrides, excludeEnumValues) {
   const hasExclusions = excludeParams && excludeParams.length > 0;
   const hasOverrides = descriptionOverrides && Object.keys(descriptionOverrides).length > 0;
@@ -51426,6 +51703,32 @@ function filterExcludedEnumValues(validated, excludeEnumValues) {
   }
   return result;
 }
+
+const CATEGORY_VALUES = [ "instruments", "audio_effects", "midi_effects", "drums", "sounds", "samples", "clips", "current_project", "user_library", "user_folders", "packs", "plugins", "max_for_live" ];
+
+const toolDefBrowse = defineTool("adj-browse", {
+  title: "Browse",
+  description: "Browse Ableton Live's Library and User Library tree. Returns category roots, folder children, and loadable items with their stable browser URIs. Pair the URI with adj-create-device to load by URI. Requires the Live Browser Bridge — install with `npm run install:bridge`.",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false
+  },
+  inputSchema: {
+    category: _enum$2(CATEGORY_VALUES).optional().describe("browser category root to enter; omit to list available categories"),
+    path: string$1().optional().describe("slash-separated names walked under the category root (e.g., 'Synths/Operator')"),
+    search: string$1().optional().describe("case-insensitive substring filter applied to children"),
+    depth: number$1().int().min(1).max(3).optional().describe("how many child levels to expand inline (default 1)"),
+    limit: number$1().int().min(1).max(500).optional().describe("maximum number of top-level items to return (default 100)")
+  }
+});
+
+const MAX_SPLIT_POINTS = 32;
+
+const MONITORING_STATE = {
+  IN: "in",
+  AUTO: "auto",
+  OFF: "off"
+};
 
 const toolDefCreateClip = defineTool("adj-create-clip", {
   title: "Create Clip",
@@ -51600,13 +51903,15 @@ const toolDefCreateDevice = defineTool("adj-create-device", {
   inputSchema: {
     deviceName: string$1().optional().describe("device name, omit to list available devices"),
     path: string$1().optional().describe("insertion path(s), required with deviceName, comma-separated for multiple (e.g., 't0' or 't0,t1,t0/d0/c0')"),
-    name: string$1().optional().describe("name for all, or comma-separated for each")
+    name: string$1().optional().describe("name for all, or comma-separated for each"),
+    browserUri: string$1().optional().describe("browser URI from adj-browse to load the exact item; pass with deviceName='Drum Rack' to load a kit into a freshly-inserted rack. Requires the Live Browser Bridge.")
   },
   smallModelModeConfig: {
     excludeParams: [],
     descriptionOverrides: {
       path: "insertion path, required with deviceName (e.g., 't0', 't0/d1', 't0/d0/c0')",
-      name: "display name"
+      name: "display name",
+      browserUri: "URI from adj-browse to load by browser"
     }
   }
 });
@@ -51993,7 +52298,7 @@ const toolDefContext = defineTool("adj-context", {
   }
 });
 
-const STANDARD_TOOL_DEFS = [ toolDefConnect, toolDefContext, toolDefReadLiveSet, toolDefUpdateLiveSet, toolDefReadTrack, toolDefCreateTrack, toolDefUpdateTrack, toolDefReadScene, toolDefCreateScene, toolDefUpdateScene, toolDefReadClip, toolDefCreateClip, toolDefUpdateClip, toolDefReadDevice, toolDefCreateDevice, toolDefUpdateDevice, toolDefDelete, toolDefDuplicate, toolDefSelect, toolDefPlayback, toolDefGenerate ];
+const STANDARD_TOOL_DEFS = [ toolDefConnect, toolDefContext, toolDefReadLiveSet, toolDefUpdateLiveSet, toolDefReadTrack, toolDefCreateTrack, toolDefUpdateTrack, toolDefReadScene, toolDefCreateScene, toolDefUpdateScene, toolDefReadClip, toolDefCreateClip, toolDefUpdateClip, toolDefReadDevice, toolDefCreateDevice, toolDefUpdateDevice, toolDefDelete, toolDefDuplicate, toolDefSelect, toolDefPlayback, toolDefGenerate, toolDefBrowse ];
 
 const TOOL_NAMES = Object.freeze(STANDARD_TOOL_DEFS.map(td => td.toolName));
 
@@ -52011,18 +52316,6 @@ function createMcpServer(callLiveApi, options = {}) {
     });
   }
   return server;
-}
-
-const MAX_ERROR_DELIMITER = "$$___MAX_ERRORS___$$";
-
-function formatErrorResponse(errorMessage) {
-  return {
-    content: [ {
-      type: "text",
-      text: errorMessage
-    } ],
-    isError: true
-  };
 }
 
 const SILENCE_WAV = require$$8.join(os.tmpdir(), "adj-silence.wav");
@@ -52250,6 +52543,10 @@ function unwrapMcpResponse(mcpResponse) {
   };
 }
 
+const bridgeClient = new BrowserBridgeClient;
+
+const dispatchLiveApi = makeBridgeDispatcher(callLiveApi, bridgeClient);
+
 const config = {
   memoryEnabled: false,
   memoryContent: "",
@@ -52310,7 +52607,7 @@ function createExpressApp() {
   app.post("/mcp", async (req, res) => {
     try {
       info("New MCP connection: " + JSON.stringify(req.body));
-      const server = createMcpServer(callLiveApi, {
+      const server = createMcpServer(dispatchLiveApi, {
         smallModelMode: config.smallModelMode,
         tools: config.tools
       });
@@ -52338,7 +52635,7 @@ function createExpressApp() {
     res.json(config);
   });
   app.post("/config", handleConfigUpdate);
-  registerRestApiRoutes(app, () => config, callLiveApi);
+  registerRestApiRoutes(app, () => config, dispatchLiveApi);
   return app;
 }
 

--- a/docs/PROJECT_INDEX.md
+++ b/docs/PROJECT_INDEX.md
@@ -13,7 +13,7 @@ this to orient before any task; load the linked file when relevant.
 
 ## Tools
 
-- [Tools-Reference.md](Tools-Reference.md) — canonical catalog of all 22 `adj-*`
+- [Tools-Reference.md](Tools-Reference.md) — canonical catalog of all 23 `adj-*`
   tools, with actions and parameters
 - [contributing/Read-Tool-Includes.md](contributing/Read-Tool-Includes.md) —
   `include` parameter conventions for all read tools
@@ -27,7 +27,7 @@ this to orient before any task; load the linked file when relevant.
 - [specs/Transforms-Spec.md](specs/Transforms-Spec.md) — transform DSL
   (`src/notation/transform/`)
 - [specs/Browser-Bridge-Spec.md](specs/Browser-Bridge-Spec.md) — Python
-  remote-script bridge for Live's Browser API (DRAFT, issue #26)
+  remote-script bridge for Live's Browser API (issue #26)
 
 ## Code conventions and dev workflow
 
@@ -65,6 +65,7 @@ Each tool has 3 layers:
 | `scripts/`              | Dev utilities: `adj-client.ts`, loc counter, open-live-set |
 | `dist/`                 | Build output (git-ignored)                                 |
 | `max-for-live-device/`  | `.amxd` device + sibling JS bundles loaded by Max          |
+| `live_browser_bridge/`  | Python remote-script sidecar, exposes Live's Browser API   |
 
 ## Entry Points
 
@@ -93,6 +94,7 @@ Each tool has 3 layers:
 
 ## Ports
 
-| Port | Service              |
-| ---- | -------------------- |
-| 3350 | MCP server (default) |
+| Port  | Service                                              |
+| ----- | ---------------------------------------------------- |
+| 3350  | MCP server (default)                                 |
+| 11077 | Live Browser Bridge UDP (override `ADJ_BRIDGE_PORT`) |

--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -1,6 +1,6 @@
 # Tools Reference
 
-Canonical catalog of all 22 `adj-*` tools. Other docs link here instead of
+Canonical catalog of all 23 `adj-*` tools. Other docs link here instead of
 duplicating. Read the `.def.ts` files for the full Zod schemas.
 
 ---
@@ -120,10 +120,35 @@ Read device parameters and chain structure.
 
 ### `adj-create-device`
 
-Load a device onto a track by name.
+Load a device onto a track by name, or by browser URI (via the bridge).
 
 - `deviceName` — Ableton native device name (see `src/tools/constants.ts`)
 - `path` — `"trackIndex/deviceIndex"` where to insert
+- `browserUri` — load the exact item from `adj-browse` (e.g., a specific preset
+  or User Library file). Pair with `deviceName: "Drum Rack"` to insert a rack
+  and load a kit into it in one call. Requires the Live Browser Bridge — install
+  with `npm run install:bridge`.
+
+### `adj-browse`
+
+Walk Ableton Live's library tree and return loadable items with their stable
+browser URIs. Use the URIs with `adj-create-device --browserUri` to load.
+
+- `category` — one of `instruments`, `audio_effects`, `midi_effects`, `drums`,
+  `sounds`, `samples`, `clips`, `current_project`, `user_library`, `packs`,
+  `plugins`, `max_for_live` (omit to list available categories)
+- `path` — slash-separated names walked under the category root (e.g.,
+  `"Synths/Operator"`)
+- `search` — case-insensitive substring filter applied to children
+- `depth` — child levels to expand inline (default 1, max 3)
+- `limit` — top-level items to return (default 100, max 500)
+
+Requires the Live Browser Bridge Python sidecar — install with
+`npm run install:bridge`, then enable **AbletonDjMcp** under Live's Preferences
+→ Link/Tempo/MIDI → Control Surface. The bridge is the only path to
+`Application.Browser`; Max-for-Live JavaScript cannot reach it. See
+`docs/specs/Browser-Bridge-Spec.md` and
+`docs/findings/dev/m4l-no-browser-api.md`.
 
 ### `adj-update-device`
 

--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -10,6 +10,15 @@ Line format: `- [<slug>](<domain>/<slug>.md) [<glob>,<glob>] — <summary>`
 - [barbeat-notation-order](dev/barbeat-notation-order.md)
   [src/notation/barbeat/**, src/tools/generative/**, **/notes-formatter*] —
   pitch must precede time pos in barbeat or first note drops + warning
+- [browser-search-shallow](dev/browser-search-shallow.md) [src/tools/browse/**,
+  live_browser_bridge/browser_ops.py, src/mcp-server/bridge-dispatcher.ts] —
+  adj-browse search filters only direct children; user Places not reachable via
+  Live categories
+- [drum-kit-uri-loads-full-rack](dev/drum-kit-uri-loads-full-rack.md)
+  [src/tools/device/create/**, src/mcp-server/bridge-dispatcher.ts,
+  live_browser_bridge/BrowserBridge.py] — load_item on a kit URI creates a
+  populated Drum Rack; pre-inserting "Drum Rack" device yields an extra empty
+  rack
 - [empty-drum-rack-silent](dev/empty-drum-rack-silent.md) [src/tools/device/**,
   **/adj-create-device*] — adj-create-device "Drum Rack" returns success but
   rack has no samples = no sound

--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -19,9 +19,11 @@ Line format: `- [<slug>](<domain>/<slug>.md) [<glob>,<glob>] — <summary>`
 - [live-instrument-limit](dev/live-instrument-limit.md) [src/tools/device/**,
   src/tools/track/**] — Live blocks 2nd instrument per track with vague error;
   delete first
-- [m4l-no-browser-api](dev/m4l-no-browser-api.md) [src/tools/browser/**,
-  src/tools/device/create/**, live-browser-bridge/**] — Live Browser object not
-  exposed to M4L LiveAPI JS in 12.4; Python remote script is only path
+- [m4l-no-browser-api](dev/m4l-no-browser-api.md) [src/tools/browse/**,
+  src/tools/device/create/**, live_browser_bridge/**,
+  src/mcp-server/browser-bridge-client.ts, src/mcp-server/bridge-dispatcher.ts]
+  — Live Browser object not exposed to M4L LiveAPI JS in 12.4; Python remote
+  script is only path (now implemented as `live_browser_bridge/`)
 - [release-please-version-sync](dev/release-please-version-sync.md)
   [release-please-config.json, src/shared/version.ts, package.json] — VERSION
   constants need extra-files entry + marker comment

--- a/docs/findings/dev/browser-search-shallow.md
+++ b/docs/findings/dev/browser-search-shallow.md
@@ -1,0 +1,35 @@
+---
+title: browser-search-shallow
+domain: dev
+validated: 2026-05-07
+evidence: PR #119, manual session
+---
+
+## Fact
+
+`adj-browse`'s `search` filter only matches direct children of the target node
+(category root or path-walked node). It is not a recursive search across the
+tree. `Application.Browser.<category>` only exposes Live's curated categories;
+user-added Places (sidebar folders, external sample packs dropped onto the
+browser) are not reachable via standard category attributes.
+
+## Evidence
+
+```
+adj-browse search=lunatica           → returns only the categories list
+adj-browse category=user_library search=lunatica → items: []
+adj-browse category=samples search=lunatica → items: []
+adj-browse category=packs            → only "Core Library"
+adj-browse category=user_folders     → items: []
+```
+
+The Zenhiser pack lived at `~/Downloads/Zenhiser - Headliner Lunatica/` and was
+not reachable via any category. Plain `.wav` files load fine via
+`adj-create-clip sampleFile=<absolute path>`, no bridge needed.
+
+## Apply when
+
+Designing search UX in `src/tools/browse/` or extending `browser_ops.browse`.
+Two implications: (1) the bridge must expose a recursive search op if cross-tree
+lookup is wanted, and (2) the bridge is for Live-managed (URI'd) content only —
+filesystem samples bypass it via `sampleFile`.

--- a/docs/findings/dev/drum-kit-uri-loads-full-rack.md
+++ b/docs/findings/dev/drum-kit-uri-loads-full-rack.md
@@ -1,0 +1,37 @@
+---
+title: drum-kit-uri-loads-full-rack
+domain: dev
+validated: 2026-05-07
+evidence: PR #119, manual session
+---
+
+## Fact
+
+Calling `Browser.load_item(item)` with a Drum Rack `.adg` URI creates a
+populated Drum Rack (samples + macros + return-chain FX) on the focused track in
+one step. Pre-inserting an empty `Drum Rack` device first is unnecessary and
+produces a second empty rack — `load_item` does not load into a focused rack, it
+spawns its own.
+
+## Evidence
+
+```
+adj-create-device path=t6 browserUri=query:Drums#FileId_15636
+  → loaded:true, deviceId=4812320176, deviceCountBefore=0, deviceCountAfter=1
+
+adj-read-device path=t6/d0 include=["*"] maxDepth=3
+  → drum-rack "808 Core Kit" with 16 pads, each pad → instrument-rack →
+    Chain → Simpler with sample (e.g., "Bass Drum 808"), plus
+    rc0/d0/c0 = Channel EQ | Saturator | Drum Buss | Limiter chain.
+```
+
+The compound path (`deviceName: "Drum Rack"` + `browserUri`) instead yields one
+empty Drum Rack from the JS insert plus a populated one from `load_item` —
+visible as `deviceCountBefore: 1` then unchanged after load.
+
+## Apply when
+
+Implementing the bridge dispatcher for `adj-create-device`, or extending
+`live_browser_bridge/BrowserBridge.py`'s `_op_load_item` for kit/preset flows.
+Drop the compound branch — pass `browserUri` alone whenever the URI points to a
+`.adg` / kit file.

--- a/docs/specs/Browser-Bridge-Spec.md
+++ b/docs/specs/Browser-Bridge-Spec.md
@@ -1,8 +1,11 @@
 # Browser Bridge — Specification
 
-> Status: DRAFT — under review. Issue [#26]. Supersedes the M4L-JS-only design
+> Status: IMPLEMENTED (Phase 1). Issue [#26]. Supersedes the M4L-JS-only design
 > sketched in the original issue, which was disproven by a runtime probe (see
 > [`docs/findings/dev/m4l-no-browser-api.md`](../findings/dev/m4l-no-browser-api.md)).
+>
+> Source: [`live_browser_bridge/`](../../live_browser_bridge/). Install with
+> `npm run install:bridge`. Phase 2 (auto prefs toggle) still deferred.
 
 ---
 

--- a/live_browser_bridge/BrowserBridge.py
+++ b/live_browser_bridge/BrowserBridge.py
@@ -1,0 +1,280 @@
+# Ableton DJ MCP - Live Browser Bridge
+# Copyright (C) 2026 Gabriel Pulga
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""ControlSurface that opens a UDP socket and dispatches browser ops on Live's
+main thread.
+
+Wire-protocol:
+
+    Request:  {"id": "...", "op": "ping|browse|load_item|shutdown", "args": {...}}
+    Reply OK: {"id": "...", "ok": true,  "result": {...}}
+    Reply NO: {"id": "...", "ok": false, "error": {"code": "...", "message": "..."}}
+
+Threading:
+    - Socket thread: blocking ``recvfrom`` loop. Validates JSON, hands off to
+      the request queue, drains the response queue and sends UDP replies.
+    - Live main thread: ``update_display`` is called by Live every 100 ms; we
+      drain the request queue there and execute browser ops, then push results
+      onto the response queue."""
+
+import json
+import os
+import socket
+import threading
+import traceback
+
+try:
+    import Live
+except ImportError:  # pragma: no cover - tests stub Live
+    Live = None
+
+try:
+    from _Framework.ControlSurface import ControlSurface
+except ImportError:  # pragma: no cover - tests stub the base class
+    class ControlSurface(object):  # type: ignore[no-redef]
+        def __init__(self, c_instance):
+            self._c_instance = c_instance
+
+        def application(self):
+            raise NotImplementedError
+
+        def log_message(self, message):  # noqa: D401
+            print(message)
+
+        def disconnect(self):
+            pass
+
+        def update_display(self):
+            pass
+
+from . import browser_ops
+from .queue_runner import BridgeQueues
+from .version import BRIDGE_VERSION, DEFAULT_PORT
+
+
+SOCKET_RECV_BUF = 65535
+MAX_REQUESTS_PER_TICK = 8
+
+
+class BrowserBridge(ControlSurface):
+    """Live remote-script entry point. One instance per Live session."""
+
+    def __init__(self, c_instance):
+        ControlSurface.__init__(self, c_instance)
+        self._queues = BridgeQueues()
+        self._socket = None
+        self._addr_by_id = {}
+        self._socket_thread = None
+        self._stop_event = threading.Event()
+        self._port = self._resolve_port()
+        self._start_socket()
+        self._log("Ableton DJ MCP browser bridge %s listening on udp:%d" %
+                  (BRIDGE_VERSION, self._port))
+
+    # ------------------------------------------------------------------ setup
+
+    def _resolve_port(self):
+        env = os.environ.get("ADJ_BRIDGE_PORT")
+        if env:
+            try:
+                return int(env)
+            except ValueError:
+                self._log("ignoring invalid ADJ_BRIDGE_PORT=%r" % env)
+        return DEFAULT_PORT
+
+    def _start_socket(self):
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(("127.0.0.1", self._port))
+            sock.settimeout(0.25)
+            self._socket = sock
+        except Exception as exc:
+            self._log("failed to bind udp:%d (%s); bridge inactive" %
+                      (self._port, exc))
+            self._socket = None
+            return
+
+        self._socket_thread = threading.Thread(
+            target=self._socket_loop, name="adj-browser-bridge"
+        )
+        self._socket_thread.daemon = True
+        self._socket_thread.start()
+
+    # --------------------------------------------------------- socket thread
+
+    def _socket_loop(self):
+        sock = self._socket
+        while not self._stop_event.is_set():
+            self._drain_responses_to_socket()
+            try:
+                data, addr = sock.recvfrom(SOCKET_RECV_BUF)
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            try:
+                message = json.loads(data.decode("utf-8"))
+            except Exception as exc:
+                self._send(addr, self._error(None, "INVALID_ARGS",
+                           "could not parse request: %s" % exc))
+                continue
+            req_id = message.get("id")
+            op = message.get("op")
+            if not req_id or not op:
+                self._send(addr, self._error(req_id, "INVALID_ARGS",
+                           "request missing id or op"))
+                continue
+            self._addr_by_id[req_id] = addr
+            self._queues.submit_request(message)
+
+    def _drain_responses_to_socket(self):
+        for response in self._queues.drain_responses():
+            req_id = response.get("id")
+            addr = self._addr_by_id.pop(req_id, None) if req_id else None
+            if addr is None:
+                continue
+            self._send(addr, response)
+
+    def _send(self, addr, payload):
+        if self._socket is None:
+            return
+        try:
+            self._socket.sendto(json.dumps(payload).encode("utf-8"), addr)
+        except Exception as exc:
+            self._log("udp send failed: %s" % exc)
+
+    # ----------------------------------------------------------- main thread
+
+    def update_display(self):
+        # Called by Live ~10 Hz. Process pending bridge requests here so all
+        # LOM access happens on the main thread.
+        try:
+            requests = self._queues.drain_requests(max_items=MAX_REQUESTS_PER_TICK)
+            for message in requests:
+                response = self._handle_request(message)
+                self._queues.submit_response(response)
+        except Exception:
+            # Never let a bridge failure crash Live's display tick.
+            self._log("bridge tick error:\n%s" % traceback.format_exc())
+
+    def _handle_request(self, message):
+        req_id = message.get("id")
+        op = message.get("op")
+        args = message.get("args") or {}
+        try:
+            if op == "ping":
+                return self._ok(req_id, self._op_ping())
+            if op == "browse":
+                return self._ok(req_id, self._op_browse(args))
+            if op == "load_item":
+                return self._ok(req_id, self._op_load_item(args))
+            if op == "shutdown":
+                # Best-effort; Live restart is the canonical way to stop us.
+                return self._ok(req_id, {"acknowledged": True})
+            return self._error(req_id, "INVALID_ARGS", "unknown op: %s" % op)
+        except browser_ops.BrowserOpError as exc:
+            return self._error(req_id, "BROWSER_API_FAILED", str(exc))
+        except Exception as exc:
+            return self._error(
+                req_id,
+                "MAIN_THREAD_ERROR",
+                "%s: %s" % (exc.__class__.__name__, exc),
+            )
+
+    # ----------------------------------------------------------- ops impl
+
+    def _browser(self):
+        app = self.application()
+        browser = getattr(app, "browser", None)
+        if browser is None:
+            raise browser_ops.BrowserOpError("Application.browser unavailable")
+        return browser
+
+    def _op_ping(self):
+        live_version = "unknown"
+        try:
+            app = self.application()
+            live_version = "%d.%d.%d" % (
+                app.get_major_version(),
+                app.get_minor_version(),
+                app.get_bugfix_version(),
+            )
+        except Exception:
+            pass
+        return {"version": BRIDGE_VERSION, "liveVersion": live_version}
+
+    def _op_browse(self, args):
+        return browser_ops.browse(
+            self._browser(),
+            category=args.get("category"),
+            path=args.get("path"),
+            search=args.get("search"),
+            depth=int(args.get("depth", 1)),
+            limit=int(args.get("limit", 100)),
+        )
+
+    def _op_load_item(self, args):
+        uri = args.get("uri")
+        if not uri:
+            raise browser_ops.BrowserOpError("uri is required for load_item")
+
+        browser = self._browser()
+        item = browser_ops.find_by_uri(browser, uri, category=args.get("category"))
+        if item is None:
+            raise browser_ops.BrowserOpError("uri not found in browser tree: %s" % uri)
+        if not getattr(item, "is_loadable", False):
+            raise browser_ops.BrowserOpError("item is not loadable: %s" % uri)
+
+        # Capture pre-load device set on the focused track so we can report
+        # the new device id after load.
+        before_ids = self._focused_track_device_ids()
+        browser.load_item(item)
+        after_ids = self._focused_track_device_ids()
+        new_ids = [d for d in after_ids if d not in before_ids]
+        return {
+            "loaded": True,
+            "deviceId": new_ids[0] if new_ids else None,
+            "deviceCountBefore": len(before_ids),
+            "deviceCountAfter": len(after_ids),
+        }
+
+    def _focused_track_device_ids(self):
+        try:
+            song = self.application().get_document()
+            track = song.view.selected_track
+            return [str(d._live_ptr) if hasattr(d, "_live_ptr") else id(d)
+                    for d in track.devices]
+        except Exception:
+            return []
+
+    # ----------------------------------------------------------- responses
+
+    def _ok(self, req_id, result):
+        return {"id": req_id, "ok": True, "result": result}
+
+    def _error(self, req_id, code, message):
+        return {"id": req_id, "ok": False,
+                "error": {"code": code, "message": message}}
+
+    def _log(self, message):
+        try:
+            self.log_message("[adj-bridge] %s" % message)
+        except Exception:  # pragma: no cover - log_message itself failing
+            print("[adj-bridge] %s" % message)
+
+    # ----------------------------------------------------------- shutdown
+
+    def disconnect(self):
+        self._stop_event.set()
+        if self._socket is not None:
+            try:
+                self._socket.close()
+            except Exception:
+                pass
+            self._socket = None
+        try:
+            ControlSurface.disconnect(self)
+        except Exception:
+            pass

--- a/live_browser_bridge/LICENSE
+++ b/live_browser_bridge/LICENSE
@@ -1,0 +1,4 @@
+This directory ships under the same license as the parent project,
+GPL-3.0-or-later. The full license text is in the repo root LICENSE file.
+
+Copyright (C) 2026 Gabriel Pulga

--- a/live_browser_bridge/README.md
+++ b/live_browser_bridge/README.md
@@ -1,0 +1,49 @@
+# Ableton DJ MCP — Browser Bridge
+
+Live remote-control script that exposes `Application.Browser` over a local UDP
+socket. The Node-side MCP server forwards browser navigation and URI-based
+device loads here; nothing else in the package needs the bridge.
+
+License: GPL-3.0-or-later (matches the parent project).
+
+## Why it exists
+
+`Application.Browser` is exposed to Python remote scripts but deliberately
+filtered out of Live's Max-for-Live JavaScript bindings. See
+`docs/findings/dev/m4l-no-browser-api.md` and
+`docs/specs/Browser-Bridge-Spec.md` in the parent repo for the full rationale.
+
+## Install
+
+From the parent repo:
+
+```
+npm run install:bridge
+```
+
+That copies this directory to:
+
+- macOS: `~/Music/Ableton/User Library/Remote Scripts/AbletonDjMcp/`
+- Windows:
+  `%USERPROFILE%\Documents\Ableton\User Library\Remote Scripts\AbletonDjMcp\`
+
+After installing, restart Live and enable the surface in **Preferences →
+Link/Tempo/MIDI → Control Surface → AbletonDjMcp**.
+
+## Protocol
+
+UDP on `127.0.0.1:11077` (override with the `ADJ_BRIDGE_PORT` env var). One JSON
+datagram per request and reply. See the parent repo spec for the full schema.
+
+## Layout
+
+| File               | Purpose                                                |
+| ------------------ | ------------------------------------------------------ |
+| `__init__.py`      | Live entry point; returns the `BrowserBridge` instance |
+| `BrowserBridge.py` | ControlSurface subclass, owns the UDP loop             |
+| `browser_ops.py`   | Pure tree walking / serialisation helpers              |
+| `queue_runner.py`  | Thread-safe queues bridging socket and main thread     |
+| `version.py`       | Version + default port constants                       |
+
+`browser_ops.py` is import-clean (no Live import) so it can be unit-tested with
+a stubbed browser module.

--- a/live_browser_bridge/__init__.py
+++ b/live_browser_bridge/__init__.py
@@ -1,0 +1,11 @@
+# Ableton DJ MCP - Live Browser Bridge
+# Copyright (C) 2026 Gabriel Pulga
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Live's remote-script loader imports this package and calls
+# create_instance(c_instance) to obtain the ControlSurface.
+from .BrowserBridge import BrowserBridge
+
+
+def create_instance(c_instance):
+    return BrowserBridge(c_instance)

--- a/live_browser_bridge/browser_ops.py
+++ b/live_browser_bridge/browser_ops.py
@@ -1,0 +1,194 @@
+# Ableton DJ MCP - Live Browser Bridge
+# Copyright (C) 2026 Gabriel Pulga
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Pure helpers for browsing Live's Application.Browser tree.
+
+Functions here take a `browser` object and operate on it. They never touch
+sockets or queues, which makes them easy to unit-test with a stubbed Live
+module.
+
+The functions tolerate Live's mix of attribute/iterator-style children
+(``BrowserItem.children`` is a sequence in modern versions; older versions
+exposed ``iter_children``)."""
+
+CATEGORY_ATTRS = (
+    "instruments",
+    "audio_effects",
+    "midi_effects",
+    "drums",
+    "sounds",
+    "samples",
+    "clips",
+    "current_project",
+    "user_library",
+    "user_folders",
+    "packs",
+    "plugins",
+    "max_for_live",
+)
+
+
+class BrowserOpError(Exception):
+    """Raised by ops when the Live browser API behaves unexpectedly."""
+
+
+def list_categories(browser):
+    """Return the names of category roots present on this browser instance.
+
+    Different Live versions expose different roots; we probe for each known
+    attribute and skip any that are missing or None."""
+    out = []
+    for attr in CATEGORY_ATTRS:
+        if hasattr(browser, attr) and getattr(browser, attr) is not None:
+            out.append(attr)
+    return out
+
+
+def get_category_root(browser, category):
+    """Return the BrowserItem root for ``category`` or raise BrowserOpError."""
+    if category not in CATEGORY_ATTRS:
+        raise BrowserOpError("unknown category: %s" % category)
+    root = getattr(browser, category, None)
+    if root is None:
+        raise BrowserOpError("category not available: %s" % category)
+    return root
+
+
+def children_of(item):
+    """Return a list of children for a BrowserItem, abstracting over Live versions."""
+    children = getattr(item, "children", None)
+    if children is None:
+        children = getattr(item, "iter_children", None)
+        if callable(children):
+            children = list(children())
+        else:
+            children = []
+    # children may be a Live "vector" — coerce to plain list
+    return list(children)
+
+
+def serialize_item(item, depth=0, max_depth=1, include_children=True):
+    """Convert a BrowserItem to a JSON-safe dict.
+
+    ``depth=0, max_depth=1`` returns the item plus one level of children.
+    Pass ``max_depth=0`` to get a leaf-only dict (no children traversal)."""
+    out = {
+        "name": getattr(item, "name", "") or "",
+        "uri": getattr(item, "uri", "") or "",
+        "isFolder": bool(getattr(item, "is_folder", False)),
+        "isDevice": bool(getattr(item, "is_device", False)),
+        "isLoadable": bool(getattr(item, "is_loadable", False)),
+    }
+    if include_children and depth < max_depth:
+        kids = []
+        for child in children_of(item):
+            kids.append(
+                serialize_item(
+                    child,
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                    include_children=True,
+                )
+            )
+        out["children"] = kids
+    return out
+
+
+def walk_path(root, path):
+    """Walk a slash-separated path of BrowserItem names down from ``root``.
+
+    Empty/None path returns the root unchanged. Raises BrowserOpError on
+    a missing segment, with the partial path that resolved."""
+    if not path:
+        return root
+    segments = [s for s in path.split("/") if s]
+    current = root
+    walked = []
+    for seg in segments:
+        match = None
+        for child in children_of(current):
+            if getattr(child, "name", "") == seg:
+                match = child
+                break
+        if match is None:
+            raise BrowserOpError(
+                "path segment not found: %s (resolved: %s)" % (seg, "/".join(walked))
+            )
+        walked.append(seg)
+        current = match
+    return current
+
+
+def browse(browser, category=None, path=None, search=None, depth=1, limit=100):
+    """Return a serialized listing of the browser tree.
+
+    - No ``category``: list category names.
+    - With ``category``, no ``path``: list category root's direct children.
+    - With ``category`` + ``path``: walk to that subnode and list its children.
+    - With ``search``: case-insensitive substring filter applied AFTER children
+      enumeration. depth>1 supported to expand sub-folders inline.
+    - ``limit`` truncates the top-level item list. Truncation is reported via
+      the ``truncated`` flag on the result."""
+    if category is None:
+        return {
+            "categories": list_categories(browser),
+            "items": [],
+        }
+
+    root = get_category_root(browser, category)
+    target = walk_path(root, path)
+    raw_items = children_of(target)
+
+    if search:
+        needle = search.lower()
+        raw_items = [it for it in raw_items if needle in (getattr(it, "name", "") or "").lower()]
+
+    truncated = False
+    if limit is not None and len(raw_items) > limit:
+        raw_items = raw_items[:limit]
+        truncated = True
+
+    items = [
+        serialize_item(it, depth=0, max_depth=max(depth - 1, 0), include_children=depth > 1)
+        for it in raw_items
+    ]
+
+    return {
+        "category": category,
+        "path": path or "",
+        "items": items,
+        "truncated": truncated,
+    }
+
+
+def find_by_uri(browser, uri, category=None):
+    """Depth-first search for the first BrowserItem whose ``uri`` matches.
+
+    Searches all categories when ``category`` is None; restricts to that
+    category root otherwise. Returns the matching item or None."""
+    if not uri:
+        return None
+    roots = (
+        [get_category_root(browser, category)]
+        if category is not None
+        else [
+            getattr(browser, attr)
+            for attr in CATEGORY_ATTRS
+            if hasattr(browser, attr) and getattr(browser, attr) is not None
+        ]
+    )
+
+    seen = 0
+    stack = list(roots)
+    # Cap the walk so a malformed URI can't spin Live for ages. Live's full
+    # browser is large but a few thousand items is enough headroom.
+    MAX_NODES = 50_000
+    while stack and seen < MAX_NODES:
+        item = stack.pop()
+        seen += 1
+        if getattr(item, "uri", None) == uri:
+            return item
+        for child in children_of(item):
+            stack.append(child)
+    return None

--- a/live_browser_bridge/queue_runner.py
+++ b/live_browser_bridge/queue_runner.py
@@ -1,0 +1,52 @@
+# Ableton DJ MCP - Live Browser Bridge
+# Copyright (C) 2026 Gabriel Pulga
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Thread-safe request/response queues used to bridge the UDP socket thread
+and Live's main thread.
+
+Direct LOM access from a non-main thread crashes Live, so the socket thread
+must hand work to the main thread and vice versa. Both queues are unbounded;
+in practice request rate is low (interactive tool calls)."""
+
+try:
+    # Python 3 (Live 11+)
+    from queue import Queue, Empty
+except ImportError:  # pragma: no cover - kept for older runtimes
+    from Queue import Queue, Empty  # type: ignore[no-redef]
+
+
+class BridgeQueues(object):
+    """Pair of queues: requests go socket->main, responses go main->socket."""
+
+    def __init__(self):
+        self.requests = Queue()
+        self.responses = Queue()
+
+    def submit_request(self, message):
+        """Called from the socket thread. message is a dict with id/op/args."""
+        self.requests.put(message)
+
+    def drain_requests(self, max_items=16):
+        """Called from the main thread. Returns a list of pending requests."""
+        out = []
+        for _ in range(max_items):
+            try:
+                out.append(self.requests.get_nowait())
+            except Empty:
+                break
+        return out
+
+    def submit_response(self, message):
+        """Called from the main thread."""
+        self.responses.put(message)
+
+    def drain_responses(self, max_items=64):
+        """Called from the socket thread. Returns a list of pending responses."""
+        out = []
+        for _ in range(max_items):
+            try:
+                out.append(self.responses.get_nowait())
+            except Empty:
+                break
+        return out

--- a/live_browser_bridge/tests/test_browser_ops.py
+++ b/live_browser_bridge/tests/test_browser_ops.py
@@ -1,0 +1,159 @@
+# Ableton DJ MCP - Live Browser Bridge tests
+# Copyright (C) 2026 Gabriel Pulga
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Unit tests for browser_ops. The Live module is not imported here; we use a
+plain Python object graph that mirrors the BrowserItem shape (name, uri,
+is_folder, is_device, is_loadable, children)."""
+
+import os
+import sys
+import unittest
+
+# Make the package importable when running pytest from the repo root.
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.abspath(os.path.join(HERE, os.pardir, os.pardir))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from live_browser_bridge import browser_ops  # type: ignore  # noqa: E402
+
+
+class FakeItem(object):
+    def __init__(self, name="", uri="", is_folder=False, is_device=False,
+                 is_loadable=False, children=()):
+        self.name = name
+        self.uri = uri
+        self.is_folder = is_folder
+        self.is_device = is_device
+        self.is_loadable = is_loadable
+        self.children = list(children)
+
+
+class FakeBrowser(object):
+    def __init__(self, **roots):
+        for attr in browser_ops.CATEGORY_ATTRS:
+            setattr(self, attr, roots.get(attr))
+
+
+def _build_browser():
+    operator = FakeItem(name="Operator", uri="query:Synths#Operator",
+                        is_device=True, is_loadable=True)
+    bass_kit = FakeItem(name="808 Kit", uri="query:Drums#808",
+                        is_device=False, is_loadable=True)
+    synth_folder = FakeItem(name="Synths", is_folder=True, children=[operator])
+    instruments = FakeItem(name="Instruments", is_folder=True, children=[synth_folder])
+    drums = FakeItem(name="Drums", is_folder=True, children=[bass_kit])
+    return FakeBrowser(instruments=instruments, drums=drums)
+
+
+class ListCategoriesTest(unittest.TestCase):
+    def test_lists_only_present_roots(self):
+        browser = _build_browser()
+        cats = browser_ops.list_categories(browser)
+        self.assertIn("instruments", cats)
+        self.assertIn("drums", cats)
+        self.assertNotIn("clips", cats)
+
+
+class WalkPathTest(unittest.TestCase):
+    def test_empty_path_returns_root(self):
+        browser = _build_browser()
+        root = browser_ops.get_category_root(browser, "instruments")
+        self.assertIs(browser_ops.walk_path(root, ""), root)
+
+    def test_single_segment(self):
+        root = browser_ops.get_category_root(_build_browser(), "instruments")
+        node = browser_ops.walk_path(root, "Synths")
+        self.assertEqual(node.name, "Synths")
+
+    def test_multi_segment(self):
+        root = browser_ops.get_category_root(_build_browser(), "instruments")
+        node = browser_ops.walk_path(root, "Synths/Operator")
+        self.assertEqual(node.uri, "query:Synths#Operator")
+
+    def test_missing_segment_raises(self):
+        root = browser_ops.get_category_root(_build_browser(), "instruments")
+        with self.assertRaises(browser_ops.BrowserOpError):
+            browser_ops.walk_path(root, "Synths/Nope")
+
+
+class BrowseTest(unittest.TestCase):
+    def test_no_category_lists_categories(self):
+        result = browser_ops.browse(_build_browser())
+        self.assertIn("instruments", result["categories"])
+        self.assertEqual(result["items"], [])
+
+    def test_with_category_lists_root_children(self):
+        result = browser_ops.browse(_build_browser(), category="instruments")
+        names = [it["name"] for it in result["items"]]
+        self.assertEqual(names, ["Synths"])
+        self.assertFalse(result["truncated"])
+
+    def test_with_path_walks(self):
+        result = browser_ops.browse(_build_browser(), category="instruments",
+                                    path="Synths")
+        names = [it["name"] for it in result["items"]]
+        self.assertEqual(names, ["Operator"])
+
+    def test_search_filters(self):
+        result = browser_ops.browse(_build_browser(), category="drums",
+                                    search="808")
+        names = [it["name"] for it in result["items"]]
+        self.assertEqual(names, ["808 Kit"])
+
+    def test_search_negative(self):
+        result = browser_ops.browse(_build_browser(), category="drums",
+                                    search="bigband")
+        self.assertEqual(result["items"], [])
+
+    def test_limit_truncates(self):
+        children = [FakeItem(name="Item%d" % i) for i in range(5)]
+        big_root = FakeItem(name="Big", is_folder=True, children=children)
+        browser = FakeBrowser(instruments=big_root)
+        result = browser_ops.browse(browser, category="instruments", limit=3)
+        self.assertEqual(len(result["items"]), 3)
+        self.assertTrue(result["truncated"])
+
+    def test_depth_recurses(self):
+        result = browser_ops.browse(_build_browser(), category="instruments",
+                                    depth=2)
+        self.assertEqual(result["items"][0]["name"], "Synths")
+        self.assertEqual(result["items"][0]["children"][0]["name"], "Operator")
+
+
+class FindByUriTest(unittest.TestCase):
+    def test_finds_in_category(self):
+        browser = _build_browser()
+        item = browser_ops.find_by_uri(browser, "query:Synths#Operator")
+        self.assertIsNotNone(item)
+        self.assertEqual(item.uri, "query:Synths#Operator")
+
+    def test_finds_in_other_category(self):
+        browser = _build_browser()
+        item = browser_ops.find_by_uri(browser, "query:Drums#808")
+        self.assertIsNotNone(item)
+
+    def test_returns_none_when_missing(self):
+        browser = _build_browser()
+        self.assertIsNone(browser_ops.find_by_uri(browser, "query:Nope"))
+
+    def test_empty_uri_returns_none(self):
+        self.assertIsNone(browser_ops.find_by_uri(_build_browser(), ""))
+
+
+class SerializeItemTest(unittest.TestCase):
+    def test_leaf_no_children_when_max_depth_zero(self):
+        item = FakeItem(name="x", uri="u", is_loadable=True,
+                        children=[FakeItem(name="kid")])
+        out = browser_ops.serialize_item(item, max_depth=0, include_children=False)
+        self.assertNotIn("children", out)
+
+    def test_includes_children_at_depth(self):
+        item = FakeItem(name="x", children=[FakeItem(name="kid")])
+        out = browser_ops.serialize_item(item, max_depth=1)
+        self.assertEqual(len(out["children"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/live_browser_bridge/version.py
+++ b/live_browser_bridge/version.py
@@ -1,0 +1,10 @@
+# Ableton DJ MCP - Live Browser Bridge
+# Copyright (C) 2026 Gabriel Pulga
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Bridge protocol/package version. Bump on protocol changes.
+# Read by ping op so the Node side can warn on mismatch.
+BRIDGE_VERSION = "0.1.0"
+
+# Default UDP port. Configurable via env var ADJ_BRIDGE_PORT (read at boot).
+DEFAULT_PORT = 11077

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "loc": "node scripts/loc/loc.ts",
     "init:workspace": "node scripts/init-workspace.ts",
     "install:device": "node scripts/install-device.ts",
+    "install:bridge": "node scripts/install-bridge.ts",
     "start:live": "node scripts/start-live.ts",
     "tc": "npm run typecheck",
     "typecheck": "echo 'Typechecking...' && node scripts/run-parallel.ts typecheck:src typecheck:scripts typecheck:e2e && echo 'No typecheck violations.\n'",

--- a/scripts/install-bridge.ts
+++ b/scripts/install-bridge.ts
@@ -1,0 +1,120 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Installs the Live Browser Bridge Python remote script into Ableton's
+// per-user Remote Scripts directory.
+//
+//   Source: live_browser_bridge/   (repo root, ships verbatim)
+//   Dest:   <Live User Library>/Remote Scripts/AbletonDjMcp/
+//
+// Live discovers the surface by directory name; the dest dir name is the
+// label that appears in Preferences → Link/Tempo/MIDI → Control Surface.
+// The remote-script entry point is __init__.py exposing create_instance.
+
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { platform } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveRemoteScriptsDir } from "./shared/user-library-path.ts";
+
+const SURFACE_DIR_NAME = "AbletonDjMcp";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..");
+const sourceDir = join(repoRoot, "live_browser_bridge");
+
+if (!existsSync(sourceDir)) {
+  console.error(`install-bridge failed: missing source dir ${sourceDir}`);
+  process.exit(1);
+}
+
+const targetRoot = resolveRemoteScriptsDir();
+
+if (targetRoot === null) {
+  console.error(
+    `install-bridge: unsupported platform '${platform()}'. ` +
+      "Ableton Live runs on macOS or Windows only.",
+  );
+  process.exit(1);
+}
+
+const targetDir = join(targetRoot, SURFACE_DIR_NAME);
+
+if (!existsSync(targetRoot)) {
+  mkdirSync(targetRoot, { recursive: true });
+}
+
+if (existsSync(targetDir)) {
+  // Wipe a stale install so removed files don't linger. Only deletes inside
+  // our own surface dir, never the parent Remote Scripts dir.
+  rmSync(targetDir, { recursive: true, force: true });
+}
+
+mkdirSync(targetDir, { recursive: true });
+
+copyTree(sourceDir, targetDir, [
+  "tests", // unit tests don't belong inside Live's load path
+  "__pycache__",
+]);
+
+console.log("");
+console.log(`Installed bridge to: ${targetDir}`);
+console.log("");
+console.log("Next steps:");
+console.log("  1. Quit Ableton Live if it is running.");
+console.log("  2. Start Live (`npm run start:live` or open it manually).");
+console.log("  3. Live → Preferences → Link/Tempo/MIDI →");
+console.log("     pick 'AbletonDjMcp' under Control Surface.");
+console.log("");
+console.log(
+  "After enabling, the bridge listens on udp:11077 (override with " +
+    "ADJ_BRIDGE_PORT). adj-browse and adj-create-device --browserUri are " +
+    "then available.",
+);
+
+interface CopyOptions {
+  excludedSegments: Set<string>;
+}
+
+/**
+ * Recursively copy a directory tree.
+ * @param fromDir - Source directory
+ * @param toDir - Destination directory (must already exist)
+ * @param excluded - Directory or file names to skip at any depth
+ */
+function copyTree(fromDir: string, toDir: string, excluded: string[]): void {
+  const opts: CopyOptions = { excludedSegments: new Set(excluded) };
+
+  copyTreeImpl(fromDir, toDir, opts);
+}
+
+/**
+ * Internal recursive worker for copyTree.
+ * @param fromDir - Source directory
+ * @param toDir - Destination directory (must exist)
+ * @param opts - Excluded segment set, computed once by copyTree
+ */
+function copyTreeImpl(fromDir: string, toDir: string, opts: CopyOptions): void {
+  for (const entry of readdirSync(fromDir)) {
+    if (opts.excludedSegments.has(entry)) continue;
+    const sourcePath = join(fromDir, entry);
+    const targetPath = join(toDir, entry);
+    const info = statSync(sourcePath);
+
+    if (info.isDirectory()) {
+      mkdirSync(targetPath, { recursive: true });
+      copyTreeImpl(sourcePath, targetPath, opts);
+    } else if (info.isFile()) {
+      copyFileSync(sourcePath, targetPath);
+      console.log(`  copied ${entry}`);
+    }
+  }
+}

--- a/scripts/shared/user-library-path.ts
+++ b/scripts/shared/user-library-path.ts
@@ -2,12 +2,30 @@
 // Copyright (C) 2026 Gabriel Pulga
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// Shared resolver for the Live User Library Max MIDI Effect dir. Used by
-// scripts/install-device.ts and scripts/dev-hot.ts so both target the same
-// path on every platform.
+// Shared resolvers for Live User Library subdirectories. Used by
+// scripts/install-device.ts, scripts/dev-hot.ts, and scripts/install-bridge.ts
+// so they all target the same paths on every platform.
 
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
+
+/**
+ * Resolve the platform-specific root of Live's per-user library, or null on
+ * unsupported platforms (Live runs on macOS/Windows only).
+ * @returns Absolute path or null
+ */
+export function resolveUserLibraryRoot(): string | null {
+  const home = homedir();
+
+  switch (platform()) {
+    case "darwin":
+      return join(home, "Music", "Ableton", "User Library");
+    case "win32":
+      return join(home, "Documents", "Ableton", "User Library");
+    default:
+      return null;
+  }
+}
 
 /**
  * Resolve Live's per-user Max MIDI Effect preset directory for the current
@@ -15,30 +33,21 @@ import { join } from "node:path";
  * @returns Absolute path on macOS/Windows, null on unsupported platforms
  */
 export function resolveUserLibraryDir(): string | null {
-  const home = homedir();
+  const root = resolveUserLibraryRoot();
 
-  switch (platform()) {
-    case "darwin":
-      return join(
-        home,
-        "Music",
-        "Ableton",
-        "User Library",
-        "Presets",
-        "MIDI Effects",
-        "Max MIDI Effect",
-      );
-    case "win32":
-      return join(
-        home,
-        "Documents",
-        "Ableton",
-        "User Library",
-        "Presets",
-        "MIDI Effects",
-        "Max MIDI Effect",
-      );
-    default:
-      return null;
-  }
+  return root === null
+    ? null
+    : join(root, "Presets", "MIDI Effects", "Max MIDI Effect");
+}
+
+/**
+ * Resolve the Remote Scripts directory inside Live's per-user library. This
+ * is where Live looks for Python control surface scripts (the browser
+ * bridge ships into here).
+ * @returns Absolute path or null on unsupported platforms
+ */
+export function resolveRemoteScriptsDir(): string | null {
+  const root = resolveUserLibraryRoot();
+
+  return root === null ? null : join(root, "Remote Scripts");
 }

--- a/src/mcp-server/bridge-dispatcher.ts
+++ b/src/mcp-server/bridge-dispatcher.ts
@@ -1,0 +1,150 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Dispatcher wrapper that intercepts browser-aware tool calls and forwards
+// them to the Python sidecar over UDP. Other tool calls pass straight through
+// to the existing v8 LiveAPI dispatcher.
+
+import { formatErrorResponse } from "#src/shared/mcp-response-utils.ts";
+import {
+  BridgeCallError,
+  type BrowserBridgeClient,
+} from "./browser-bridge-client.ts";
+import { type CallLiveApiFunction } from "./create-mcp-server.ts";
+import { type McpResponse } from "./max-api-adapter.ts";
+
+interface BrowseToolArgs {
+  category?: string;
+  path?: string;
+  search?: string;
+  depth?: number;
+  limit?: number;
+}
+
+interface CreateDeviceArgs {
+  deviceName?: string;
+  path?: string;
+  name?: string;
+  browserUri?: string;
+  focus?: boolean;
+}
+
+const INSTALL_HINT =
+  "Bridge unavailable. Run `npm run install:bridge`, then restart Live and " +
+  "enable AbletonDjMcp under Preferences → Link/Tempo/MIDI → Control Surface.";
+
+/**
+ * Wrap the v8 dispatcher with bridge-aware handling for browser tools.
+ *
+ * @param next - Underlying call (forwards to Max v8 over Max API)
+ * @param bridge - Browser bridge client (lazy: ping is deferred until use)
+ * @returns Wrapped dispatcher with the same callable signature
+ */
+export function makeBridgeDispatcher(
+  next: CallLiveApiFunction,
+  bridge: BrowserBridgeClient,
+): CallLiveApiFunction {
+  return async (tool: string, args: object): Promise<object> => {
+    if (tool === "adj-browse") {
+      return await handleBrowse(bridge, args);
+    }
+
+    if (tool === "adj-create-device") {
+      const cdArgs = args as CreateDeviceArgs;
+
+      if (cdArgs.browserUri) {
+        return await handleCreateDeviceBrowserUri(bridge, next, cdArgs);
+      }
+    }
+
+    return await next(tool, args);
+  };
+}
+
+async function handleBrowse(
+  bridge: BrowserBridgeClient,
+  args: BrowseToolArgs,
+): Promise<McpResponse> {
+  if (!(await bridge.ensureAlive())) {
+    return formatErrorResponse(INSTALL_HINT);
+  }
+
+  try {
+    const result = await bridge.browse(args);
+
+    return successPayload(result);
+  } catch (err) {
+    return formatErrorResponse(formatBridgeError("browse", err));
+  }
+}
+
+async function handleCreateDeviceBrowserUri(
+  bridge: BrowserBridgeClient,
+  next: CallLiveApiFunction,
+  args: CreateDeviceArgs,
+): Promise<McpResponse> {
+  if (!args.path) {
+    return formatErrorResponse(
+      "createDevice failed: path is required when using browserUri",
+    );
+  }
+
+  if (!(await bridge.ensureAlive())) {
+    return formatErrorResponse(INSTALL_HINT);
+  }
+
+  // Pre-select the target track/chain via the v8 layer so the bridge's
+  // load_item lands in the right place. selected_track is the only handle the
+  // browser API accepts for routing the load.
+  const selectArgs: Record<string, unknown> = {
+    path: args.path,
+    detailView: "device",
+  };
+  const selectResult = (await next("adj-select", selectArgs)) as McpResponse;
+
+  if (selectResult.isError) return selectResult;
+
+  // Drum-kit compound: caller passed deviceName=Drum Rack + browserUri. Insert
+  // the rack first, then load the kit into the now-focused rack.
+  if (args.deviceName) {
+    const insertArgs: Record<string, unknown> = {
+      deviceName: args.deviceName,
+      path: args.path,
+    };
+
+    if (args.name != null) insertArgs.name = args.name;
+    const insertResult = (await next(
+      "adj-create-device",
+      insertArgs,
+    )) as McpResponse;
+
+    if (insertResult.isError) return insertResult;
+  }
+
+  try {
+    const result = await bridge.loadItem({ uri: args.browserUri ?? "" });
+
+    return successPayload(result);
+  } catch (err) {
+    return formatErrorResponse(formatBridgeError("load_item", err));
+  }
+}
+
+function successPayload(value: unknown): McpResponse {
+  return {
+    content: [{ type: "text", text: JSON.stringify(value) }],
+  };
+}
+
+function formatBridgeError(op: string, err: unknown): string {
+  if (err instanceof BridgeCallError) {
+    return `Bridge ${op} failed [${err.code}]: ${err.message}`;
+  }
+
+  if (err instanceof Error) {
+    return `Bridge ${op} failed: ${err.message}`;
+  }
+
+  return `Bridge ${op} failed: ${String(err)}`;
+}

--- a/src/mcp-server/browser-bridge-client.ts
+++ b/src/mcp-server/browser-bridge-client.ts
@@ -1,0 +1,359 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// UDP client for the Live Browser Bridge Python remote script.
+// Lives on the Node-for-Max side (browser API is unreachable from Max v8 JS,
+// so all browser tool calls forward through here over localhost UDP).
+
+import { randomUUID } from "node:crypto";
+import { type RemoteInfo, type Socket, createSocket } from "node:dgram";
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 11_077;
+const DEFAULT_BROWSE_TIMEOUT_MS = 10_000;
+const DEFAULT_LOAD_TIMEOUT_MS = 30_000;
+const DEFAULT_PING_TIMEOUT_MS = 1_500;
+// How long a successful ping is treated as "bridge up". Avoids round-tripping
+// a ping before every browse.
+const PING_FRESHNESS_MS = 30_000;
+const CLIENT_CLOSED_MESSAGE = "client closed";
+
+export type BridgeErrorCode =
+  | "BRIDGE_NOT_FOUND"
+  | "MAIN_THREAD_ERROR"
+  | "BROWSER_API_FAILED"
+  | "INVALID_ARGS"
+  | "TIMEOUT_INTERNAL";
+
+export interface BridgeError {
+  code: BridgeErrorCode;
+  message: string;
+}
+
+interface BridgeReplyOk<T> {
+  id: string;
+  ok: true;
+  result: T;
+}
+
+interface BridgeReplyErr {
+  id: string;
+  ok: false;
+  error: BridgeError;
+}
+
+type BridgeReply<T> = BridgeReplyOk<T> | BridgeReplyErr;
+
+interface BridgeRequest {
+  id: string;
+  op: "ping" | "browse" | "load_item" | "shutdown";
+  args: Record<string, unknown>;
+}
+
+interface PendingCall<T> {
+  resolve: (reply: BridgeReply<T>) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export interface BrowserBridgeClientOptions {
+  host?: string;
+  port?: number;
+  /** Inject a socket factory for tests; defaults to node:dgram createSocket. */
+  socketFactory?: () => Socket;
+}
+
+export interface PingResult {
+  version: string;
+  liveVersion: string;
+}
+
+export interface BrowseArgs {
+  category?: string;
+  path?: string;
+  search?: string;
+  depth?: number;
+  limit?: number;
+}
+
+export interface BrowseItem {
+  name: string;
+  uri: string;
+  isFolder: boolean;
+  isDevice: boolean;
+  isLoadable: boolean;
+  children?: BrowseItem[];
+}
+
+export interface BrowseResult {
+  category?: string;
+  categories?: string[];
+  path?: string;
+  items: BrowseItem[];
+  truncated?: boolean;
+}
+
+export interface LoadItemArgs {
+  uri: string;
+  category?: string;
+}
+
+export interface LoadItemResult {
+  loaded: boolean;
+  deviceId: string | null;
+  deviceCountBefore: number;
+  deviceCountAfter: number;
+}
+
+/**
+ * Client for the Python browser bridge. One instance per process; methods are
+ * safe to call concurrently (each request gets its own UUID).
+ */
+export class BrowserBridgeClient {
+  private readonly host: string;
+  private readonly port: number;
+  private readonly socketFactory: () => Socket;
+  private socket: Socket | null = null;
+  private socketReady: Promise<void> | null = null;
+  private readonly pending = new Map<string, PendingCall<unknown>>();
+  private lastPingOkAt = 0;
+  private closed = false;
+
+  constructor(options: BrowserBridgeClientOptions = {}) {
+    this.host = options.host ?? DEFAULT_HOST;
+    const envPort = Number.parseInt(process.env.ADJ_BRIDGE_PORT ?? "", 10);
+
+    this.port =
+      options.port ?? (Number.isFinite(envPort) ? envPort : DEFAULT_PORT);
+    this.socketFactory = options.socketFactory ?? (() => createSocket("udp4"));
+  }
+
+  /**
+   * Verify the bridge responds. Result cached for 30 s on success.
+   * @param timeoutMs - Milliseconds to wait before treating the bridge as down
+   * @returns Bridge version + Live version reported by the sidecar
+   */
+  async ping(timeoutMs: number = DEFAULT_PING_TIMEOUT_MS): Promise<PingResult> {
+    const reply = await this.send<PingResult>("ping", {}, timeoutMs);
+
+    this.lastPingOkAt = Date.now();
+
+    return reply;
+  }
+
+  /**
+   * Returns true if a recent ping succeeded; otherwise sends a fresh one.
+   * @returns Whether the bridge is currently reachable
+   */
+  async ensureAlive(): Promise<boolean> {
+    if (Date.now() - this.lastPingOkAt < PING_FRESHNESS_MS) return true;
+
+    try {
+      await this.ping();
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Send a browse request to the bridge.
+   * @param args - Browse arguments forwarded verbatim to the bridge
+   * @param timeoutMs - Operation timeout in milliseconds
+   * @returns Serialized browser tree slice
+   */
+  async browse(
+    args: BrowseArgs,
+    timeoutMs: number = DEFAULT_BROWSE_TIMEOUT_MS,
+  ): Promise<BrowseResult> {
+    return await this.send<BrowseResult>("browse", { ...args }, timeoutMs);
+  }
+
+  /**
+   * Load an item by browser URI into the currently focused track/device.
+   * @param args - URI plus optional category to scope the lookup
+   * @param timeoutMs - Operation timeout in milliseconds
+   * @returns Loader result reporting the new device id (when available)
+   */
+  async loadItem(
+    args: LoadItemArgs,
+    timeoutMs: number = DEFAULT_LOAD_TIMEOUT_MS,
+  ): Promise<LoadItemResult> {
+    return await this.send<LoadItemResult>("load_item", { ...args }, timeoutMs);
+  }
+
+  /** Tear down the client. Outstanding requests reject with TIMEOUT_INTERNAL. */
+  close(): void {
+    this.closed = true;
+
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.resolve({
+        id,
+        ok: false,
+        error: {
+          code: "TIMEOUT_INTERNAL",
+          message: CLIENT_CLOSED_MESSAGE,
+        },
+      });
+    }
+
+    this.pending.clear();
+
+    if (this.socket) {
+      try {
+        this.socket.close();
+      } catch {
+        /* noop */
+      }
+
+      this.socket = null;
+      this.socketReady = null;
+    }
+  }
+
+  private async send<T>(
+    op: BridgeRequest["op"],
+    args: Record<string, unknown>,
+    timeoutMs: number,
+  ): Promise<T> {
+    if (this.closed) {
+      throw new BridgeCallError({
+        code: "TIMEOUT_INTERNAL",
+        message: CLIENT_CLOSED_MESSAGE,
+      });
+    }
+
+    await this.ensureSocket();
+    // ensureSocket awaits, so re-check the closed flag without TS narrowing.
+    const closedNow = (this as unknown as { closed: boolean }).closed;
+    const socket = this.socket;
+
+    if (closedNow || !socket) {
+      throw new BridgeCallError({
+        code: closedNow ? "TIMEOUT_INTERNAL" : "BRIDGE_NOT_FOUND",
+        message: closedNow
+          ? CLIENT_CLOSED_MESSAGE
+          : "bridge socket unavailable",
+      });
+    }
+
+    const id = `req_${randomUUID()}`;
+    const request: BridgeRequest = { id, op, args };
+    const payload = Buffer.from(JSON.stringify(request), "utf8");
+
+    const replyPromise = new Promise<BridgeReply<T>>((resolve) => {
+      const timer = setTimeout(() => {
+        if (this.pending.delete(id)) {
+          resolve({
+            id,
+            ok: false,
+            error: {
+              code: "TIMEOUT_INTERNAL",
+              message: `bridge ${op} timed out after ${timeoutMs}ms`,
+            },
+          });
+        }
+      }, timeoutMs);
+
+      this.pending.set(id, {
+        resolve: resolve as (reply: BridgeReply<unknown>) => void,
+        timer,
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      socket.send(payload, this.port, this.host, (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    }).catch((err: Error) => {
+      const pending = this.pending.get(id);
+
+      if (pending) {
+        clearTimeout(pending.timer);
+        this.pending.delete(id);
+      }
+
+      throw new BridgeCallError({
+        code: "BRIDGE_NOT_FOUND",
+        message: `udp send failed: ${err.message}`,
+      });
+    });
+
+    const reply = await replyPromise;
+
+    if (!reply.ok) {
+      // Mark bridge stale on first failure so the next call re-pings.
+      this.lastPingOkAt = 0;
+      throw new BridgeCallError(reply.error);
+    }
+
+    return reply.result;
+  }
+
+  private ensureSocket(): Promise<void> {
+    if (this.socketReady) return this.socketReady;
+
+    this.socketReady = new Promise<void>((resolve, reject) => {
+      const socket = this.socketFactory();
+
+      socket.on("message", (msg: Buffer, _rinfo: RemoteInfo) =>
+        this.onMessage(msg),
+      );
+      socket.on("error", (err: Error) => {
+        for (const [id, pending] of this.pending) {
+          clearTimeout(pending.timer);
+          pending.resolve({
+            id,
+            ok: false,
+            error: {
+              code: "BRIDGE_NOT_FOUND",
+              message: `socket error: ${err.message}`,
+            },
+          });
+        }
+
+        this.pending.clear();
+      });
+      socket.bind(0, () => {
+        this.socket = socket;
+        resolve();
+      });
+      socket.once("error", (err: Error) => {
+        if (!this.socket) reject(err);
+      });
+    });
+
+    return this.socketReady;
+  }
+
+  private onMessage(buf: Buffer): void {
+    let parsed: BridgeReply<unknown>;
+
+    try {
+      parsed = JSON.parse(buf.toString("utf8")) as BridgeReply<unknown>;
+    } catch {
+      return; // ignore malformed datagrams
+    }
+
+    const pending = this.pending.get(parsed.id);
+
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.pending.delete(parsed.id);
+    pending.resolve(parsed);
+  }
+}
+
+/** Thrown by client methods on a non-OK reply or transport failure. */
+export class BridgeCallError extends Error {
+  readonly code: BridgeErrorCode;
+
+  constructor(error: BridgeError) {
+    super(error.message);
+    this.name = "BridgeCallError";
+    this.code = error.code;
+  }
+}

--- a/src/mcp-server/create-express-app.ts
+++ b/src/mcp-server/create-express-app.ts
@@ -12,10 +12,17 @@ import express, {
 } from "express";
 import Max from "max-api";
 import { errorMessage } from "#src/shared/error-utils.ts";
+import { makeBridgeDispatcher } from "./bridge-dispatcher.ts";
+import { BrowserBridgeClient } from "./browser-bridge-client.ts";
 import { TOOL_NAMES, createMcpServer } from "./create-mcp-server.ts";
 import { callLiveApi } from "./max-api-adapter.ts";
 import * as console from "./node-for-max-logger.ts";
 import { registerRestApiRoutes } from "./rest-api-routes.ts";
+
+// Single browser bridge client lives for the lifetime of the server. The
+// underlying socket is created lazily on first use.
+const bridgeClient = new BrowserBridgeClient();
+const dispatchLiveApi = makeBridgeDispatcher(callLiveApi, bridgeClient);
 
 interface ServerConfig {
   memoryEnabled: boolean;
@@ -130,7 +137,7 @@ export function createExpressApp(): Express {
     try {
       console.info("New MCP connection: " + JSON.stringify(req.body));
 
-      const server = createMcpServer(callLiveApi, {
+      const server = createMcpServer(dispatchLiveApi, {
         smallModelMode: config.smallModelMode,
         tools: config.tools,
       });
@@ -169,7 +176,7 @@ export function createExpressApp(): Express {
 
   app.post("/config", handleConfigUpdate);
 
-  registerRestApiRoutes(app, () => config, callLiveApi);
+  registerRestApiRoutes(app, () => config, dispatchLiveApi);
 
   return app;
 }

--- a/src/mcp-server/create-mcp-server.ts
+++ b/src/mcp-server/create-mcp-server.ts
@@ -4,6 +4,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { VERSION } from "#src/shared/version.ts";
+import { toolDefBrowse } from "#src/tools/browse/browse.def.ts";
 import { toolDefCreateClip } from "#src/tools/clip/create/create-clip.def.ts";
 import { toolDefReadClip } from "#src/tools/clip/read/read-clip.def.ts";
 import { toolDefUpdateClip } from "#src/tools/clip/update/update-clip.def.ts";
@@ -55,6 +56,7 @@ export const STANDARD_TOOL_DEFS: ToolDefFunction[] = [
   toolDefSelect,
   toolDefPlayback,
   toolDefGenerate,
+  toolDefBrowse,
 ];
 
 /** All standard tool names (frozen). Does not include dev-only tools like adj-raw-live-api. */

--- a/src/mcp-server/tests/bridge/bridge-dispatcher.test.ts
+++ b/src/mcp-server/tests/bridge/bridge-dispatcher.test.ts
@@ -1,0 +1,180 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it, vi } from "vitest";
+import { type BrowserBridgeClient } from "../../browser-bridge-client.ts";
+import { makeBridgeDispatcher } from "../../bridge-dispatcher.ts";
+import { type McpResponse } from "../../max-api-adapter.ts";
+
+interface FakeBridge {
+  ensureAlive: ReturnType<typeof vi.fn>;
+  browse: ReturnType<typeof vi.fn>;
+  loadItem: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeBridge(overrides: Partial<FakeBridge> = {}): FakeBridge {
+  return {
+    ensureAlive: overrides.ensureAlive ?? vi.fn().mockResolvedValue(true),
+    browse: overrides.browse ?? vi.fn(),
+    loadItem: overrides.loadItem ?? vi.fn(),
+  };
+}
+
+function asBridge(b: FakeBridge): BrowserBridgeClient {
+  return b as unknown as BrowserBridgeClient;
+}
+
+function parseSuccess(response: McpResponse): unknown {
+  expect(response.isError).not.toBe(true);
+  expect(response.content[0]?.type).toBe("text");
+
+  return JSON.parse(response.content[0]?.text ?? "");
+}
+
+describe("makeBridgeDispatcher", () => {
+  it("forwards adj-browse to the bridge and returns wrapped result", async () => {
+    const bridge = makeFakeBridge({
+      browse: vi.fn().mockResolvedValue({ items: [{ name: "Operator" }] }),
+    });
+    const next = vi.fn();
+    const dispatch = makeBridgeDispatcher(next, asBridge(bridge));
+
+    const response = (await dispatch("adj-browse", {
+      category: "instruments",
+    })) as McpResponse;
+
+    const parsed = parseSuccess(response) as { items: { name: string }[] };
+
+    expect(parsed.items[0]?.name).toBe("Operator");
+    expect(bridge.browse).toHaveBeenCalledWith({ category: "instruments" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns install hint when bridge is unavailable", async () => {
+    const bridge = makeFakeBridge({
+      ensureAlive: vi.fn().mockResolvedValue(false),
+    });
+    const next = vi.fn();
+    const dispatch = makeBridgeDispatcher(next, asBridge(bridge));
+
+    const response = (await dispatch("adj-browse", {})) as McpResponse;
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toMatch(/install:bridge/);
+  });
+
+  it("falls through non-browser tools to next", async () => {
+    const bridge = makeFakeBridge();
+    const next = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "v8-result" }],
+    });
+    const dispatch = makeBridgeDispatcher(next, asBridge(bridge));
+
+    const response = (await dispatch("adj-read-track", {
+      id: "1",
+    })) as McpResponse;
+
+    expect(response.content[0]?.text).toBe("v8-result");
+    expect(next).toHaveBeenCalledWith("adj-read-track", { id: "1" });
+  });
+
+  it("forwards adj-create-device with no browserUri straight to v8", async () => {
+    const bridge = makeFakeBridge();
+    const next = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "v8-create" }],
+    });
+    const dispatch = makeBridgeDispatcher(next, asBridge(bridge));
+
+    await dispatch("adj-create-device", {
+      deviceName: "Operator",
+      path: "t0",
+    });
+
+    expect(next).toHaveBeenCalledWith("adj-create-device", {
+      deviceName: "Operator",
+      path: "t0",
+    });
+    expect(bridge.loadItem).not.toHaveBeenCalled();
+  });
+
+  it("create-device + browserUri (no deviceName) selects then loads", async () => {
+    const bridge = makeFakeBridge({
+      loadItem: vi.fn().mockResolvedValue({
+        loaded: true,
+        deviceId: "id-99",
+        deviceCountBefore: 0,
+        deviceCountAfter: 1,
+      }),
+    });
+    const next = vi.fn().mockResolvedValueOnce({
+      content: [{ type: "text", text: "selected" }],
+    });
+    const dispatch = makeBridgeDispatcher(next, asBridge(bridge));
+
+    const response = (await dispatch("adj-create-device", {
+      browserUri: "query:Synths#Operator",
+      path: "t0",
+    })) as McpResponse;
+
+    expect(next).toHaveBeenNthCalledWith(1, "adj-select", {
+      path: "t0",
+      detailView: "device",
+    });
+    expect(bridge.loadItem).toHaveBeenCalledWith({
+      uri: "query:Synths#Operator",
+    });
+    const parsed = parseSuccess(response) as { deviceId: string };
+
+    expect(parsed.deviceId).toBe("id-99");
+  });
+
+  it("create-device + browserUri + deviceName inserts rack then loads kit", async () => {
+    const bridge = makeFakeBridge({
+      loadItem: vi.fn().mockResolvedValue({
+        loaded: true,
+        deviceId: "id-1",
+        deviceCountBefore: 1,
+        deviceCountAfter: 1,
+      }),
+    });
+    const next = vi
+      .fn()
+      // adj-select
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "selected" }],
+      })
+      // adj-create-device for rack insertion
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "rack-created" }],
+      });
+    const dispatch = makeBridgeDispatcher(next, asBridge(bridge));
+
+    await dispatch("adj-create-device", {
+      deviceName: "Drum Rack",
+      browserUri: "query:Drums#808",
+      path: "t0",
+    });
+
+    expect(next).toHaveBeenNthCalledWith(2, "adj-create-device", {
+      deviceName: "Drum Rack",
+      path: "t0",
+    });
+    expect(bridge.loadItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("browserUri without path errors before touching bridge", async () => {
+    const bridge = makeFakeBridge();
+    const next = vi.fn();
+    const dispatch = makeBridgeDispatcher(next, asBridge(bridge));
+
+    const response = (await dispatch("adj-create-device", {
+      browserUri: "query:x",
+    })) as McpResponse;
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0]?.text).toMatch(/path is required/);
+    expect(next).not.toHaveBeenCalled();
+    expect(bridge.loadItem).not.toHaveBeenCalled();
+  });
+});

--- a/src/mcp-server/tests/bridge/browser-bridge-client.test.ts
+++ b/src/mcp-server/tests/bridge/browser-bridge-client.test.ts
@@ -125,9 +125,13 @@ describe("BrowserBridgeClient", () => {
     };
 
     const promise = client.browse({}, 50);
+    // Attach the rejection assertion BEFORE advancing fake timers so the
+    // promise's catch handler is in place when the timeout fires. Otherwise
+    // vitest reports a transient unhandled rejection and exits non-zero in CI.
+    const assertion = expect(promise).rejects.toThrow(/timed out/i);
 
     await vi.advanceTimersByTimeAsync(60);
-    await expect(promise).rejects.toThrow(/timed out/i);
+    await assertion;
     vi.useRealTimers();
   });
 

--- a/src/mcp-server/tests/bridge/browser-bridge-client.test.ts
+++ b/src/mcp-server/tests/bridge/browser-bridge-client.test.ts
@@ -1,0 +1,165 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import {
+  BridgeCallError,
+  BrowserBridgeClient,
+} from "../../browser-bridge-client.ts";
+
+interface SentMessage {
+  id: string;
+  op: string;
+  args: Record<string, unknown>;
+  replyAddr: { port: number; host: string };
+}
+
+class FakeSocket extends EventEmitter {
+  readonly sent: SentMessage[] = [];
+  /** Test hook: called with each sent request id so the test can build a reply. */
+  onSend?: (msg: SentMessage) => void;
+  closed = false;
+
+  bind(_port: number, cb: () => void): void {
+    setImmediate(cb);
+  }
+
+  send(
+    payload: Buffer,
+    port: number,
+    host: string,
+    cb: (err: Error | null) => void,
+  ): void {
+    const parsed = JSON.parse(payload.toString("utf8")) as {
+      id: string;
+      op: string;
+      args: Record<string, unknown>;
+    };
+    const record: SentMessage = { ...parsed, replyAddr: { port, host } };
+
+    this.sent.push(record);
+    cb(null);
+    this.onSend?.(record);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  /**
+   * Push a reply datagram into the client.
+   * @param payload - JSON-serializable reply mirroring what the bridge would send
+   */
+  reply(payload: object): void {
+    this.emit("message", Buffer.from(JSON.stringify(payload), "utf8"), {});
+  }
+}
+
+function makeClient(): { client: BrowserBridgeClient; socket: FakeSocket } {
+  const socket = new FakeSocket();
+  const client = new BrowserBridgeClient({
+    socketFactory: () => socket as unknown as ReturnType<typeof Object>,
+  });
+
+  return { client, socket };
+}
+
+describe("BrowserBridgeClient", () => {
+  it("ping resolves on ok reply", async () => {
+    const { client, socket } = makeClient();
+
+    socket.onSend = (msg) =>
+      socket.reply({
+        id: msg.id,
+        ok: true,
+        result: { version: "0.1.0", liveVersion: "12.4.0" },
+      });
+
+    const result = await client.ping();
+
+    expect(result.version).toBe("0.1.0");
+    expect(result.liveVersion).toBe("12.4.0");
+  });
+
+  it("browse forwards args and parses reply", async () => {
+    const { client, socket } = makeClient();
+
+    socket.onSend = (msg) => {
+      expect(msg.op).toBe("browse");
+      expect(msg.args.category).toBe("instruments");
+      socket.reply({
+        id: msg.id,
+        ok: true,
+        result: { items: [{ name: "Operator", uri: "u1" }] },
+      });
+    };
+
+    const result = await client.browse({ category: "instruments" });
+
+    expect(result.items[0]?.name).toBe("Operator");
+  });
+
+  it("translates non-ok replies into BridgeCallError", async () => {
+    const { client, socket } = makeClient();
+
+    socket.onSend = (msg) =>
+      socket.reply({
+        id: msg.id,
+        ok: false,
+        error: { code: "BROWSER_API_FAILED", message: "uri not found" },
+      });
+
+    await expect(client.browse({ category: "instruments" })).rejects.toThrow(
+      BridgeCallError,
+    );
+  });
+
+  it("times out when bridge does not reply", async () => {
+    vi.useFakeTimers();
+    const { client, socket } = makeClient();
+
+    socket.onSend = () => {
+      /* never reply */
+    };
+
+    const promise = client.browse({}, 50);
+
+    await vi.advanceTimersByTimeAsync(60);
+    await expect(promise).rejects.toThrow(/timed out/i);
+    vi.useRealTimers();
+  });
+
+  it("ensureAlive caches successful pings", async () => {
+    const { client, socket } = makeClient();
+    let pingCount = 0;
+
+    socket.onSend = (msg) => {
+      pingCount += 1;
+      socket.reply({
+        id: msg.id,
+        ok: true,
+        result: { version: "0.1.0", liveVersion: "12.4.0" },
+      });
+    };
+
+    expect(await client.ensureAlive()).toBe(true);
+    expect(await client.ensureAlive()).toBe(true);
+    expect(pingCount).toBe(1);
+  });
+
+  it("close drops outstanding requests with TIMEOUT_INTERNAL", async () => {
+    const { client, socket } = makeClient();
+
+    socket.onSend = () => {
+      /* never reply */
+    };
+
+    const promise = client.browse({}, 5_000);
+
+    client.close();
+
+    await expect(promise).rejects.toThrow(/closed/);
+  });
+});

--- a/src/mcp-server/tests/bridge/browser-bridge-client.test.ts
+++ b/src/mcp-server/tests/bridge/browser-bridge-client.test.ts
@@ -125,13 +125,15 @@ describe("BrowserBridgeClient", () => {
     };
 
     const promise = client.browse({}, 50);
-    // Attach the rejection assertion BEFORE advancing fake timers so the
-    // promise's catch handler is in place when the timeout fires. Otherwise
-    // vitest reports a transient unhandled rejection and exits non-zero in CI.
-    const assertion = expect(promise).rejects.toThrow(/timed out/i);
+
+    // Attach a catch handler BEFORE advancing fake timers so vitest does not
+    // observe a transient unhandled rejection (CI exits non-zero on those).
+    promise.catch(() => {
+      /* assertion below verifies the rejection details */
+    });
 
     await vi.advanceTimersByTimeAsync(60);
-    await assertion;
+    await expect(promise).rejects.toThrow(/timed out/i);
     vi.useRealTimers();
   });
 

--- a/src/mcp-server/tests/create-express-app.test.ts
+++ b/src/mcp-server/tests/create-express-app.test.ts
@@ -128,6 +128,7 @@ describe("MCP Express App", () => {
         "adj-select",
         "adj-playback",
         "adj-generate",
+        "adj-browse",
         "adj-raw-live-api",
       ]);
     });

--- a/src/tools/browse/browse.def.ts
+++ b/src/tools/browse/browse.def.ts
@@ -1,0 +1,70 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { z } from "zod";
+import { defineTool } from "#src/tools/shared/tool-framework/define-tool.ts";
+
+// Categories the Live Application.Browser exposes. Names must match the
+// attribute names on the Python Browser instance — they are passed through
+// verbatim to the bridge.
+const CATEGORY_VALUES = [
+  "instruments",
+  "audio_effects",
+  "midi_effects",
+  "drums",
+  "sounds",
+  "samples",
+  "clips",
+  "current_project",
+  "user_library",
+  "user_folders",
+  "packs",
+  "plugins",
+  "max_for_live",
+] as const;
+
+export const toolDefBrowse = defineTool("adj-browse", {
+  title: "Browse",
+  description:
+    "Browse Ableton Live's Library and User Library tree. Returns category " +
+    "roots, folder children, and loadable items with their stable browser " +
+    "URIs. Pair the URI with adj-create-device to load by URI. Requires the " +
+    "Live Browser Bridge — install with `npm run install:bridge`.",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+  },
+  inputSchema: {
+    category: z
+      .enum(CATEGORY_VALUES)
+      .optional()
+      .describe(
+        "browser category root to enter; omit to list available categories",
+      ),
+    path: z
+      .string()
+      .optional()
+      .describe(
+        "slash-separated names walked under the category root (e.g., 'Synths/Operator')",
+      ),
+    search: z
+      .string()
+      .optional()
+      .describe("case-insensitive substring filter applied to children"),
+    depth: z
+      .number()
+      .int()
+      .min(1)
+      .max(3)
+      .optional()
+      .describe("how many child levels to expand inline (default 1)"),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(500)
+      .optional()
+      .describe("maximum number of top-level items to return (default 100)"),
+  },
+});

--- a/src/tools/device/create/create-device.def.ts
+++ b/src/tools/device/create/create-device.def.ts
@@ -28,6 +28,12 @@ export const toolDefCreateDevice = defineTool("adj-create-device", {
       .string()
       .optional()
       .describe("name for all, or comma-separated for each"),
+    browserUri: z
+      .string()
+      .optional()
+      .describe(
+        "browser URI from adj-browse to load the exact item; pass with deviceName='Drum Rack' to load a kit into a freshly-inserted rack. Requires the Live Browser Bridge.",
+      ),
   },
 
   smallModelModeConfig: {
@@ -35,6 +41,7 @@ export const toolDefCreateDevice = defineTool("adj-create-device", {
     descriptionOverrides: {
       path: "insertion path, required with deviceName (e.g., 't0', 't0/d1', 't0/d0/c0')",
       name: "display name",
+      browserUri: "URI from adj-browse to load by browser",
     },
   },
 });


### PR DESCRIPTION
### **User description**
## Summary

Implements issue #26 per `docs/specs/Browser-Bridge-Spec.md`. Live's
`Application.Browser` is exposed only to Python remote scripts, not to
Max-for-Live JS, so this ships a Python sidecar (`live_browser_bridge/`)
that the Node-for-Max process forwards browser ops to over UDP
localhost:11077.

- New tool `adj-browse` walks the Library / User Library and returns
  loadable items with their stable browser URIs.
- `adj-create-device` gains optional `browserUri`. Pair with
  `deviceName: "Drum Rack"` to insert a rack and load a kit into it
  in one call.
- `npm run install:bridge` copies the Python source into Live's User
  Library Remote Scripts dir under `AbletonDjMcp/`.
- Bridge unavailable surfaces a structured error pointing the user at
  `install:bridge` + the prefs toggle. No fallback, no hardcoded
  device curation.

Phase 2 (auto Preferences.cfg toggle to skip the manual Control Surface
selection) is deferred per the spec.

## Test plan

- [x] `npm run check` — lint clean, typecheck clean, format clean,
      3763/3763 tests pass, 98.46% statement coverage
- [x] Python: `python3 -m unittest discover -s live_browser_bridge/tests`
      — 18/18 pass
- [x] Vitest bridge suites:
  - `src/mcp-server/tests/bridge/browser-bridge-client.test.ts` (6 tests)
  - `src/mcp-server/tests/bridge/bridge-dispatcher.test.ts` (7 tests)
- [x] Build clean — `dist/mcp-server.mjs` carries `BrowserBridgeClient`,
      `adj-browse`, dispatcher
- [x] `npm run install:bridge` end-to-end: copies all 7 files (no
      `tests/`, no `__pycache__`) to
      `~/Music/Ableton/User Library/Remote Scripts/AbletonDjMcp/`
- [ ] User: restart Live, enable AbletonDjMcp under Preferences →
      Link/Tempo/MIDI → Control Surface, exercise `adj-browse` and
      `adj-create-device --browserUri`

## Files of note

- `live_browser_bridge/` — Python package (ControlSurface + UDP loop,
  pure tree-walk helpers, queue runner, version constants, README,
  LICENSE, pytest suite)
- `src/mcp-server/browser-bridge-client.ts` — UDP client, ping cache,
  per-op timeouts, structured `BridgeCallError`
- `src/mcp-server/bridge-dispatcher.ts` — wraps `callLiveApi`,
  intercepts `adj-browse` and `adj-create-device --browserUri`
- `scripts/install-bridge.ts` — install workflow with restart prompt
- `docs/specs/Browser-Bridge-Spec.md` — flipped from DRAFT to
  IMPLEMENTED (Phase 1)

Closes #26.


___

### **PR Type**
Enhancement


___

### **Description**
- Introduces `adj-browse` tool for Live's library.

- `adj-create-device` loads items via `browserUri`.

- Python sidecar bridges Live's browser API.

- New `install:bridge` script deploys sidecar.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Node-for-Max Server] --> B{BrowserBridgeClient};
  B -- "UDP localhost:11077" --> C[Python BrowserBridge Sidecar];
  C -- "Live API calls" --> D[Ableton Live Application.Browser];
  B -- "Non-browser tools" --> E[Max/MSP LiveAPI];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Script</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>install-bridge.ts</strong><dd><code>Adds script to install Python browser bridge into Live's Remote </code><br><code>Scripts</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-16e8f523423622633d8144247e532f0459c4f720ea06ba21dc26fa67c47ce72d">+120/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Utility</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>user-library-path.ts</strong><dd><code>Adds `resolveRemoteScriptsDir` for Python control surfaces</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-a3ec262d7673e23c40bd9dc3e8bd008811302781266bc9d56fe6bfc1f168f029">+34/-25</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>browser_ops.py</strong><dd><code>Provides pure Python helpers for traversing Live's <code>Application.Browser</code> <br>tree</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-769f8e95f6e78226c576a2d3bdfe38b3577fd1ed3d1bcb5ab865a6714931d784">+194/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>queue_runner.py</strong><dd><code>Implements thread-safe queues for inter-thread communication in Python</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-d81a0c1965b2faadd20761de51776207afe762dfaadfe867a214068de5af8c71">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>bridge-dispatcher.ts</strong><dd><code>Introduces dispatcher to route browser-related calls to the Python </code><br><code>bridge</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-920550fd4a2a315896d2d98d2f0f2a53f35360c7bf4a47179fbd9c3f36a2c4be">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>create-device.def.ts</strong><dd><code>Adds <code>browserUri</code> parameter to <code>adj-create-device</code> for URI-based loading</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-7edf6891e475a32445b57cb25b56370461e720b19451cdf6389895403f8e4d7c">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Networking</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>browser-bridge-client.ts</strong><dd><code>Adds UDP client for communication with the Python browser bridge</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-fa1ca103845c55e76ff0f5a978d536442a515090654bdedf7877cf01427c9343">+359/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>create-express-app.ts</strong><dd><code>Integrates browser bridge client and dispatcher into the MCP server</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-f9fb64a5ee8ff9f4c9f4cd013b19273dabec439bd3e1b00c246858d3e026d85c">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Defines the entry point for Live's remote-script loader</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-e8f97892eb533459662af0b6a524ca748ecea6166c130b3f387458c97b475480">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>version.py</strong><dd><code>Defines version and default UDP port for the Python bridge</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-ed444b41e9d6cf0c0b940344760765ed14e83ef53d0e35777a8974c101513881">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>package.json</strong><dd><code>Adds `install:bridge` script to the package scripts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tool registration</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>create-mcp-server.ts</strong><dd><code>Registers the new `adj-browse` tool definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-9aedb34621fd14bd2830d9f454c3b5fbf3fc108d294bcc60b01f4247cd306f04">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>bridge-dispatcher.test.ts</strong><dd><code>Adds unit tests for the `makeBridgeDispatcher` functionality</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-cedd56b51ec37265e041c5c838c9f1b21dc05929177765ed10f2d14e017d527b">+180/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>browser-bridge-client.test.ts</strong><dd><code>Adds unit tests for the `BrowserBridgeClient` UDP communication</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-fa3d79969ee84673e1fcaa4fb4426a9b7cc2c34eff610e409ad3973083fd2aed">+165/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>create-express-app.test.ts</strong><dd><code>Updates tool list in tests to include `adj-browse`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-ba023da9e605a5eb98132a10ff03265f8f4a2a7037de25f2d4622fac0d85c0c9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_browser_ops.py</strong><dd><code>Adds unit tests for the Python browser operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-e0964afcc96249ad7f130ca83514eddba30c17cbe5d97b695686bc3961e51665">+159/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>New feature</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>browse.def.ts</strong><dd><code>Defines the new `adj-browse` tool for Live's library traversal</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-14e6031cccaaaba70efc300b3823bbca56f4472715d5783f698eea2505318127">+70/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BrowserBridge.py</strong><dd><code>Implements Python ControlSurface for UDP communication and Live API </code><br><code>dispatch</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-6640acee310b1a77c7f046a1edb55eb118072d8687cdf8df4dcf3e999407688c">+280/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Build output</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ableton-dj-mcp-portal.js</strong><dd><code>Rebuilds distribution with browser bridge client and <code>adj-browse</code> tool</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-09145fb3a1fb499bb649e61afeb792066e1cde2de87ab3e45036613cabacca3b">+31/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>live-api-adapter.js</strong><dd><code>Updates build info and reflects changes in tool definitions</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-0a025e0ebbef610cee32b3d48fc7a6c0a353cb908b47aa3d74137d68b4a4d6dc">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mcp-server.mjs</strong><dd><code>Rebuilds distribution with browser bridge client and dispatcher</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-5723cdad2e31879af7515acf8d027626338c319a3b51a54a5e9b239e4b4e2a73">+326/-29</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>CLAUDE.md</strong><dd><code>Updates the total count of available tools to 23</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PROJECT_INDEX.md</strong><dd><code>Updates tool count, adds browser bridge section and port info</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-6b62521c254cc758592c5074ff3eb506453d30d7d0fa720b6c0ff948e3b54120">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Tools-Reference.md</strong><dd><code>Documents <code>adj-browse</code> tool and <code>browserUri</code> parameter for <br><code>adj-create-device</code></code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-1144a39ffd998b6c8832a8e6e38fae79a98231f8e64046307c61134a0b297194">+27/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>INDEX.md</strong><dd><code>Updates `m4l-no-browser-api` finding with implementation details</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-979fccfe801351786b9cff5fb897af3ff04082c758a89f3c81ac6903e5592f98">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Browser-Bridge-Spec.md</strong><dd><code>Updates specification status to "IMPLEMENTED (Phase 1)"</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-be385f4b984bc7a1e837b48386aae08a2e98bb8f22d5e60b3cc68893206104ae">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Adds README for the Python browser bridge, explaining its purpose and </code><br><code>installation</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-be9bfc5394b076af0084967bc377e04577a33a5eaa07350cc7437eb233d3d78c">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>License</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>LICENSE</strong><dd><code>Adds license file for the Python browser bridge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-fabb2eccc7c2cd8b7af3ec6a717323c1ac83a7d706c71ed94b6c433c3ad173f4">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/119/files#diff-a55a62990207bc14528a24e69ffc1e7ccf0b44bb05dfac71dc909a9e2485a197">[link]</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

