### PR TITLE
docs(findings): drop mechanics + energy curve + indie-dance microsection arc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,7 @@ report/
 local/
 
 # User's personal music context (scaffolded from workspace.template/ via npm run init:workspace)
-workspace/
+# Track validated findings (workspace/findings/) so they can be shared via PR.
+# Keep projects/, AI.md, genres/, techniques/ private (per-user session data).
+workspace/*
+!workspace/findings/

--- a/workspace/findings/HOW-TO-WRITE.md
+++ b/workspace/findings/HOW-TO-WRITE.md
@@ -1,18 +1,24 @@
 # How to Write a Music Finding
 
-Format spec for `workspace/findings/`. Loaded by `/update-docs` skill before writing. AI-optimized: lazy loading, no duplicates, no boilerplate.
+Format spec for `workspace/findings/`. Loaded by `/update-docs` skill before
+writing. AI-optimized: lazy loading, no duplicates, no boilerplate.
 
-Mirror of `docs/findings/HOW-TO-WRITE.md` (the tool/dev findings spec) but tuned for music production knowledge.
+Mirror of `docs/findings/HOW-TO-WRITE.md` (the tool/dev findings spec) but tuned
+for music production knowledge.
 
 ## What goes here
 
-Validated music production knowledge captured during real sessions. Each finding is one technique, one observation, or one rule with concrete evidence from your own work.
+Validated music production knowledge captured during real sessions. Each finding
+is one technique, one observation, or one rule with concrete evidence from your
+own work.
 
 ## What does NOT go here
 
-- Tool bugs or feature requests → file as a GitHub issue in `gabrielpulga/ableton-dj-mcp` instead
+- Tool bugs or feature requests → file as a GitHub issue in
+  `gabrielpulga/ableton-dj-mcp` instead
 - Generic music theory available anywhere on the web
-- Things from a tutorial or article (unless you tested them yourself and it worked)
+- Things from a tutorial or article (unless you tested them yourself and it
+  worked)
 - Speculation: "I think X would sound good"
 - Restating what's already in `AI.md`
 
@@ -26,7 +32,8 @@ A music finding is valid only if proven in a real session by ONE of:
 - A failure that taught you what NOT to do (cite the symptom)
 - A technique you applied across multiple projects with consistent results
 
-If you can't point to a specific session, project, or audio output → don't write the finding.
+If you can't point to a specific session, project, or audio output → don't write
+the finding.
 
 ## File layout
 
@@ -45,7 +52,8 @@ Add new domains as needed. Mirror the routing-by-glob pattern.
 
 - Path: `<domain>/<slug>.md`
 - Slug: kebab-case, ≤ 5 words
-- Slug names the technique, not the symptom: `bass-off-beat-rule` not `bass-sounds-bad-fix`
+- Slug names the technique, not the symptom: `bass-off-beat-rule` not
+  `bass-sounds-bad-fix`
 - Lowercase only
 
 ## Strict file template
@@ -60,15 +68,18 @@ evidence: <project name | reference track | session description>
 ---
 
 ## Fact
+
 <one or two sentences. The technique itself. No buildup.>
 
 ## Evidence
-<concrete proof: project where it worked, reference track that uses it,
-A/B comparison, or failed attempt that taught the lesson.>
+
+<concrete proof: project where it worked, reference track that uses it, A/B
+comparison, or failed attempt that taught the lesson.>
 
 ## Apply when
-<condition that triggers relevance: genre, section type, instrument,
-or production stage.>
+
+<condition that triggers relevance: genre, section type, instrument, or
+production stage.>
 ```
 
 ### Section rules
@@ -126,16 +137,18 @@ Two files for same fact = wasted context.
 
 ## When in doubt, skip
 
-Better to capture nothing than to capture noise. Bad findings rot the knowledge base faster than good ones grow it.
+Better to capture nothing than to capture noise. Bad findings rot the knowledge
+base faster than good ones grow it.
 
 ## Tool vs music findings
 
-| Discovery type | Where to capture |
-|---|---|
-| MCP tool bug or missing feature | GitHub issue in `gabrielpulga/ableton-dj-mcp` |
-| MCP tool quirk that affects how you use it | `docs/findings/dev/` (in tool repo, public) |
-| Music technique that worked | `workspace/findings/technique/` (here, private) |
-| Genre-specific pattern from analysis | `workspace/findings/genre/` (here, private) |
-| Sound design recipe | `workspace/findings/sound-design/` (here, private) |
+| Discovery type                             | Where to capture                                   |
+| ------------------------------------------ | -------------------------------------------------- |
+| MCP tool bug or missing feature            | GitHub issue in `gabrielpulga/ableton-dj-mcp`      |
+| MCP tool quirk that affects how you use it | `docs/findings/dev/` (in tool repo, public)        |
+| Music technique that worked                | `workspace/findings/technique/` (here, private)    |
+| Genre-specific pattern from analysis       | `workspace/findings/genre/` (here, private)        |
+| Sound design recipe                        | `workspace/findings/sound-design/` (here, private) |
 
-When unsure: if it's about HOW to use the tool, it's tool. If it's about WHAT to make musically, it's music.
+When unsure: if it's about HOW to use the tool, it's tool. If it's about WHAT to
+make musically, it's music.

--- a/workspace/findings/HOW-TO-WRITE.md
+++ b/workspace/findings/HOW-TO-WRITE.md
@@ -1,0 +1,141 @@
+# How to Write a Music Finding
+
+Format spec for `workspace/findings/`. Loaded by `/update-docs` skill before writing. AI-optimized: lazy loading, no duplicates, no boilerplate.
+
+Mirror of `docs/findings/HOW-TO-WRITE.md` (the tool/dev findings spec) but tuned for music production knowledge.
+
+## What goes here
+
+Validated music production knowledge captured during real sessions. Each finding is one technique, one observation, or one rule with concrete evidence from your own work.
+
+## What does NOT go here
+
+- Tool bugs or feature requests → file as a GitHub issue in `gabrielpulga/ableton-dj-mcp` instead
+- Generic music theory available anywhere on the web
+- Things from a tutorial or article (unless you tested them yourself and it worked)
+- Speculation: "I think X would sound good"
+- Restating what's already in `AI.md`
+
+## Validation bar
+
+A music finding is valid only if proven in a real session by ONE of:
+
+- A clip you generated that sounded right (cite project + clip name)
+- A reference track analysis you completed (cite track + timestamp)
+- An A/B test where one approach clearly worked better (cite both)
+- A failure that taught you what NOT to do (cite the symptom)
+- A technique you applied across multiple projects with consistent results
+
+If you can't point to a specific session, project, or audio output → don't write the finding.
+
+## File layout
+
+```
+workspace/findings/
+├── INDEX.md                 ← always loaded, one line per finding
+├── HOW-TO-WRITE.md          ← this file
+├── genre/                   ← genre-specific patterns (techno, house, psy, etc.)
+├── technique/               ← cross-genre techniques (mixing, arrangement, sound design)
+└── sound-design/            ← specific sound recipes (pads, leads, kicks, basses)
+```
+
+Add new domains as needed. Mirror the routing-by-glob pattern.
+
+## Filename rules
+
+- Path: `<domain>/<slug>.md`
+- Slug: kebab-case, ≤ 5 words
+- Slug names the technique, not the symptom: `bass-off-beat-rule` not `bass-sounds-bad-fix`
+- Lowercase only
+
+## Strict file template
+
+```markdown
+---
+title: <slug-matches-filename>
+domain: <genre|technique|sound-design>
+genre: <house|techno|melodic-techno|psy|indie-dance|all>
+validated: <YYYY-MM-DD>
+evidence: <project name | reference track | session description>
+---
+
+## Fact
+<one or two sentences. The technique itself. No buildup.>
+
+## Evidence
+<concrete proof: project where it worked, reference track that uses it,
+A/B comparison, or failed attempt that taught the lesson.>
+
+## Apply when
+<condition that triggers relevance: genre, section type, instrument,
+or production stage.>
+```
+
+### Section rules
+
+- Exactly 3 sections: Fact, Evidence, Apply when
+- No "Background", "Why", "History" — they rot
+- No marketing language ("warm", "punchy", "magic") without explaining HOW
+- Code blocks for exact parameters only — bar|beat notation, velocity, BPM
+- Reference real artists/tracks if the technique came from analysis
+
+## INDEX rules
+
+`INDEX.md` is always loaded by AI sessions in `workspace/`. Keep it lean.
+
+Format per line:
+
+```
+- [<slug>](<domain>/<slug>.md) [<glob>,<glob>] — <summary>
+```
+
+Globs match against:
+
+- Genre keywords in your prompt (`techno`, `psy`, `melodic`)
+- Section keywords (`intro`, `breakdown`, `peak`, `outro`)
+- Instrument keywords (`bass`, `kick`, `lead`, `pad`)
+- Project file paths (`projects/melodic-track/**`)
+
+Examples:
+
+```
+- [bass-off-beat-rule](technique/bass-off-beat-rule.md) [bass*, melodic*, techno*] — first bass hit at 1.25 not 1, creates pump against kick
+- [psy-acid-bassline](genre/psy-acid-bassline.md) [psy*, acid*, bass*] — 16th-note pattern with filter env, root + b2 + root within bar
+```
+
+Summary ≤ 120 chars. Sort alphabetically within domain.
+
+## Deduplication
+
+Before writing:
+
+1. Read INDEX
+2. grep for keywords from the candidate finding
+3. If match → read existing file → extend or skip
+4. If no match → new file
+
+Two files for same fact = wasted context.
+
+## Anti-patterns
+
+- ❌ "Tried X, didn't work, will try Y" — not validated yet, save when Y works
+- ❌ "Generic minor key sounds emotional" — too generic, not actionable
+- ❌ Multiple findings stuffed in one file
+- ❌ "Use this for any genre" — too broad, hurts routing
+- ❌ Documenting a one-off accident as a rule
+
+## When in doubt, skip
+
+Better to capture nothing than to capture noise. Bad findings rot the knowledge base faster than good ones grow it.
+
+## Tool vs music findings
+
+| Discovery type | Where to capture |
+|---|---|
+| MCP tool bug or missing feature | GitHub issue in `gabrielpulga/ableton-dj-mcp` |
+| MCP tool quirk that affects how you use it | `docs/findings/dev/` (in tool repo, public) |
+| Music technique that worked | `workspace/findings/technique/` (here, private) |
+| Genre-specific pattern from analysis | `workspace/findings/genre/` (here, private) |
+| Sound design recipe | `workspace/findings/sound-design/` (here, private) |
+
+When unsure: if it's about HOW to use the tool, it's tool. If it's about WHAT to make musically, it's music.

--- a/workspace/findings/INDEX.md
+++ b/workspace/findings/INDEX.md
@@ -1,21 +1,46 @@
 # Music Findings Index
 
-One line per finding. Always loaded in `workspace/` sessions. Individual files load on demand only when bracketed globs match the current task's context (genre, section, instrument, or file path).
+One line per finding. Always loaded in `workspace/` sessions. Individual files
+load on demand only when bracketed globs match the current task's context
+(genre, section, instrument, or file path).
 
 Line format: `- [<slug>](<domain>/<slug>.md) [<glob>,<glob>] — <summary>`
 
 ## genre
-- [indie-dance-microsection-arc](genre/indie-dance-microsection-arc.md) [indie-dance*, adam-ten*, mita-gami*, microsection*, loop*, groove*, maccabi*] — 4-microsection arc in 8-bar loop (intro/lift/peak/resolution every 2 bars) with adj-update-clip transforms
-- [maccabi-house-foundational-bass](genre/maccabi-house-foundational-bass.md) [maccabi*, bass*, adam-ten*, indie-dance*, build*] — 2-bar question/response bass, 6 hits, off-beat groove, color in response bar
-- [maccabi-house-percussion-stack](genre/maccabi-house-percussion-stack.md) [maccabi*, percussion*, drum*, adam-ten*, indie-dance*, build*, groove*] — clave + off-beat open hat + 16th shaker, 3 layers, no overlap
+
+- [indie-dance-microsection-arc](genre/indie-dance-microsection-arc.md)
+  [indie-dance*, adam-ten*, mita-gami*, microsection*, loop*, groove*, maccabi*]
+  — 4-microsection arc in 8-bar loop (intro/lift/peak/resolution every 2 bars)
+  with adj-update-clip transforms
+- [maccabi-house-foundational-bass](genre/maccabi-house-foundational-bass.md)
+  [maccabi*, bass*, adam-ten*, indie-dance*, build*] — 2-bar question/response
+  bass, 6 hits, off-beat groove, color in response bar
+- [maccabi-house-percussion-stack](genre/maccabi-house-percussion-stack.md)
+  [maccabi*, percussion*, drum*, adam-ten*, indie-dance*, build*, groove*] —
+  clave + off-beat open hat + 16th shaker, 3 layers, no overlap
 
 ## technique
-- [breakdown-lead-chord-aligned](technique/breakdown-lead-chord-aligned.md) [lead*, breakdown*, melody*, melodic*, indie-dance*, melodic-techno*] — breakdown leads must enter on chord change boundaries, exit before next change, ring-out for last 2 bars
-- [drop-mechanics](technique/drop-mechanics.md) [drop*, peak*, build*, transition*, indie-dance*, melodic-techno*, house*, arrangement*] — 3 drop types (subtractive/additive/contrast), build → silence → release timing, kick-return + sub-bass psychology, bar-by-bar example
-- [energy-curve-math](technique/energy-curve-math.md) [energy*, arrangement*, structure*, intro*, build*, peak*, outro*, drop*] — 0-100% per-bar formula, every-4 / every-8 / every-16 rules, sample 128-bar curve table
-- [lead-stab-plus-sustain-roles](technique/lead-stab-plus-sustain-roles.md) [lead*, melody*, call-response*, maccabi*, indie-dance*, main*] — two-lead trick: stab cluster in bass gaps + long sustain answer, distinct roles
-- [pre-drop-fill-formula](technique/pre-drop-fill-formula.md) [build*, drop*, fill*, transition*, snare*, indie-dance*, maccabi*] — 16-bar snare velocity ramp + kick drops last 2 bars + 32nd snare blast bar 16
-- [progressive-pad-reveal](technique/progressive-pad-reveal.md) [pad*, intro*, indie-dance*, melodic*, chord*] — 16-bar pad: drone → 5th → triad → octave, 4-bar phases, no melody needed
+
+- [breakdown-lead-chord-aligned](technique/breakdown-lead-chord-aligned.md)
+  [lead*, breakdown*, melody*, melodic*, indie-dance*, melodic-techno*] —
+  breakdown leads must enter on chord change boundaries, exit before next
+  change, ring-out for last 2 bars
+- [drop-mechanics](technique/drop-mechanics.md) [drop*, peak*, build*,
+  transition*, indie-dance*, melodic-techno*, house*, arrangement*] — 3 drop
+  types (subtractive/additive/contrast), build → silence → release timing,
+  kick-return + sub-bass psychology, bar-by-bar example
+- [energy-curve-math](technique/energy-curve-math.md) [energy*, arrangement*,
+  structure*, intro*, build*, peak*, outro*, drop*] — 0-100% per-bar formula,
+  every-4 / every-8 / every-16 rules, sample 128-bar curve table
+- [lead-stab-plus-sustain-roles](technique/lead-stab-plus-sustain-roles.md)
+  [lead*, melody*, call-response*, maccabi*, indie-dance*, main*] — two-lead
+  trick: stab cluster in bass gaps + long sustain answer, distinct roles
+- [pre-drop-fill-formula](technique/pre-drop-fill-formula.md) [build*, drop*,
+  fill*, transition*, snare*, indie-dance*, maccabi*] — 16-bar snare velocity
+  ramp + kick drops last 2 bars + 32nd snare blast bar 16
+- [progressive-pad-reveal](technique/progressive-pad-reveal.md) [pad*, intro*,
+  indie-dance*, melodic*, chord*] — 16-bar pad: drone → 5th → triad → octave,
+  4-bar phases, no melody needed
 
 ## sound-design
 

--- a/workspace/findings/INDEX.md
+++ b/workspace/findings/INDEX.md
@@ -1,0 +1,33 @@
+# Music Findings Index
+
+One line per finding. Always loaded in `workspace/` sessions. Individual files load on demand only when bracketed globs match the current task's context (genre, section, instrument, or file path).
+
+Line format: `- [<slug>](<domain>/<slug>.md) [<glob>,<glob>] — <summary>`
+
+## genre
+- [indie-dance-microsection-arc](genre/indie-dance-microsection-arc.md) [indie-dance*, adam-ten*, mita-gami*, microsection*, loop*, groove*, maccabi*] — 4-microsection arc in 8-bar loop (intro/lift/peak/resolution every 2 bars) with adj-update-clip transforms
+- [maccabi-house-foundational-bass](genre/maccabi-house-foundational-bass.md) [maccabi*, bass*, adam-ten*, indie-dance*, build*] — 2-bar question/response bass, 6 hits, off-beat groove, color in response bar
+- [maccabi-house-percussion-stack](genre/maccabi-house-percussion-stack.md) [maccabi*, percussion*, drum*, adam-ten*, indie-dance*, build*, groove*] — clave + off-beat open hat + 16th shaker, 3 layers, no overlap
+
+## technique
+- [breakdown-lead-chord-aligned](technique/breakdown-lead-chord-aligned.md) [lead*, breakdown*, melody*, melodic*, indie-dance*, melodic-techno*] — breakdown leads must enter on chord change boundaries, exit before next change, ring-out for last 2 bars
+- [drop-mechanics](technique/drop-mechanics.md) [drop*, peak*, build*, transition*, indie-dance*, melodic-techno*, house*, arrangement*] — 3 drop types (subtractive/additive/contrast), build → silence → release timing, kick-return + sub-bass psychology, bar-by-bar example
+- [energy-curve-math](technique/energy-curve-math.md) [energy*, arrangement*, structure*, intro*, build*, peak*, outro*, drop*] — 0-100% per-bar formula, every-4 / every-8 / every-16 rules, sample 128-bar curve table
+- [lead-stab-plus-sustain-roles](technique/lead-stab-plus-sustain-roles.md) [lead*, melody*, call-response*, maccabi*, indie-dance*, main*] — two-lead trick: stab cluster in bass gaps + long sustain answer, distinct roles
+- [pre-drop-fill-formula](technique/pre-drop-fill-formula.md) [build*, drop*, fill*, transition*, snare*, indie-dance*, maccabi*] — 16-bar snare velocity ramp + kick drops last 2 bars + 32nd snare blast bar 16
+- [progressive-pad-reveal](technique/progressive-pad-reveal.md) [pad*, intro*, indie-dance*, melodic*, chord*] — 16-bar pad: drone → 5th → triad → octave, 4-bar phases, no melody needed
+
+## sound-design
+
+<!-- Examples (delete or replace with your real findings):
+
+## technique
+- [bass-off-beat-rule](technique/bass-off-beat-rule.md) [bass*, melodic*, techno*] — first bass hit at 1.25 not 1, creates pump against kick
+
+## genre
+- [psy-acid-bassline](genre/psy-acid-bassline.md) [psy*, acid*, bass*] — 16th-note pattern with filter env, root + b2 + root within bar
+
+## sound-design
+- [innellea-pluck-velocity](sound-design/innellea-pluck-velocity.md) [pluck*, melodic*, arp*] — root v94, 3rd v45, 5th v59, octave v72 — velocity shapes the arp
+
+-->

--- a/workspace/findings/genre/indie-dance-microsection-arc.md
+++ b/workspace/findings/genre/indie-dance-microsection-arc.md
@@ -1,0 +1,129 @@
+---
+name: indie-dance-microsection-arc
+description: 4-microsection arc within an 8-bar loop (intro/lift/peak/resolution every 2 bars). Fixes "every layer plays every bar" failure with adj-update-clip transform snippets to silence elements per bar range.
+type: genre
+---
+
+# Indie-dance microsection arc — story inside an 8-bar loop
+
+A correct 8-bar loop in indie-dance is not a 1-bar groove tiled 8 times. It is a 4-part arc: **intro (bars 1-2) → lift (bars 3-4) → peak (bars 5-6) → resolution (bars 7-8)**. Each microsection has different element activity. Without this arc, the loop sounds flat regardless of how good the patterns are.
+
+## The failure mode this fixes
+
+2026-05-08 indie-dance session targeting Adam Ten / Mita Gami groove. Patterns were correct (right scale, right rhythm, right velocity curves), but result felt soulless. Diagnosed cause: **every layer played every bar at the same density**. Drums, bass, pads, both leads, e-piano stabs all running flat across 8 bars = no breathing room, no narrative.
+
+Fix is not to make patterns more complex. Fix is to make patterns sparser per bar and stagger which elements play in which microsection.
+
+## The 4-microsection arc (8-bar loop)
+
+```
+Bars  | Microsection | Energy | What plays
+------|--------------|--------|----------------------------------------
+1-2   | Intro        |  60%   | kick + bass + pad. No lead. No clap. No top perc.
+3-4   | Lift         |  75%   | + clap on bar 4|2. + lead stab (one hit per bar).
+5-6   | Peak         |  90%   | + sustain lead. + open hat. + shaker. Full stack.
+7-8   | Resolution   |  70%   | drop sustain lead. drop shaker. clap only on 7|2,8|2. Last beat: pad tail only.
+```
+
+Bars 1-2 set the pulse. Bars 3-4 introduce melodic motion. Bars 5-6 are the loop's peak. Bars 7-8 strip back so bar 1 of the next loop feels like a re-entry. The listener feels the loop breathing.
+
+## Element activity table
+
+```
+Element             | B1 | B2 | B3 | B4 | B5 | B6 | B7 | B8
+--------------------|----|----|----|----|----|----|----|----
+Kick C1             |  X |  X |  X |  X |  X |  X |  X |  X
+Closed hat F#1      |  X |  X |  X |  X |  X |  X |  X |  X
+Bass               |  X |  X |  X |  X |  X |  X |  X |  -
+Pad sustain         |  X |  X |  X |  X |  X |  X |  X |  X
+Clap Eb1            |  - |  - |  - |  X |  X |  X |  X |  X (sparse: 7|2, 8|2)
+Stab lead           |  - |  - |  X |  X |  X |  X |  - |  -
+Sustain lead        |  - |  - |  - |  - |  X |  X |  - |  -
+Open hat A#1        |  - |  - |  - |  - |  X |  X |  X |  -
+Shaker              |  - |  - |  - |  - |  X |  X |  - |  -
+E-piano stabs       |  - |  - |  X |  - |  X |  - |  X |  -
+```
+
+Only kick + closed hat + pad play every bar. Everything else sits out at least 2 bars per loop. The breathing room is the groove.
+
+## adj-update-clip transform snippets
+
+Workflow: write the full pattern across 8 bars first (loop the 1-bar / 2-bar core), then use `adj-update-clip` transforms to silence specific bar ranges per element. Merge mode.
+
+### Mute clap during intro (bars 1-2)
+
+```
+clipId: <drum-clip-id>
+mode: merge
+transforms:
+  - "Eb1 1|1-2|4: velocity = 0"
+```
+
+Sets every clap note in bars 1-2 to v=0. Use a velocity transform rather than a delete because it survives humanization (notes that were nudged off-grid still get hit by the velocity-by-pitch filter).
+
+### Mute sustain lead outside peak (bars 1-4 + bars 7-8)
+
+```
+clipId: <lead-clip-id>
+mode: merge
+transforms:
+  - "1|1-4|4: velocity = 0"
+  - "7|1-8|4: velocity = 0"
+```
+
+Sustain lead only audible bars 5-6.
+
+### Drop bass for bar 8 only (resolution breath)
+
+```
+clipId: <bass-clip-id>
+mode: merge
+transforms:
+  - "8|1-8|4: velocity = 0"
+```
+
+Bar 8 has no bass = listener feels the gap, ready for bar 1 re-entry.
+
+### Sparse clap (only beats 2 of bars 7-8)
+
+```
+clipId: <drum-clip-id>
+mode: merge
+transforms:
+  - "Eb1 7|1-7|1.99: velocity = 0"
+  - "Eb1 7|2.01-7|4: velocity = 0"
+  - "Eb1 8|1-8|1.99: velocity = 0"
+  - "Eb1 8|2.01-8|4: velocity = 0"
+```
+
+Keeps only the 7|2 and 8|2 hits.
+
+## Why velocity = 0 (not delete)
+
+If your patterns are humanized (timing nudged ± 0.02), a delete-by-exact-position misses notes that drifted off-grid. A velocity-by-bar-range transform catches every note in the range regardless of timing jitter. CLAUDE.md root rule: "v0 won't delete humanized notes" → use velocity transforms via `adj-update-clip`.
+
+## Common failures the arc fixes
+
+- **All layers play all bars** → no breathing. Fix: pick 3-4 elements that drop out at least 2 bars per 8-bar loop.
+- **Sustain lead plays whole loop** → no peak moment. Fix: sustain lead = bars 5-6 ONLY.
+- **Clap on every bar** → loses impact. Fix: clap = bars 4-8, with sparse hits in 7-8.
+- **Bass plays bar 8** → no resolution breath. Fix: bass mutes bar 8, returns bar 1.
+- **Lead motif plays continuously** → no contrast between stab and sustain. Fix: stab lead = bars 3-6, sustain lead = bars 5-6, both off bars 7-8.
+
+## When to use
+
+- Indie-dance, Maccabi House, melodic-house at 120-128 BPM.
+- 8-bar loops in any Main / Drop section that feel "busy but flat."
+- Any section where multiple melodic layers overlap and lack distinct roles.
+- Adam Ten, Mita Gami, Innellea, Argy-style productions.
+
+## When NOT to use
+
+- Techno main grooves (130+ BPM) where relentless repetition IS the point — Kraftwerk minimalism rules instead.
+- 2-bar loops — too short for 4 microsections, use 1 + 1 question/response instead.
+- Breakdowns — different rules (see `breakdown-lead-chord-aligned`).
+
+## Validated in
+
+- 2026-05-08 indie-dance Session-view jam (Adam Ten / Mita Gami target + Pink Floyd "Shine On" lead). Failure mode: every layer every bar = soulless. Arc derived from analyzing what was missing, not from a single working session — pending live A/B in next indie-dance project.
+- Cross-references: `lead-stab-plus-sustain-roles` (the two-lead conversation pattern this arc deploys), `maccabi-house-foundational-bass` (the bass pattern that mutes on bar 8), `pre-drop-fill-formula` (used at the macro 16-bar level, this arc operates inside it).

--- a/workspace/findings/genre/indie-dance-microsection-arc.md
+++ b/workspace/findings/genre/indie-dance-microsection-arc.md
@@ -1,18 +1,29 @@
 ---
 name: indie-dance-microsection-arc
-description: 4-microsection arc within an 8-bar loop (intro/lift/peak/resolution every 2 bars). Fixes "every layer plays every bar" failure with adj-update-clip transform snippets to silence elements per bar range.
+description:
+  4-microsection arc within an 8-bar loop (intro/lift/peak/resolution every 2
+  bars). Fixes "every layer plays every bar" failure with adj-update-clip
+  transform snippets to silence elements per bar range.
 type: genre
 ---
 
 # Indie-dance microsection arc — story inside an 8-bar loop
 
-A correct 8-bar loop in indie-dance is not a 1-bar groove tiled 8 times. It is a 4-part arc: **intro (bars 1-2) → lift (bars 3-4) → peak (bars 5-6) → resolution (bars 7-8)**. Each microsection has different element activity. Without this arc, the loop sounds flat regardless of how good the patterns are.
+A correct 8-bar loop in indie-dance is not a 1-bar groove tiled 8 times. It is a
+4-part arc: **intro (bars 1-2) → lift (bars 3-4) → peak (bars 5-6) → resolution
+(bars 7-8)**. Each microsection has different element activity. Without this
+arc, the loop sounds flat regardless of how good the patterns are.
 
 ## The failure mode this fixes
 
-2026-05-08 indie-dance session targeting Adam Ten / Mita Gami groove. Patterns were correct (right scale, right rhythm, right velocity curves), but result felt soulless. Diagnosed cause: **every layer played every bar at the same density**. Drums, bass, pads, both leads, e-piano stabs all running flat across 8 bars = no breathing room, no narrative.
+2026-05-08 indie-dance session targeting Adam Ten / Mita Gami groove. Patterns
+were correct (right scale, right rhythm, right velocity curves), but result felt
+soulless. Diagnosed cause: **every layer played every bar at the same density**.
+Drums, bass, pads, both leads, e-piano stabs all running flat across 8 bars = no
+breathing room, no narrative.
 
-Fix is not to make patterns more complex. Fix is to make patterns sparser per bar and stagger which elements play in which microsection.
+Fix is not to make patterns more complex. Fix is to make patterns sparser per
+bar and stagger which elements play in which microsection.
 
 ## The 4-microsection arc (8-bar loop)
 
@@ -25,7 +36,9 @@ Bars  | Microsection | Energy | What plays
 7-8   | Resolution   |  70%   | drop sustain lead. drop shaker. clap only on 7|2,8|2. Last beat: pad tail only.
 ```
 
-Bars 1-2 set the pulse. Bars 3-4 introduce melodic motion. Bars 5-6 are the loop's peak. Bars 7-8 strip back so bar 1 of the next loop feels like a re-entry. The listener feels the loop breathing.
+Bars 1-2 set the pulse. Bars 3-4 introduce melodic motion. Bars 5-6 are the
+loop's peak. Bars 7-8 strip back so bar 1 of the next loop feels like a
+re-entry. The listener feels the loop breathing.
 
 ## Element activity table
 
@@ -44,11 +57,14 @@ Shaker              |  - |  - |  - |  - |  X |  X |  - |  -
 E-piano stabs       |  - |  - |  X |  - |  X |  - |  X |  -
 ```
 
-Only kick + closed hat + pad play every bar. Everything else sits out at least 2 bars per loop. The breathing room is the groove.
+Only kick + closed hat + pad play every bar. Everything else sits out at least 2
+bars per loop. The breathing room is the groove.
 
 ## adj-update-clip transform snippets
 
-Workflow: write the full pattern across 8 bars first (loop the 1-bar / 2-bar core), then use `adj-update-clip` transforms to silence specific bar ranges per element. Merge mode.
+Workflow: write the full pattern across 8 bars first (loop the 1-bar / 2-bar
+core), then use `adj-update-clip` transforms to silence specific bar ranges per
+element. Merge mode.
 
 ### Mute clap during intro (bars 1-2)
 
@@ -59,7 +75,9 @@ transforms:
   - "Eb1 1|1-2|4: velocity = 0"
 ```
 
-Sets every clap note in bars 1-2 to v=0. Use a velocity transform rather than a delete because it survives humanization (notes that were nudged off-grid still get hit by the velocity-by-pitch filter).
+Sets every clap note in bars 1-2 to v=0. Use a velocity transform rather than a
+delete because it survives humanization (notes that were nudged off-grid still
+get hit by the velocity-by-pitch filter).
 
 ### Mute sustain lead outside peak (bars 1-4 + bars 7-8)
 
@@ -100,15 +118,24 @@ Keeps only the 7|2 and 8|2 hits.
 
 ## Why velocity = 0 (not delete)
 
-If your patterns are humanized (timing nudged ± 0.02), a delete-by-exact-position misses notes that drifted off-grid. A velocity-by-bar-range transform catches every note in the range regardless of timing jitter. CLAUDE.md root rule: "v0 won't delete humanized notes" → use velocity transforms via `adj-update-clip`.
+If your patterns are humanized (timing nudged ± 0.02), a
+delete-by-exact-position misses notes that drifted off-grid. A
+velocity-by-bar-range transform catches every note in the range regardless of
+timing jitter. CLAUDE.md root rule: "v0 won't delete humanized notes" → use
+velocity transforms via `adj-update-clip`.
 
 ## Common failures the arc fixes
 
-- **All layers play all bars** → no breathing. Fix: pick 3-4 elements that drop out at least 2 bars per 8-bar loop.
-- **Sustain lead plays whole loop** → no peak moment. Fix: sustain lead = bars 5-6 ONLY.
-- **Clap on every bar** → loses impact. Fix: clap = bars 4-8, with sparse hits in 7-8.
-- **Bass plays bar 8** → no resolution breath. Fix: bass mutes bar 8, returns bar 1.
-- **Lead motif plays continuously** → no contrast between stab and sustain. Fix: stab lead = bars 3-6, sustain lead = bars 5-6, both off bars 7-8.
+- **All layers play all bars** → no breathing. Fix: pick 3-4 elements that drop
+  out at least 2 bars per 8-bar loop.
+- **Sustain lead plays whole loop** → no peak moment. Fix: sustain lead = bars
+  5-6 ONLY.
+- **Clap on every bar** → loses impact. Fix: clap = bars 4-8, with sparse hits
+  in 7-8.
+- **Bass plays bar 8** → no resolution breath. Fix: bass mutes bar 8, returns
+  bar 1.
+- **Lead motif plays continuously** → no contrast between stab and sustain. Fix:
+  stab lead = bars 3-6, sustain lead = bars 5-6, both off bars 7-8.
 
 ## When to use
 
@@ -119,11 +146,19 @@ If your patterns are humanized (timing nudged ± 0.02), a delete-by-exact-positi
 
 ## When NOT to use
 
-- Techno main grooves (130+ BPM) where relentless repetition IS the point — Kraftwerk minimalism rules instead.
-- 2-bar loops — too short for 4 microsections, use 1 + 1 question/response instead.
+- Techno main grooves (130+ BPM) where relentless repetition IS the point —
+  Kraftwerk minimalism rules instead.
+- 2-bar loops — too short for 4 microsections, use 1 + 1 question/response
+  instead.
 - Breakdowns — different rules (see `breakdown-lead-chord-aligned`).
 
 ## Validated in
 
-- 2026-05-08 indie-dance Session-view jam (Adam Ten / Mita Gami target + Pink Floyd "Shine On" lead). Failure mode: every layer every bar = soulless. Arc derived from analyzing what was missing, not from a single working session — pending live A/B in next indie-dance project.
-- Cross-references: `lead-stab-plus-sustain-roles` (the two-lead conversation pattern this arc deploys), `maccabi-house-foundational-bass` (the bass pattern that mutes on bar 8), `pre-drop-fill-formula` (used at the macro 16-bar level, this arc operates inside it).
+- 2026-05-08 indie-dance Session-view jam (Adam Ten / Mita Gami target + Pink
+  Floyd "Shine On" lead). Failure mode: every layer every bar = soulless. Arc
+  derived from analyzing what was missing, not from a single working session —
+  pending live A/B in next indie-dance project.
+- Cross-references: `lead-stab-plus-sustain-roles` (the two-lead conversation
+  pattern this arc deploys), `maccabi-house-foundational-bass` (the bass pattern
+  that mutes on bar 8), `pre-drop-fill-formula` (used at the macro 16-bar level,
+  this arc operates inside it).

--- a/workspace/findings/genre/maccabi-house-foundational-bass.md
+++ b/workspace/findings/genre/maccabi-house-foundational-bass.md
@@ -1,0 +1,59 @@
+---
+name: maccabi-house-foundational-bass
+description: 2-bar question/response bass pattern for Maccabi House (Adam Ten style) — 6 hits with built-in breath, off-beat groove, color tones in response bar
+type: genre
+---
+
+# Maccabi House foundational bass — question/response
+
+Maccabi House (Adam Ten / Mita Gami scene) bass character per the genre: filtered saw, **short rhythmically-placed notes that leave space**. The space is the groove. Don't fill it.
+
+## 2-bar pattern (C minor, tile across 16 bars)
+
+```
+# Bar 1 — QUESTION (3 hits anchor + 1 hit + roll setup)
+v115 t/4 C1 1|1
+v100 t/4 C1 1|1.5
+v110 t/4 C1 1|2
+# rest 2.5-3 (the "xx" gap = breathing room)
+v95 t/4 C1 1|3.5
+# rest 4 (the "x" gap before response)
+v100 t/8 C1 1|4.25
+v110 t/8 C1 1|4.5
+v120 t/8 C1 1|4.75
+# bar-end 16th roll = building tension into response
+
+# Bar 2 — RESPONSE (same rhythm, color tones)
+v115 t/4 C1 2|1
+v100 t/4 C1 2|1.5
+v110 t/4 Eb1 2|2     # 3rd substitution
+# rest
+v95 t/4 Bb0 2|3.5    # low 7th drop = resolution color
+# rest
+v100 t/8 C1 2|4.25
+v110 t/8 C1 2|4.5
+v120 t/8 C1 2|4.75
+```
+
+## Why it works
+
+- 6 hits across 2 bars = lots of space. Maccabi House signature is what's NOT played.
+- Bar-end 16th-note roll (1|4.25-4.75 and 2|4.25-4.75) creates rhythmic tension that resolves on next bar's downbeat.
+- Color tones (Eb1, Bb0) only in response bar = subtle harmonic movement without losing the groove anchor.
+- Velocity dynamics (v95-120) avoid robotic feel.
+
+## Production notes
+
+- **Bass synth**: filtered saw (steep low-pass / MG Low 24 in Serum, or Drift saw + lowpass).
+- **Sidechain to kick** is essential — Maccabi House requires the pump.
+- Kick on every beat, bass off-beat. Off-beat groove against four-on-floor.
+
+## When to use
+
+- Maccabi House / Adam Ten / Mita Gami productions.
+- Build sections where bass enters first (before percussion layers).
+- 125 BPM target.
+
+## Validated in
+
+- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "I like it."

--- a/workspace/findings/genre/maccabi-house-foundational-bass.md
+++ b/workspace/findings/genre/maccabi-house-foundational-bass.md
@@ -1,12 +1,16 @@
 ---
 name: maccabi-house-foundational-bass
-description: 2-bar question/response bass pattern for Maccabi House (Adam Ten style) — 6 hits with built-in breath, off-beat groove, color tones in response bar
+description:
+  2-bar question/response bass pattern for Maccabi House (Adam Ten style) — 6
+  hits with built-in breath, off-beat groove, color tones in response bar
 type: genre
 ---
 
 # Maccabi House foundational bass — question/response
 
-Maccabi House (Adam Ten / Mita Gami scene) bass character per the genre: filtered saw, **short rhythmically-placed notes that leave space**. The space is the groove. Don't fill it.
+Maccabi House (Adam Ten / Mita Gami scene) bass character per the genre:
+filtered saw, **short rhythmically-placed notes that leave space**. The space is
+the groove. Don't fill it.
 
 ## 2-bar pattern (C minor, tile across 16 bars)
 
@@ -37,14 +41,18 @@ v120 t/8 C1 2|4.75
 
 ## Why it works
 
-- 6 hits across 2 bars = lots of space. Maccabi House signature is what's NOT played.
-- Bar-end 16th-note roll (1|4.25-4.75 and 2|4.25-4.75) creates rhythmic tension that resolves on next bar's downbeat.
-- Color tones (Eb1, Bb0) only in response bar = subtle harmonic movement without losing the groove anchor.
+- 6 hits across 2 bars = lots of space. Maccabi House signature is what's NOT
+  played.
+- Bar-end 16th-note roll (1|4.25-4.75 and 2|4.25-4.75) creates rhythmic tension
+  that resolves on next bar's downbeat.
+- Color tones (Eb1, Bb0) only in response bar = subtle harmonic movement without
+  losing the groove anchor.
 - Velocity dynamics (v95-120) avoid robotic feel.
 
 ## Production notes
 
-- **Bass synth**: filtered saw (steep low-pass / MG Low 24 in Serum, or Drift saw + lowpass).
+- **Bass synth**: filtered saw (steep low-pass / MG Low 24 in Serum, or Drift
+  saw + lowpass).
 - **Sidechain to kick** is essential — Maccabi House requires the pump.
 - Kick on every beat, bass off-beat. Off-beat groove against four-on-floor.
 
@@ -56,4 +64,5 @@ v120 t/8 C1 2|4.75
 
 ## Validated in
 
-- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "I like it."
+- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "I like
+  it."

--- a/workspace/findings/genre/maccabi-house-percussion-stack.md
+++ b/workspace/findings/genre/maccabi-house-percussion-stack.md
@@ -1,18 +1,22 @@
 ---
 name: maccabi-house-percussion-stack
-description: Minimum percussion stack for Maccabi House Build/groove sections — clave + open hat + shaker on top of kick. Three layers each with one job.
+description:
+  Minimum percussion stack for Maccabi House Build/groove sections — clave +
+  open hat + shaker on top of kick. Three layers each with one job.
 type: genre
 ---
 
 # Maccabi House percussion stack (Build / groove sections)
 
-Maccabi House lives in percussion. Per the genre article, percussion is "what makes the track interesting." Three layers cover the foundation.
+Maccabi House lives in percussion. Per the genre article, percussion is "what
+makes the track interesting." Three layers cover the foundation.
 
 ## The three layers
 
 ### 1. Clave (asymmetric off-beat color)
 
-Son-clave-influenced 2-bar pattern. Hits NOT on the downbeats — fills the gaps between kick and bass.
+Son-clave-influenced 2-bar pattern. Hits NOT on the downbeats — fills the gaps
+between kick and bass.
 
 ```
 v90 t/8 D1 1|1.5
@@ -41,23 +45,28 @@ All 16ths. Velocity curve creates groove — the AND is loudest:
 v40 (downbeat) → v55 (e) → v70 (and) → v50 (a)
 ```
 
-Tile per beat × 4 beats × full clip length. The dynamic shape IS the groove, not note placement.
+Tile per beat × 4 beats × full clip length. The dynamic shape IS the groove, not
+note placement.
 
 ## Drum Rack pad layout (suggested)
 
-| Pad | Sample | Pattern |
-|-----|--------|---------|
-| C1 | Kick | 4-on-floor |
-| D1 | Clave/rim | son-clave 2-bar loop |
-| F#1 (Gb1) | Open hat | off-beats only |
-| A#1 (Bb1) | Shaker | 16ths velocity-curved |
+| Pad       | Sample    | Pattern               |
+| --------- | --------- | --------------------- |
+| C1        | Kick      | 4-on-floor            |
+| D1        | Clave/rim | son-clave 2-bar loop  |
+| F#1 (Gb1) | Open hat  | off-beats only        |
+| A#1 (Bb1) | Shaker    | 16ths velocity-curved |
 
 ## Why it works
 
-- **Three jobs, no overlap**: clave = color, open hat = push, shaker = drive. None compete.
-- **Off-beat dominant**: kick on the beat, everything else off — interlocking puzzle.
-- **Velocity-driven groove on shaker**: avoids robotic feel without timing humanization tricks.
-- **Sparse clave** (3 hits per bar) = breathing room inside the dense shaker stream.
+- **Three jobs, no overlap**: clave = color, open hat = push, shaker = drive.
+  None compete.
+- **Off-beat dominant**: kick on the beat, everything else off — interlocking
+  puzzle.
+- **Velocity-driven groove on shaker**: avoids robotic feel without timing
+  humanization tricks.
+- **Sparse clave** (3 hits per bar) = breathing room inside the dense shaker
+  stream.
 
 ## When to use
 
@@ -67,4 +76,5 @@ Tile per beat × 4 beats × full clip length. The dynamic shape IS the groove, n
 
 ## Validated in
 
-- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "this actually sounds pretty good now."
+- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "this
+  actually sounds pretty good now."

--- a/workspace/findings/genre/maccabi-house-percussion-stack.md
+++ b/workspace/findings/genre/maccabi-house-percussion-stack.md
@@ -1,0 +1,70 @@
+---
+name: maccabi-house-percussion-stack
+description: Minimum percussion stack for Maccabi House Build/groove sections — clave + open hat + shaker on top of kick. Three layers each with one job.
+type: genre
+---
+
+# Maccabi House percussion stack (Build / groove sections)
+
+Maccabi House lives in percussion. Per the genre article, percussion is "what makes the track interesting." Three layers cover the foundation.
+
+## The three layers
+
+### 1. Clave (asymmetric off-beat color)
+
+Son-clave-influenced 2-bar pattern. Hits NOT on the downbeats — fills the gaps between kick and bass.
+
+```
+v90 t/8 D1 1|1.5
+v85 t/8 D1 1|2.5
+v95 t/8 D1 1|4
+v90 t/8 D1 2|1.5
+v95 t/8 D1 2|3
+v85 t/8 D1 2|4.5
+@3-16=1-2  // tile across full clip
+```
+
+### 2. Open hat (classic push)
+
+Off-beats only. The "and" of every beat. v85, t/2.
+
+```
+v85 t/2 Gb1 1|1.5,2.5,3.5,4.5
+@2-16=1
+```
+
+### 3. Shaker (16th-note drive)
+
+All 16ths. Velocity curve creates groove — the AND is loudest:
+
+```
+v40 (downbeat) → v55 (e) → v70 (and) → v50 (a)
+```
+
+Tile per beat × 4 beats × full clip length. The dynamic shape IS the groove, not note placement.
+
+## Drum Rack pad layout (suggested)
+
+| Pad | Sample | Pattern |
+|-----|--------|---------|
+| C1 | Kick | 4-on-floor |
+| D1 | Clave/rim | son-clave 2-bar loop |
+| F#1 (Gb1) | Open hat | off-beats only |
+| A#1 (Bb1) | Shaker | 16ths velocity-curved |
+
+## Why it works
+
+- **Three jobs, no overlap**: clave = color, open hat = push, shaker = drive. None compete.
+- **Off-beat dominant**: kick on the beat, everything else off — interlocking puzzle.
+- **Velocity-driven groove on shaker**: avoids robotic feel without timing humanization tricks.
+- **Sparse clave** (3 hits per bar) = breathing room inside the dense shaker stream.
+
+## When to use
+
+- Maccabi House / Adam Ten / Mita Gami Build and groove sections.
+- Indie dance / afro house with organic feel.
+- Any 125 BPM 4-on-floor groove that needs life without being busy.
+
+## Validated in
+
+- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "this actually sounds pretty good now."

--- a/workspace/findings/technique/breakdown-lead-chord-aligned.md
+++ b/workspace/findings/technique/breakdown-lead-chord-aligned.md
@@ -1,0 +1,52 @@
+---
+name: breakdown-lead-chord-aligned
+description: In breakdowns (no bass rhythm), lead notes must enter on chord boundaries and exit before/at next change. Off-grid entries feel "wrong place / wrong close."
+type: technique
+---
+
+# Breakdown lead — chord-aligned entry/exit
+
+In Main sections the lead dodges bass groove gaps. In **breakdowns there's no bass rhythm to dodge** — pad and bass are sustained. Different placement rule applies: leads must align with chord boundaries, not bar grid alone.
+
+## The rule
+
+- **Enter on the bar a chord changes** (1, 5, 9, 13 in a 16-bar breakdown with 4-bar chord changes)
+- **Exit on or before the next chord change**, never mid-chord
+- **Last 2 bars before drop = silence** — the breathing room IS the transition
+
+## Example (16-bar breakdown, Cm → Bb → Ab → Gm progression)
+
+```
+v80 t8 G4 5|1     // Bb arrives → lead enters with chord, sustains 2 bars to bar 7
+v95 t8 Eb5 9|1    // Ab arrives → climbs higher, sustains 2 bars to bar 11
+v110 t6 G5 13|1   // Gm climax → peak note 1.5 bars, ends bar 14|3
+// bars 14|3 - 16|4 → silence (ring-out + breathing room)
+```
+
+## Why off-grid entries feel wrong
+
+If lead enters at e.g. bar 5|2.5 (not aligned with chord change at 5|1), listener hears:
+- Sustained pad chord that already established (bored)
+- Lead arrives "late" relative to harmony
+- Sustain ends at random beat, mid-next-chord = unresolved tension
+
+Breakdown is about **harmonic motion** carrying the section. Lead must amplify chord changes, not float over them.
+
+## Pitch selection per chord
+
+Pick a chord tone for entry, but vary **which** tone for variety across the section:
+- Cm → G (5th, anchored)
+- Bb → G (6th, suspended feel)
+- Ab → Eb (5th, lifted)
+- Gm → G (root, peak)
+
+Climbing motion (G4 → Eb5 → G5) creates breakdown arc. Each entry higher than the last.
+
+## When to use
+
+- Any breakdown / sparse section / atmospheric break with sustained pads.
+- Whenever leads feel "in the wrong place" or "closing in the wrong place."
+
+## Validated in
+
+- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "way better." Earlier off-grid entries got "coming in the wrong place and closing in the wrong place."

--- a/workspace/findings/technique/breakdown-lead-chord-aligned.md
+++ b/workspace/findings/technique/breakdown-lead-chord-aligned.md
@@ -1,16 +1,21 @@
 ---
 name: breakdown-lead-chord-aligned
-description: In breakdowns (no bass rhythm), lead notes must enter on chord boundaries and exit before/at next change. Off-grid entries feel "wrong place / wrong close."
+description:
+  In breakdowns (no bass rhythm), lead notes must enter on chord boundaries and
+  exit before/at next change. Off-grid entries feel "wrong place / wrong close."
 type: technique
 ---
 
 # Breakdown lead — chord-aligned entry/exit
 
-In Main sections the lead dodges bass groove gaps. In **breakdowns there's no bass rhythm to dodge** — pad and bass are sustained. Different placement rule applies: leads must align with chord boundaries, not bar grid alone.
+In Main sections the lead dodges bass groove gaps. In **breakdowns there's no
+bass rhythm to dodge** — pad and bass are sustained. Different placement rule
+applies: leads must align with chord boundaries, not bar grid alone.
 
 ## The rule
 
-- **Enter on the bar a chord changes** (1, 5, 9, 13 in a 16-bar breakdown with 4-bar chord changes)
+- **Enter on the bar a chord changes** (1, 5, 9, 13 in a 16-bar breakdown with
+  4-bar chord changes)
 - **Exit on or before the next chord change**, never mid-chord
 - **Last 2 bars before drop = silence** — the breathing room IS the transition
 
@@ -25,22 +30,28 @@ v110 t6 G5 13|1   // Gm climax → peak note 1.5 bars, ends bar 14|3
 
 ## Why off-grid entries feel wrong
 
-If lead enters at e.g. bar 5|2.5 (not aligned with chord change at 5|1), listener hears:
+If lead enters at e.g. bar 5|2.5 (not aligned with chord change at 5|1),
+listener hears:
+
 - Sustained pad chord that already established (bored)
 - Lead arrives "late" relative to harmony
 - Sustain ends at random beat, mid-next-chord = unresolved tension
 
-Breakdown is about **harmonic motion** carrying the section. Lead must amplify chord changes, not float over them.
+Breakdown is about **harmonic motion** carrying the section. Lead must amplify
+chord changes, not float over them.
 
 ## Pitch selection per chord
 
-Pick a chord tone for entry, but vary **which** tone for variety across the section:
+Pick a chord tone for entry, but vary **which** tone for variety across the
+section:
+
 - Cm → G (5th, anchored)
 - Bb → G (6th, suspended feel)
 - Ab → Eb (5th, lifted)
 - Gm → G (root, peak)
 
-Climbing motion (G4 → Eb5 → G5) creates breakdown arc. Each entry higher than the last.
+Climbing motion (G4 → Eb5 → G5) creates breakdown arc. Each entry higher than
+the last.
 
 ## When to use
 
@@ -49,4 +60,6 @@ Climbing motion (G4 → Eb5 → G5) creates breakdown arc. Each entry higher tha
 
 ## Validated in
 
-- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "way better." Earlier off-grid entries got "coming in the wrong place and closing in the wrong place."
+- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "way
+  better." Earlier off-grid entries got "coming in the wrong place and closing
+  in the wrong place."

--- a/workspace/findings/technique/drop-mechanics.md
+++ b/workspace/findings/technique/drop-mechanics.md
@@ -1,12 +1,17 @@
 ---
 name: drop-mechanics
-description: Drop construction craft — 3 drop types (subtractive/additive/contrast), build → silence → release timing, kick-return rules, sub-bass-first-hit psychology, why silence beats fill before drop
+description:
+  Drop construction craft — 3 drop types (subtractive/additive/contrast), build
+  → silence → release timing, kick-return rules, sub-bass-first-hit psychology,
+  why silence beats fill before drop
 type: technique
 ---
 
 # Drop mechanics — build, silence, release
 
-The drop is not the moment the bass hits. The drop is the contrast between bar 16 (silence/anchor) and bar 17 (full energy). Without that contrast, no drop — just a louder section.
+The drop is not the moment the bass hits. The drop is the contrast between bar
+16 (silence/anchor) and bar 17 (full energy). Without that contrast, no drop —
+just a louder section.
 
 ## The 3 drop types
 
@@ -22,11 +27,13 @@ Bar 16|4   : everything cuts. 1 beat of silence.
 Bar 17|1   : kick + sub + groove + lead all return at full energy.
 ```
 
-The listener's nervous system fills the silence with anticipation. When elements return, brain reads it as "release."
+The listener's nervous system fills the silence with anticipation. When elements
+return, brain reads it as "release."
 
 ### 2. Additive drop (techno, peak-time)
 
-Build density 16 bars without removing anything. Land everything at once on bar 1 of next section.
+Build density 16 bars without removing anything. Land everything at once on bar
+1 of next section.
 
 ```
 Bars 1-4   : kick + bass
@@ -36,7 +43,8 @@ Bars 13-16 : add lead motif teasing + riser climb
 Bar 17|1   : sub-bass joins for first time + full chord stab. Drop = sub entry.
 ```
 
-Sub-bass entering for the first time IS the drop. Reserve sub for this moment — if sub plays in the build, the drop loses 50% of impact.
+Sub-bass entering for the first time IS the drop. Reserve sub for this moment —
+if sub plays in the build, the drop loses 50% of impact.
 
 ### 3. Contrast drop (Maceo Plex / Adam Beyer peak-time)
 
@@ -48,13 +56,15 @@ Bars 15-16 : everything cuts except a single sustained pad note + reverse cymbal
 Bar 17|1   : full groove returns identical to bar 14. No transition. Just shock.
 ```
 
-Works when the groove is already locked — listener wants it back. Pause makes return feel inevitable.
+Works when the groove is already locked — listener wants it back. Pause makes
+return feel inevitable.
 
 ## Build → silence → release timing rules
 
 ### Build phase (8 or 16 bars)
 
-- Density grows but melodic content stays simple. Don't add new chords during build — emotional payload lands on the drop, not the build.
+- Density grows but melodic content stays simple. Don't add new chords during
+  build — emotional payload lands on the drop, not the build.
 - Riser starts 8 bars before drop. Filter sweep opens across full 8 bars.
 - Snare 16th-note ramp (see `pre-drop-fill-formula`) starts 16 bars before drop.
 
@@ -63,9 +73,13 @@ Works when the groove is already locked — listener wants it back. Pause makes 
 Two valid options:
 
 - **Hard silence**: cut everything for 1 beat to 1 bar. Maximum contrast.
-- **Anchor only**: keep one sustained element (pad note, riser tail, vocal "ahh") through the gap. Less brutal, more emotional.
+- **Anchor only**: keep one sustained element (pad note, riser tail, vocal
+  "ahh") through the gap. Less brutal, more emotional.
 
-**Why silence > fill**: a fill (drum roll, snare blast, big riser climb) tells the brain "energy peaks here." A silence/anchor tells the brain "energy is gone — what comes next?" The second framing is what makes the drop hit. Fills sit at the same energy level as the drop, so the drop feels equal, not bigger.
+**Why silence > fill**: a fill (drum roll, snare blast, big riser climb) tells
+the brain "energy peaks here." A silence/anchor tells the brain "energy is gone
+— what comes next?" The second framing is what makes the drop hit. Fills sit at
+the same energy level as the drop, so the drop feels equal, not bigger.
 
 ### Drop bar (bar 1 of new section) — entry order WITHIN the bar
 
@@ -78,30 +92,44 @@ Bar 17|1.25  : groove perc enters (off-beat — confirms the rhythm)
 Bar 17|1.5   : top elements (lead motif, hat, ride) — fill the bar
 ```
 
-Kick + sub on exact downbeat = body feels the impact. Top elements 8th-note later = ear hears the texture. Both at once = mush.
+Kick + sub on exact downbeat = body feels the impact. Top elements 8th-note
+later = ear hears the texture. Both at once = mush.
 
 ## Kick-return rules
 
 - Kick must return on bar 17|1.0 exactly. Not 17|1.25, not delayed by an 8th.
-- If kick was absent for last 2 bars of build, return at velocity ≥ build kick velocity. Often louder by 5-10 (v110 → v120) for first 4 bars.
-- Don't taper the kick on bars 17-20. Full velocity for at least 8 bars before any variation.
+- If kick was absent for last 2 bars of build, return at velocity ≥ build kick
+  velocity. Often louder by 5-10 (v110 → v120) for first 4 bars.
+- Don't taper the kick on bars 17-20. Full velocity for at least 8 bars before
+  any variation.
 
 ## Sub-bass-first-hit psychology
 
-Sub-bass is the only element the body feels physically before the brain registers it. Use this:
+Sub-bass is the only element the body feels physically before the brain
+registers it. Use this:
 
 - Reserve sub for the drop. If sub plays in build, drop sub-feeling is gone.
-- Sub first hit at bar 17|1.0 is the moment the listener's chest moves. That IS the drop.
-- Sub note: root of the section, sustained 1-2 bars, no rhythm. Let it ring. Rhythm comes from the bass-mid layer.
-- **Avoid**: sub starting at bar 16|4.5 as a "pickup." Kills the drop. Sub starts AT the drop.
+- Sub first hit at bar 17|1.0 is the moment the listener's chest moves. That IS
+  the drop.
+- Sub note: root of the section, sustained 1-2 bars, no rhythm. Let it ring.
+  Rhythm comes from the bass-mid layer.
+- **Avoid**: sub starting at bar 16|4.5 as a "pickup." Kills the drop. Sub
+  starts AT the drop.
 
 ### Why this works (psychoacoustics)
 
-- **20-60 Hz range** stimulates the autonomic nervous system (heart rate, arousal response).
-- **Sacculus** (inner ear organ) responds to low-frequency vibrations above ~90 dB SPL → physical pleasure response distinct from auditory perception.
-- Low-frequency timing perception is more accurate than high-frequency, so the listener's body locks onto sub timing before the brain processes the topline.
-- Implication: sub-bass *absence* across breakdown → sub-bass *return* on drop = the most physical moment available in the track. Not just "louder bass" — a different perceptual event.
-- Mix rule: roll bass off through breakdown — automate HPF cutoff from ~30 Hz to ~175 Hz across the build. Drop returns full sub at bar 1 by snapping HPF back to 30 Hz.
+- **20-60 Hz range** stimulates the autonomic nervous system (heart rate,
+  arousal response).
+- **Sacculus** (inner ear organ) responds to low-frequency vibrations above ~90
+  dB SPL → physical pleasure response distinct from auditory perception.
+- Low-frequency timing perception is more accurate than high-frequency, so the
+  listener's body locks onto sub timing before the brain processes the topline.
+- Implication: sub-bass _absence_ across breakdown → sub-bass _return_ on drop =
+  the most physical moment available in the track. Not just "louder bass" — a
+  different perceptual event.
+- Mix rule: roll bass off through breakdown — automate HPF cutoff from ~30 Hz to
+  ~175 Hz across the build. Drop returns full sub at bar 1 by snapping HPF back
+  to 30 Hz.
 
 ## Genre-specific drop mechanics
 
@@ -110,51 +138,84 @@ Sub-bass is the only element the body feels physically before the brain register
 - **Intro**: 32 bars drums-only (DJ-friendly).
 - **Breakdown**: 8 bars, beatless or half-time.
 - **Build**: 8 bars (fail-safe length — longer feels indulgent).
-- **Drop A**: 32 bars sparse. Bass at ~5 sixteenth-note hits per bar, lead minimal.
+- **Drop A**: 32 bars sparse. Bass at ~5 sixteenth-note hits per bar, lead
+  minimal.
 - **Element rotation rule**: every 8 bars swap which element holds attention.
-- **Signature**: vocal chop or one-shot stab drops in for 1 bar at every 4-bar accent.
-- **Sidechain**: kick → bass with fast attack, fast release, high ratio, low threshold (French-house pump). Heavier than indie-dance sidechain.
+- **Signature**: vocal chop or one-shot stab drops in for 1 bar at every 4-bar
+  accent.
+- **Sidechain**: kick → bass with fast attack, fast release, high ratio, low
+  threshold (French-house pump). Heavier than indie-dance sidechain.
 
 ### Peak-time techno (130-138 BPM, Adam Beyer / Layton Giordani / Maceo Plex)
 
-- **Build technique**: automate LPF cutoff on bassline through breakdown for tension. Don't add new layers — modulate existing ones.
-- **Reverse-kick pre-drop**: duplicate kick channel, delete all but the last hit before drop, reverse the audio. Lands as a "whoosh into kick return."
-- **Drop construction**: relentless 4-on-floor + driving sub + 1-2 atmospheric/lead elements only. Density comes from velocity and mix, not layer count.
-- **Hard-pause drop** (Beyer / Maceo signature): full energy → 1-2 bars total silence → return at full. Pause must be ≥1 bar to register; ≤0.5 bar reads as a glitch.
-- **Hypnotic / Kraftwerk principle**: 16+ bars before any new layer. Change comes from automation (filter, reverb send, drive), not new instruments. Repetition IS the content.
+- **Build technique**: automate LPF cutoff on bassline through breakdown for
+  tension. Don't add new layers — modulate existing ones.
+- **Reverse-kick pre-drop**: duplicate kick channel, delete all but the last hit
+  before drop, reverse the audio. Lands as a "whoosh into kick return."
+- **Drop construction**: relentless 4-on-floor + driving sub + 1-2
+  atmospheric/lead elements only. Density comes from velocity and mix, not layer
+  count.
+- **Hard-pause drop** (Beyer / Maceo signature): full energy → 1-2 bars total
+  silence → return at full. Pause must be ≥1 bar to register; ≤0.5 bar reads as
+  a glitch.
+- **Hypnotic / Kraftwerk principle**: 16+ bars before any new layer. Change
+  comes from automation (filter, reverb send, drive), not new instruments.
+  Repetition IS the content.
 
 ### Melodic techno (122-128 BPM, Innellea / Afterlife / Tale of Us)
 
-- **Long break**: 32-bar breakdown is normal. Allows full emotional reset before drop 2.
-- **Drop entry order**: kick + rolling bass first; top-bass (octave higher) layers in 8 bars later. Two-stage drop.
-- **Harmonic shift trick**: late in arrangement, transpose root down a fourth (e.g. Dm → Am) for a resolution / "we got there" feel on the final drop.
-- **FX kit**: downlifter (drop impact), short sweep (transitions), uplifter (build), snare roll (build climax). Use all four — each owns a transition role.
-- **Atmospheric layers**: tonal atmosphere on the root + vocal atmosphere fill the drop without crowding mids. Atmosphere is the "soul" of the genre.
-- **"Glitch" detail**: shorten lead notes, double rhythm, micro-stutter — adds character without changing the line.
+- **Long break**: 32-bar breakdown is normal. Allows full emotional reset before
+  drop 2.
+- **Drop entry order**: kick + rolling bass first; top-bass (octave higher)
+  layers in 8 bars later. Two-stage drop.
+- **Harmonic shift trick**: late in arrangement, transpose root down a fourth
+  (e.g. Dm → Am) for a resolution / "we got there" feel on the final drop.
+- **FX kit**: downlifter (drop impact), short sweep (transitions), uplifter
+  (build), snare roll (build climax). Use all four — each owns a transition
+  role.
+- **Atmospheric layers**: tonal atmosphere on the root + vocal atmosphere fill
+  the drop without crowding mids. Atmosphere is the "soul" of the genre.
+- **"Glitch" detail**: shorten lead notes, double rhythm, micro-stutter — adds
+  character without changing the line.
 
 ### Indie dance (118-124 BPM, Adam Ten / Mita Gami / Innellea)
 
-- **Two-part drop**: 32 bars total = 16 bars bass-focused (root locked, no melody) + 16 bars melodic B-part (lead enters).
-- **Single drop sufficient**: indie dance often runs ONE main drop with variation, not the EDM two-drop standard. Save the second drop for genuine peak moments.
-- **Melodic element handling**: filter-automated, subtle during drop, opens up in breakdown (inverse of typical EDM).
-- **Adam Ten / Mita Gami / Maccabi House signature**: psychedelic-house Israeli flavor, deep emotional aesthetic, organic perc + funk DNA. Sidechain present but lighter than tech house.
-- See `indie-dance-microsection-arc` for the 4-microsection rule that prevents flat 8-bar loops.
+- **Two-part drop**: 32 bars total = 16 bars bass-focused (root locked, no
+  melody) + 16 bars melodic B-part (lead enters).
+- **Single drop sufficient**: indie dance often runs ONE main drop with
+  variation, not the EDM two-drop standard. Save the second drop for genuine
+  peak moments.
+- **Melodic element handling**: filter-automated, subtle during drop, opens up
+  in breakdown (inverse of typical EDM).
+- **Adam Ten / Mita Gami / Maccabi House signature**: psychedelic-house Israeli
+  flavor, deep emotional aesthetic, organic perc + funk DNA. Sidechain present
+  but lighter than tech house.
+- See `indie-dance-microsection-arc` for the 4-microsection rule that prevents
+  flat 8-bar loops.
 
 ### Progressive psytrance (138-142 BPM)
 
 - **Intro**: 32-64 bars.
-- **First drop**: 64-128 bars. Introduces basic kick + rolling bass + atmosphere only.
+- **First drop**: 64-128 bars. Introduces basic kick + rolling bass + atmosphere
+  only.
 - **Short break**: 4-8 bars. Characteristically very short — psy doesn't dwell.
-- **Second drop**: 64-128 bars adds melodic layers, atmospheric pads, voice samples.
-- After 32 bars all elements typically play until end — additive, not subtractive.
+- **Second drop**: 64-128 bars adds melodic layers, atmospheric pads, voice
+  samples.
+- After 32 bars all elements typically play until end — additive, not
+  subtractive.
 
 ### Full-on psytrance (142-148 BPM)
 
-- **Kick / bass dB ratio**: kick 2-3 dB louder than bass (signature). Inverse of techno.
-- **Bass pattern**: 16th-note rolling bass on offbeats 2-3-4 of every kick beat (the "bom-tss-tss-tss" with bass on the tss).
-- **Build**: rising filter sweeps + atmosphere drone + "splash" (cymbal/zap) before drop.
-- **Empty bar before drop is mandatory** — non-negotiable in psy. The genre depends on this contrast.
-- **Drop entry**: kick alone for 1 bar → kick + bass on bar 2 (the "kick-only tease"). Bass entering one bar later than kick is the genre signature.
+- **Kick / bass dB ratio**: kick 2-3 dB louder than bass (signature). Inverse of
+  techno.
+- **Bass pattern**: 16th-note rolling bass on offbeats 2-3-4 of every kick beat
+  (the "bom-tss-tss-tss" with bass on the tss).
+- **Build**: rising filter sweeps + atmosphere drone + "splash" (cymbal/zap)
+  before drop.
+- **Empty bar before drop is mandatory** — non-negotiable in psy. The genre
+  depends on this contrast.
+- **Drop entry**: kick alone for 1 bar → kick + bass on bar 2 (the "kick-only
+  tease"). Bass entering one bar later than kick is the genre signature.
 
 ## Ableton-specific recipes
 
@@ -188,7 +249,8 @@ Bar 16     : 32nd notes + tail cut on beat 4.5  (silence into drop)
 ### Pre-drop: reverse-cymbal stop
 
 - Reverse cymbal audio clip placed so it ends exactly on bar 1|1 of the drop.
-- Master/group fader cut on the last beat before drop (drag automation point to -inf).
+- Master/group fader cut on the last beat before drop (drag automation point to
+  -inf).
 
 ### Pre-drop: reverse-kick lead-in
 
@@ -199,33 +261,38 @@ Bar 16     : 32nd notes + tail cut on beat 4.5  (silence into drop)
 
 ### Breakdown: ghost-kick sidechain
 
-- Create a silent kick MIDI track (4-on-floor, all velocities 0 OR routed to a muted/empty drum pad).
-- Route this track as the sidechain trigger for compressors on pads / bass during the breakdown.
-- Pads + bass continue to pump even though no kick is audible. Maintains rhythmic momentum across the drop-out.
+- Create a silent kick MIDI track (4-on-floor, all velocities 0 OR routed to a
+  muted/empty drum pad).
+- Route this track as the sidechain trigger for compressors on pads / bass
+  during the breakdown.
+- Pads + bass continue to pump even though no kick is audible. Maintains
+  rhythmic momentum across the drop-out.
 
 ### Drop-bar: staggered re-entry automation
 
 - Tracks muted across breakdown stay muted on bar 1 of drop.
-- Unmute via track activator automation on bars 1, 2, 3, 4 (one element per bar).
-- Or use Volume automation per track, ramping from -inf to 0 dB across 1 bar each, staggered.
+- Unmute via track activator automation on bars 1, 2, 3, 4 (one element per
+  bar).
+- Or use Volume automation per track, ramping from -inf to 0 dB across 1 bar
+  each, staggered.
 
 ## Common failures
 
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| Drop feels weak | No silence before bar 1 | Empty last bar of build (no reverb tail either) |
-| "Wall of sound" drop | All elements enter simultaneously on bar 1 | Stagger entries across bars 1-4 (one element per bar) |
-| Sub bass loses impact | Sub played throughout breakdown | HPF roll-off across breakdown, return only at drop |
-| Build out-louds the drop | Master/lead too loud during build | Volume-automate down 2-3 dB across last 4 bars of build |
-| Flat energy across drop | All elements at same velocity bars 17-32 | Add every-4 accent: drop or add one element on bar 4 of every 4-bar phrase |
-| Single-note arps sound robotic | No dyads on lead/pluck | Use 2-note chords (root + 5th) on plucks/leads |
-| Mechanical perc | AI-generated from theory | Reference real track bar-by-bar first, transcribe note-by-note |
-| Repetition fatigue | Same loop 16+ bars without change | Insert micro-variation every 4 bars (single note, velocity tweak, filter open) |
-| Sub overpowers kick or vice versa | Same frequency range | EQ split: punchy kick (60 Hz) + sub (40 Hz), or deep kick + mid bass |
-| Reverb tail kills silence | Reverb send still active in pre-drop bar | Cut reverb send via automation before pre-drop bar |
-| Kick returns late | Kick at 17|1.25 instead of 17|1.0 | Snap kick to exact downbeat |
-| Build melody too rich | Full melodic phrase in build steals drop payload | Build = riser + snare + filter sweeps. Save melody for drop bar |
-| Drop = build energy | Build climbed to 85%, drop is 80% | Drop must equal or exceed highest build energy point |
+| Symptom                           | Cause                                            | Fix                                                                            |
+| --------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------ | --- | --------------------------- |
+| Drop feels weak                   | No silence before bar 1                          | Empty last bar of build (no reverb tail either)                                |
+| "Wall of sound" drop              | All elements enter simultaneously on bar 1       | Stagger entries across bars 1-4 (one element per bar)                          |
+| Sub bass loses impact             | Sub played throughout breakdown                  | HPF roll-off across breakdown, return only at drop                             |
+| Build out-louds the drop          | Master/lead too loud during build                | Volume-automate down 2-3 dB across last 4 bars of build                        |
+| Flat energy across drop           | All elements at same velocity bars 17-32         | Add every-4 accent: drop or add one element on bar 4 of every 4-bar phrase     |
+| Single-note arps sound robotic    | No dyads on lead/pluck                           | Use 2-note chords (root + 5th) on plucks/leads                                 |
+| Mechanical perc                   | AI-generated from theory                         | Reference real track bar-by-bar first, transcribe note-by-note                 |
+| Repetition fatigue                | Same loop 16+ bars without change                | Insert micro-variation every 4 bars (single note, velocity tweak, filter open) |
+| Sub overpowers kick or vice versa | Same frequency range                             | EQ split: punchy kick (60 Hz) + sub (40 Hz), or deep kick + mid bass           |
+| Reverb tail kills silence         | Reverb send still active in pre-drop bar         | Cut reverb send via automation before pre-drop bar                             |
+| Kick returns late                 | Kick at 17                                       | 1.25 instead of 17                                                             | 1.0 | Snap kick to exact downbeat |
+| Build melody too rich             | Full melodic phrase in build steals drop payload | Build = riser + snare + filter sweeps. Save melody for drop bar                |
+| Drop = build energy               | Build climbed to 85%, drop is 80%                | Drop must equal or exceed highest build energy point                           |
 
 ## Worked example — indie-dance subtractive drop (16-bar build → 16-bar drop)
 
@@ -246,16 +313,22 @@ Pad sustain    | X  X  X  X  X  X  X  X  X  X   X   X   X   X   ~   ~ |   X   X 
 Lead motif     | -  -  -  -  -  -  -  -  -  -   -   -   -   -   -   - |   X   X   X
 ```
 
-Bar 16 last beat: cut snare ramp + riser. Pad tail rings. 1 beat anchor.
-Bar 17|1.0: kick + sub + bass-mid + clap + lead motif all return at v110-120. Top elements (hats) re-enter on 17|1.25-1.5.
+Bar 16 last beat: cut snare ramp + riser. Pad tail rings. 1 beat anchor. Bar
+17|1.0: kick + sub + bass-mid + clap + lead motif all return at v110-120. Top
+elements (hats) re-enter on 17|1.25-1.5.
 
 ## When to use
 
 - Any track with a Build → Drop / Build → Peak transition.
 - Indie-dance, melodic-techno, melodic-house, peak-time techno.
-- Choose subtractive for emotional/melodic genres, additive for techno, contrast for peak-time DJ tools.
+- Choose subtractive for emotional/melodic genres, additive for techno, contrast
+  for peak-time DJ tools.
 
 ## Validated in
 
-- Reference analysis: Innellea Spectrum V2 (subtractive, 16-bar build, sub enters at drop bar). Adam Ten "Marrakech" (subtractive). Maceo Plex peak-time sets (contrast).
-- Failure mode source: 2026-05-08 indie-dance Session-view jam — drop felt flat because sub played throughout build and last 2 bars were a snare fill instead of silence.
+- Reference analysis: Innellea Spectrum V2 (subtractive, 16-bar build, sub
+  enters at drop bar). Adam Ten "Marrakech" (subtractive). Maceo Plex peak-time
+  sets (contrast).
+- Failure mode source: 2026-05-08 indie-dance Session-view jam — drop felt flat
+  because sub played throughout build and last 2 bars were a snare fill instead
+  of silence.

--- a/workspace/findings/technique/drop-mechanics.md
+++ b/workspace/findings/technique/drop-mechanics.md
@@ -95,14 +95,137 @@ Sub-bass is the only element the body feels physically before the brain register
 - Sub note: root of the section, sustained 1-2 bars, no rhythm. Let it ring. Rhythm comes from the bass-mid layer.
 - **Avoid**: sub starting at bar 16|4.5 as a "pickup." Kills the drop. Sub starts AT the drop.
 
+### Why this works (psychoacoustics)
+
+- **20-60 Hz range** stimulates the autonomic nervous system (heart rate, arousal response).
+- **Sacculus** (inner ear organ) responds to low-frequency vibrations above ~90 dB SPL → physical pleasure response distinct from auditory perception.
+- Low-frequency timing perception is more accurate than high-frequency, so the listener's body locks onto sub timing before the brain processes the topline.
+- Implication: sub-bass *absence* across breakdown → sub-bass *return* on drop = the most physical moment available in the track. Not just "louder bass" — a different perceptual event.
+- Mix rule: roll bass off through breakdown — automate HPF cutoff from ~30 Hz to ~175 Hz across the build. Drop returns full sub at bar 1 by snapping HPF back to 30 Hz.
+
+## Genre-specific drop mechanics
+
+### Tech house (124-128 BPM, FISHER / Chris Lake / Cloonee / Michael Bibi)
+
+- **Intro**: 32 bars drums-only (DJ-friendly).
+- **Breakdown**: 8 bars, beatless or half-time.
+- **Build**: 8 bars (fail-safe length — longer feels indulgent).
+- **Drop A**: 32 bars sparse. Bass at ~5 sixteenth-note hits per bar, lead minimal.
+- **Element rotation rule**: every 8 bars swap which element holds attention.
+- **Signature**: vocal chop or one-shot stab drops in for 1 bar at every 4-bar accent.
+- **Sidechain**: kick → bass with fast attack, fast release, high ratio, low threshold (French-house pump). Heavier than indie-dance sidechain.
+
+### Peak-time techno (130-138 BPM, Adam Beyer / Layton Giordani / Maceo Plex)
+
+- **Build technique**: automate LPF cutoff on bassline through breakdown for tension. Don't add new layers — modulate existing ones.
+- **Reverse-kick pre-drop**: duplicate kick channel, delete all but the last hit before drop, reverse the audio. Lands as a "whoosh into kick return."
+- **Drop construction**: relentless 4-on-floor + driving sub + 1-2 atmospheric/lead elements only. Density comes from velocity and mix, not layer count.
+- **Hard-pause drop** (Beyer / Maceo signature): full energy → 1-2 bars total silence → return at full. Pause must be ≥1 bar to register; ≤0.5 bar reads as a glitch.
+- **Hypnotic / Kraftwerk principle**: 16+ bars before any new layer. Change comes from automation (filter, reverb send, drive), not new instruments. Repetition IS the content.
+
+### Melodic techno (122-128 BPM, Innellea / Afterlife / Tale of Us)
+
+- **Long break**: 32-bar breakdown is normal. Allows full emotional reset before drop 2.
+- **Drop entry order**: kick + rolling bass first; top-bass (octave higher) layers in 8 bars later. Two-stage drop.
+- **Harmonic shift trick**: late in arrangement, transpose root down a fourth (e.g. Dm → Am) for a resolution / "we got there" feel on the final drop.
+- **FX kit**: downlifter (drop impact), short sweep (transitions), uplifter (build), snare roll (build climax). Use all four — each owns a transition role.
+- **Atmospheric layers**: tonal atmosphere on the root + vocal atmosphere fill the drop without crowding mids. Atmosphere is the "soul" of the genre.
+- **"Glitch" detail**: shorten lead notes, double rhythm, micro-stutter — adds character without changing the line.
+
+### Indie dance (118-124 BPM, Adam Ten / Mita Gami / Innellea)
+
+- **Two-part drop**: 32 bars total = 16 bars bass-focused (root locked, no melody) + 16 bars melodic B-part (lead enters).
+- **Single drop sufficient**: indie dance often runs ONE main drop with variation, not the EDM two-drop standard. Save the second drop for genuine peak moments.
+- **Melodic element handling**: filter-automated, subtle during drop, opens up in breakdown (inverse of typical EDM).
+- **Adam Ten / Mita Gami / Maccabi House signature**: psychedelic-house Israeli flavor, deep emotional aesthetic, organic perc + funk DNA. Sidechain present but lighter than tech house.
+- See `indie-dance-microsection-arc` for the 4-microsection rule that prevents flat 8-bar loops.
+
+### Progressive psytrance (138-142 BPM)
+
+- **Intro**: 32-64 bars.
+- **First drop**: 64-128 bars. Introduces basic kick + rolling bass + atmosphere only.
+- **Short break**: 4-8 bars. Characteristically very short — psy doesn't dwell.
+- **Second drop**: 64-128 bars adds melodic layers, atmospheric pads, voice samples.
+- After 32 bars all elements typically play until end — additive, not subtractive.
+
+### Full-on psytrance (142-148 BPM)
+
+- **Kick / bass dB ratio**: kick 2-3 dB louder than bass (signature). Inverse of techno.
+- **Bass pattern**: 16th-note rolling bass on offbeats 2-3-4 of every kick beat (the "bom-tss-tss-tss" with bass on the tss).
+- **Build**: rising filter sweeps + atmosphere drone + "splash" (cymbal/zap) before drop.
+- **Empty bar before drop is mandatory** — non-negotiable in psy. The genre depends on this contrast.
+- **Drop entry**: kick alone for 1 bar → kick + bass on bar 2 (the "kick-only tease"). Bass entering one bar later than kick is the genre signature.
+
+## Ableton-specific recipes
+
+### Build-up: HPF sweep on bass/sub (psychoacoustic sub absence)
+
+- Insert EQ Eight on bass/sub bus.
+- Automate HPF cutoff: 30 Hz at start of breakdown → 175 Hz at end of build.
+- 8-bar linear ramp typical. Snap back to 30 Hz on bar 1 of drop.
+
+### Build-up: snare roll compounding
+
+MIDI clip on snare with velocity ramp + note-density compounding:
+
+```
+Bars 1-4   : quarter notes,  velocity 60 → 75
+Bars 5-8   : 8th notes,      velocity 75 → 90
+Bars 9-12  : 16th notes,     velocity 90 → 110
+Bars 13-15 : 32nd notes,     velocity 110 → 120
+Bar 16     : 32nd notes + tail cut on beat 4.5  (silence into drop)
+```
+
+### Build-up: riser via Analog or Operator
+
+- Single sustained note (root or fifth).
+- Pitch envelope: +12 semitones rising over 8 bars.
+- LPF cutoff: closed → fully open across same 8 bars.
+- LPF resonance: 30% → 80% climbing.
+- Reverb send dry/wet: 20% → 60% climbing.
+- Volume: ramp up 6-8 dB across the same window.
+
+### Pre-drop: reverse-cymbal stop
+
+- Reverse cymbal audio clip placed so it ends exactly on bar 1|1 of the drop.
+- Master/group fader cut on the last beat before drop (drag automation point to -inf).
+
+### Pre-drop: reverse-kick lead-in
+
+- Duplicate the kick clip from the drop section.
+- Delete all hits except the last one before bar 1.
+- Reverse the audio (clip context menu → Reverse).
+- Place 1 bar before the drop — the reversed kick swells into the kick return.
+
+### Breakdown: ghost-kick sidechain
+
+- Create a silent kick MIDI track (4-on-floor, all velocities 0 OR routed to a muted/empty drum pad).
+- Route this track as the sidechain trigger for compressors on pads / bass during the breakdown.
+- Pads + bass continue to pump even though no kick is audible. Maintains rhythmic momentum across the drop-out.
+
+### Drop-bar: staggered re-entry automation
+
+- Tracks muted across breakdown stay muted on bar 1 of drop.
+- Unmute via track activator automation on bars 1, 2, 3, 4 (one element per bar).
+- Or use Volume automation per track, ramping from -inf to 0 dB across 1 bar each, staggered.
+
 ## Common failures
 
-- **Drop without prior silence**: full groove → "drop" = same energy in/out. Listener does not feel a drop.
-- **Sub bass enters too early**: sub plays in build → drop sub-entry has no contrast → body doesn't move.
-- **Too many elements at once**: adding 6 new elements on bar 17 = noise, not climax. Keep drop = main groove + one new lead/motif. Hold something in reserve for bar 25 / 33.
-- **Fill instead of silence**: snare roll into drop = energy peaks during the roll, drop is anti-climax. Replace last 1-2 bars of fill with silence + atmospheric tail.
-- **Kick returns late**: kick at 17|1.25 instead of 17|1.0 = drop feels stumbled. Body expects downbeat impact.
-- **Build melody too rich**: writing a full melodic phrase in the build steals the drop's emotional payload. Build = riser + snare + filter sweeps. Save melody for drop.
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Drop feels weak | No silence before bar 1 | Empty last bar of build (no reverb tail either) |
+| "Wall of sound" drop | All elements enter simultaneously on bar 1 | Stagger entries across bars 1-4 (one element per bar) |
+| Sub bass loses impact | Sub played throughout breakdown | HPF roll-off across breakdown, return only at drop |
+| Build out-louds the drop | Master/lead too loud during build | Volume-automate down 2-3 dB across last 4 bars of build |
+| Flat energy across drop | All elements at same velocity bars 17-32 | Add every-4 accent: drop or add one element on bar 4 of every 4-bar phrase |
+| Single-note arps sound robotic | No dyads on lead/pluck | Use 2-note chords (root + 5th) on plucks/leads |
+| Mechanical perc | AI-generated from theory | Reference real track bar-by-bar first, transcribe note-by-note |
+| Repetition fatigue | Same loop 16+ bars without change | Insert micro-variation every 4 bars (single note, velocity tweak, filter open) |
+| Sub overpowers kick or vice versa | Same frequency range | EQ split: punchy kick (60 Hz) + sub (40 Hz), or deep kick + mid bass |
+| Reverb tail kills silence | Reverb send still active in pre-drop bar | Cut reverb send via automation before pre-drop bar |
+| Kick returns late | Kick at 17|1.25 instead of 17|1.0 | Snap kick to exact downbeat |
+| Build melody too rich | Full melodic phrase in build steals drop payload | Build = riser + snare + filter sweeps. Save melody for drop bar |
+| Drop = build energy | Build climbed to 85%, drop is 80% | Drop must equal or exceed highest build energy point |
 
 ## Worked example — indie-dance subtractive drop (16-bar build → 16-bar drop)
 

--- a/workspace/findings/technique/drop-mechanics.md
+++ b/workspace/findings/technique/drop-mechanics.md
@@ -1,0 +1,138 @@
+---
+name: drop-mechanics
+description: Drop construction craft — 3 drop types (subtractive/additive/contrast), build → silence → release timing, kick-return rules, sub-bass-first-hit psychology, why silence beats fill before drop
+type: technique
+---
+
+# Drop mechanics — build, silence, release
+
+The drop is not the moment the bass hits. The drop is the contrast between bar 16 (silence/anchor) and bar 17 (full energy). Without that contrast, no drop — just a louder section.
+
+## The 3 drop types
+
+### 1. Subtractive drop (most common in indie-dance / melodic-techno)
+
+Strip the groove down across the build. Drop = elements return.
+
+```
+Bars 1-8   (Build A): kick + bass + 1 perc layer + sustained pad
+Bars 9-12  (Build B): drop bass, drop perc, riser enters, snare 16th ramp
+Bars 13-16 (Pre-drop): drop kick, only riser + atmospheric pad + snare ramp
+Bar 16|4   : everything cuts. 1 beat of silence.
+Bar 17|1   : kick + sub + groove + lead all return at full energy.
+```
+
+The listener's nervous system fills the silence with anticipation. When elements return, brain reads it as "release."
+
+### 2. Additive drop (techno, peak-time)
+
+Build density 16 bars without removing anything. Land everything at once on bar 1 of next section.
+
+```
+Bars 1-4   : kick + bass
+Bars 5-8   : add hat
+Bars 9-12  : add shaker + pad swell
+Bars 13-16 : add lead motif teasing + riser climb
+Bar 17|1   : sub-bass joins for first time + full chord stab. Drop = sub entry.
+```
+
+Sub-bass entering for the first time IS the drop. Reserve sub for this moment — if sub plays in the build, the drop loses 50% of impact.
+
+### 3. Contrast drop (Maceo Plex / Adam Beyer peak-time)
+
+Full energy → hard pause 1-2 bars → shock-return at full.
+
+```
+Bars 1-14  : full main groove, all elements
+Bars 15-16 : everything cuts except a single sustained pad note + reverse cymbal
+Bar 17|1   : full groove returns identical to bar 14. No transition. Just shock.
+```
+
+Works when the groove is already locked — listener wants it back. Pause makes return feel inevitable.
+
+## Build → silence → release timing rules
+
+### Build phase (8 or 16 bars)
+
+- Density grows but melodic content stays simple. Don't add new chords during build — emotional payload lands on the drop, not the build.
+- Riser starts 8 bars before drop. Filter sweep opens across full 8 bars.
+- Snare 16th-note ramp (see `pre-drop-fill-formula`) starts 16 bars before drop.
+
+### Silence/anchor moment (last 1-2 bars before drop)
+
+Two valid options:
+
+- **Hard silence**: cut everything for 1 beat to 1 bar. Maximum contrast.
+- **Anchor only**: keep one sustained element (pad note, riser tail, vocal "ahh") through the gap. Less brutal, more emotional.
+
+**Why silence > fill**: a fill (drum roll, snare blast, big riser climb) tells the brain "energy peaks here." A silence/anchor tells the brain "energy is gone — what comes next?" The second framing is what makes the drop hit. Fills sit at the same energy level as the drop, so the drop feels equal, not bigger.
+
+### Drop bar (bar 1 of new section) — entry order WITHIN the bar
+
+Order elements in time across beat 1 to layer the impact:
+
+```
+Bar 17|1.0   : kick (downbeat — anchors the bar)
+Bar 17|1.0   : sub-bass first hit (same instant — gives weight)
+Bar 17|1.25  : groove perc enters (off-beat — confirms the rhythm)
+Bar 17|1.5   : top elements (lead motif, hat, ride) — fill the bar
+```
+
+Kick + sub on exact downbeat = body feels the impact. Top elements 8th-note later = ear hears the texture. Both at once = mush.
+
+## Kick-return rules
+
+- Kick must return on bar 17|1.0 exactly. Not 17|1.25, not delayed by an 8th.
+- If kick was absent for last 2 bars of build, return at velocity ≥ build kick velocity. Often louder by 5-10 (v110 → v120) for first 4 bars.
+- Don't taper the kick on bars 17-20. Full velocity for at least 8 bars before any variation.
+
+## Sub-bass-first-hit psychology
+
+Sub-bass is the only element the body feels physically before the brain registers it. Use this:
+
+- Reserve sub for the drop. If sub plays in build, drop sub-feeling is gone.
+- Sub first hit at bar 17|1.0 is the moment the listener's chest moves. That IS the drop.
+- Sub note: root of the section, sustained 1-2 bars, no rhythm. Let it ring. Rhythm comes from the bass-mid layer.
+- **Avoid**: sub starting at bar 16|4.5 as a "pickup." Kills the drop. Sub starts AT the drop.
+
+## Common failures
+
+- **Drop without prior silence**: full groove → "drop" = same energy in/out. Listener does not feel a drop.
+- **Sub bass enters too early**: sub plays in build → drop sub-entry has no contrast → body doesn't move.
+- **Too many elements at once**: adding 6 new elements on bar 17 = noise, not climax. Keep drop = main groove + one new lead/motif. Hold something in reserve for bar 25 / 33.
+- **Fill instead of silence**: snare roll into drop = energy peaks during the roll, drop is anti-climax. Replace last 1-2 bars of fill with silence + atmospheric tail.
+- **Kick returns late**: kick at 17|1.25 instead of 17|1.0 = drop feels stumbled. Body expects downbeat impact.
+- **Build melody too rich**: writing a full melodic phrase in the build steals the drop's emotional payload. Build = riser + snare + filter sweeps. Save melody for drop.
+
+## Worked example — indie-dance subtractive drop (16-bar build → 16-bar drop)
+
+Pattern map (X = playing, - = silent, ~ = sustained tail/riser):
+
+```
+Element        |B1 B2 B3 B4 B5 B6 B7 B8 B9 B10 B11 B12 B13 B14 B15 B16 | DROP B17 B18...
+---------------|------------------------------------------------------ | ---------------
+Kick C1        | X  X  X  X  X  X  X  X  X  X   X   X   -   -   -   - |   X   X   X
+Sub bass A0    | -  -  -  -  -  -  -  -  -  -   -   -   -   -   -   - |   X   ~   X
+Bass-mid C2    | X  X  X  X  X  X  X  X  -  -   -   -   -   -   -   - |   X   X   X
+Closed hat F#1 | X  X  X  X  X  X  X  X  X  X   X   X   -   -   -   - |   X   X   X
+Open hat A#1   | -  -  -  -  X  X  X  X  -  -   -   -   -   -   -   - |   X   X   X
+Clap E1        | X  X  X  X  X  X  X  X  X  X   X   X   -   -   -   - |   X   X   X
+Snare ramp E1  | -  -  -  -  -  -  -  -  X  X   X   X   X   X   X   X |   -   -   -
+Riser FX       | -  -  -  -  -  -  -  -  X  X   X   X   X   X   X   X |   -   -   -
+Pad sustain    | X  X  X  X  X  X  X  X  X  X   X   X   X   X   ~   ~ |   X   X   X
+Lead motif     | -  -  -  -  -  -  -  -  -  -   -   -   -   -   -   - |   X   X   X
+```
+
+Bar 16 last beat: cut snare ramp + riser. Pad tail rings. 1 beat anchor.
+Bar 17|1.0: kick + sub + bass-mid + clap + lead motif all return at v110-120. Top elements (hats) re-enter on 17|1.25-1.5.
+
+## When to use
+
+- Any track with a Build → Drop / Build → Peak transition.
+- Indie-dance, melodic-techno, melodic-house, peak-time techno.
+- Choose subtractive for emotional/melodic genres, additive for techno, contrast for peak-time DJ tools.
+
+## Validated in
+
+- Reference analysis: Innellea Spectrum V2 (subtractive, 16-bar build, sub enters at drop bar). Adam Ten "Marrakech" (subtractive). Maceo Plex peak-time sets (contrast).
+- Failure mode source: 2026-05-08 indie-dance Session-view jam — drop felt flat because sub played throughout build and last 2 bars were a snare fill instead of silence.

--- a/workspace/findings/technique/energy-curve-math.md
+++ b/workspace/findings/technique/energy-curve-math.md
@@ -1,0 +1,158 @@
+---
+name: energy-curve-math
+description: Energy as measurable 0-100% per bar — concrete formula (active elements × velocity × density), every-4 accent, every-8 structural shift, every-16 section change, sample 128-bar curve table
+type: technique
+---
+
+# Energy curve math — measurable arc per bar
+
+"Storytelling" in dance music is an energy curve. If you can plot it bar-by-bar and the line goes flat for 16+ bars without intent, the track has no story. This finding gives a concrete way to compute and shape that curve.
+
+## Formula — energy per bar (0-100%)
+
+For a single bar:
+
+```
+energy(bar) = sum over each active element of:
+              ( velocity_avg / 127 ) × density_factor × weight
+```
+
+Where:
+
+- **velocity_avg**: mean velocity of all notes in that bar for that element (0-127).
+- **density_factor**: notes_in_bar / max_useful_notes. For drums use 16 (16th grid). For pad use 1 (sustained). For bass use 8.
+- **weight**: per-element importance. Suggested defaults:
+
+| Element       | Weight |
+|---------------|--------|
+| Kick          | 1.0    |
+| Sub bass      | 0.9    |
+| Bass-mid      | 0.7    |
+| Snare / clap  | 0.6    |
+| Lead          | 0.6    |
+| Pad chord     | 0.5    |
+| Hi-hat        | 0.3    |
+| Riser FX      | 0.4    |
+| Perc top      | 0.3    |
+
+Normalize to 0-100% by dividing the sum by the max possible (all elements at full velocity + full density).
+
+Use the formula as a check, not a goal. The number tells you whether bar 33 is actually higher than bar 32 — protects against "I think this builds" when the math says it's flat.
+
+## Three timing rules — the fractal grid
+
+Dance music repeats at 4 / 8 / 16 / 32 / 64 / 128 bars. Each scale wants a different kind of change.
+
+### Every-4 accent (small)
+
+Every 4 bars, change ONE small thing. Examples:
+
+- Add a single perc hit on bar 4|4
+- Open hat on bar 4 only (not bars 1-3)
+- Snare ghost note that wasn't in bars 1-3
+- Filter cutoff +5%
+
+Listener does not consciously notice but feels the bar 4 lift. Without this, 4-bar phrases feel like loops, not phrases.
+
+### Every-8 structural shift (medium)
+
+Every 8 bars, one element changes role OR a sub-element enters/exits. Examples:
+
+- Bass switches from off-beat stabs to walking bassline
+- Pad opens from drone to triad
+- New shaker layer enters
+- Lead motif octave-up
+
+This is the boundary listeners feel as "something just happened" without being able to name it.
+
+### Every-16 section change (large)
+
+Every 16 bars, full layer in or out. This is the visible structure: intro / build / main / breakdown. Examples:
+
+- All percussion enters
+- Bass exits (breakdown)
+- Lead enters for first time
+- Drop happens
+
+These are the section boundaries the listener consciously tracks.
+
+## How to read an existing track's energy curve
+
+Bar-by-bar listening method (use on reference tracks):
+
+1. Open the reference track in your DAW with bar grid aligned.
+2. For each bar 1-32 (then sample every 8 bars after), write down which elements are playing.
+3. Estimate velocity_avg per element (loud/medium/soft → 100/75/50).
+4. Compute energy(bar). Round to nearest 5%.
+5. Plot. Look for:
+   - Where does the curve climb? (build sections)
+   - Where does it drop suddenly? (breakdown entry, hard cuts)
+   - Where does it spike? (drops)
+   - Are there flat 16+ bar stretches with no every-4 or every-8 movement? (probably not — that's why it sounds good)
+6. Steal the shape, not the notes.
+
+## Sample 128-bar indie-dance energy curve
+
+Target reference: Innellea Spectrum V2 / Adam Ten "Marrakech" hybrid. Indie-dance, 124 BPM.
+
+```
+Section      | Bar | Energy% | Element delta (what changed this bar)
+-------------|-----|---------|------------------------------------------
+Intro A      |   1 |    15   | pad drone enters (root only)
+             |   5 |    18   | every-4: pad adds 5th
+             |   9 |    25   | every-8: kick enters (4-on-floor)
+             |  13 |    28   | every-4: closed hat opens
+Build A      |  17 |    40   | every-16: bass enters (off-beat stabs)
+             |  21 |    45   | every-4: clap enters bar 4|2 only
+             |  25 |    52   | every-8: open hat layer + bass color tones
+             |  29 |    58   | every-4: snare ghost ramp begins
+Build B      |  33 |    65   | every-16: lead motif teases (1 hit per bar)
+             |  37 |    70   | every-4: snare ramp gets denser
+             |  41 |    75   | every-8: riser enters, kick still playing
+             |  45 |    78   | every-4: 2nd lead hit per bar
+Pre-drop     |  49 |    82   | kick drops, riser climbs, snare 32nds
+             |  53 |    72   | bass drops, only riser + pad + snare blast
+             |  57 |    50   | last 2 bars: only pad tail + reverse cymbal
+             |  60 |     5   | bar 60|4: hard silence (1 beat anchor)
+Drop / Main  |  61 |    95   | EVERYTHING returns: kick + sub + bass + lead + perc
+             |  65 |    95   | every-4: lead motif variation
+             |  69 |    95   | every-8: shaker enters, lead octave-up
+             |  73 |    90   | every-4: pad lifts (chord substitution)
+Breakdown    |  77 |    35   | every-16: drums + bass exit, only pad + lead sustain
+             |  81 |    30   | every-4: lead motif fragments (half the notes)
+             |  85 |    40   | every-8: sub-bass returns (foreshadow drop 2)
+             |  89 |    50   | every-4: snare ramp re-enters
+Build C      |  93 |    65   | every-16: kick returns (no bass yet)
+             |  97 |    75   | every-4: bass off-beat back
+             | 101 |    82   | every-8: full perc stack returns
+             | 105 |    85   | every-4: filter open + riser
+Drop 2       | 109 |   100   | EVERYTHING + new lead motif (peak moment)
+             | 113 |   100   | every-4: dub stab on bar 4|4
+             | 117 |    95   | every-8: lead simplifies (less notes, more sustain)
+             | 121 |    85   | every-4: pad lifts away
+Outro        | 125 |    50   | every-16: lead exits, drum solo
+             | 128 |    20   | tail: only kick fading
+```
+
+Two complete arc shapes (rise → drop → fall) in 128 bars. Drop 2 (bar 109) is 5% higher than drop 1 (bar 61) — second drop must be bigger or equal, never lower.
+
+## Common failures
+
+- **Flat 16-bar stretches**: same elements at same velocity bars 33-48 → loop, not phrase. Add every-4 or every-8 movement.
+- **Drop lower than build peak**: build climbs to 85% then drop is 80% → drop feels like a release, not a peak. Drop must equal or exceed the highest build energy.
+- **Drop 2 = Drop 1**: identical energy at bars 61 and 109 → no second-drop payoff. Drop 2 needs +5-10% (new element, octave-up lead, fuller perc).
+- **Breakdown to 0%**: full silence in breakdown → loses the listener. Keep at least pad + one melodic element at 30-40% energy.
+- **Build flat then sudden drop**: 50% bars 1-48, 95% bar 49 → drop feels arbitrary because there was no curve climbing into it.
+
+## When to use
+
+- Plotting an arrangement before writing clips. Sketch the curve, then place elements to match the curve shape.
+- Diagnosing a track that "feels boring" — compute the curve, find the flat stretches, add every-4 movement.
+- Comparing your track to a reference track — plot both, see where shapes diverge.
+- Confirming a drop is actually a drop. If energy(drop_bar) is not the highest point in the section → not a drop.
+
+## Validated in
+
+- Reference analysis: Innellea Spectrum V2 (full template — every-4/8/16 rules visible across all sections).
+- Failure mode source: 2026-05-08 indie-dance jam where every layer played every bar = flat 80% line for 16 bars = "no story." Computing the curve made the flatness obvious.
+- Curve table cross-checked against `pre-drop-fill-formula` (bar 49-60 of sample = same Build B → silence → drop pattern).

--- a/workspace/findings/technique/energy-curve-math.md
+++ b/workspace/findings/technique/energy-curve-math.md
@@ -76,6 +76,43 @@ Every 16 bars, full layer in or out. This is the visible structure: intro / buil
 
 These are the section boundaries the listener consciously tracks.
 
+### Every-32 macro boundary
+
+Every 32 bars marks a macro section transition: intro → break → drop → break → drop → outro. Cross-genre rule. Track structure decisions live at this scale.
+
+## Section-length conventions per genre
+
+All sections divisible by 8. DJ-friendly tracks need a 16+ bar percussive intro and outro for mixing.
+
+| Genre | BPM | Intro | Breakdown | Build | Drop A | Drop B |
+|-------|-----|-------|-----------|-------|--------|--------|
+| Tech house | 124-128 | 32 | 16-32 | 8 | 32 | 32 |
+| Peak-time techno | 130-138 | 32-64 | 16 | 8-16 | 32-64 | 32-64 |
+| Melodic techno | 122-128 | 16-32 | 32 | 8-16 | 32 | 32 |
+| Indie dance | 118-124 | 16-32 | 16-32 | 8 | 32 (16 bass + 16 melodic B-part) | 32 |
+| Progressive psy | 138-142 | 32-64 | 4-8 | 8-16 | 64-128 | 64-128 |
+| Full-on psy | 142-148 | 16-32 | 8-16 | 8 | 32-64 | 32-64 |
+
+Use as a default skeleton. Diverge intentionally, not by accident.
+
+## The 1-9 reference scoring scale
+
+Quick way to compare your in-progress arrangement to a reference track without building a full energy table.
+
+Method:
+
+1. Pick a reference track and divide it into 8-bar blocks.
+2. Score each 8-bar block from 1 (silence / atmospheric only) to 9 (peak — every element at full velocity).
+3. Write the sequence as a number string. Example reference (Innellea-style melodic techno):
+   ```
+   2-3-4-5-7-9-3-8-9-5
+   ```
+   Reads as: quiet intro climbing, breakdown to 3, build to 8, peak at 9, outro back to 5.
+4. Score your own track the same way.
+5. Compare. If yours is `5-5-5-5-7-7-5-5-5-5` → flat-curve problem. If yours is `2-9-2-9-2-9-2-9` → too oscillating, no arc.
+
+A good track has a sequence that rises, peaks once or twice, and falls. The numbers form a shape, not a line.
+
 ## How to read an existing track's energy curve
 
 Bar-by-bar listening method (use on reference tracks):

--- a/workspace/findings/technique/energy-curve-math.md
+++ b/workspace/findings/technique/energy-curve-math.md
@@ -1,12 +1,17 @@
 ---
 name: energy-curve-math
-description: Energy as measurable 0-100% per bar — concrete formula (active elements × velocity × density), every-4 accent, every-8 structural shift, every-16 section change, sample 128-bar curve table
+description:
+  Energy as measurable 0-100% per bar — concrete formula (active elements ×
+  velocity × density), every-4 accent, every-8 structural shift, every-16
+  section change, sample 128-bar curve table
 type: technique
 ---
 
 # Energy curve math — measurable arc per bar
 
-"Storytelling" in dance music is an energy curve. If you can plot it bar-by-bar and the line goes flat for 16+ bars without intent, the track has no story. This finding gives a concrete way to compute and shape that curve.
+"Storytelling" in dance music is an energy curve. If you can plot it bar-by-bar
+and the line goes flat for 16+ bars without intent, the track has no story. This
+finding gives a concrete way to compute and shape that curve.
 
 ## Formula — energy per bar (0-100%)
 
@@ -19,29 +24,35 @@ energy(bar) = sum over each active element of:
 
 Where:
 
-- **velocity_avg**: mean velocity of all notes in that bar for that element (0-127).
-- **density_factor**: notes_in_bar / max_useful_notes. For drums use 16 (16th grid). For pad use 1 (sustained). For bass use 8.
+- **velocity_avg**: mean velocity of all notes in that bar for that element
+  (0-127).
+- **density_factor**: notes_in_bar / max_useful_notes. For drums use 16 (16th
+  grid). For pad use 1 (sustained). For bass use 8.
 - **weight**: per-element importance. Suggested defaults:
 
-| Element       | Weight |
-|---------------|--------|
-| Kick          | 1.0    |
-| Sub bass      | 0.9    |
-| Bass-mid      | 0.7    |
-| Snare / clap  | 0.6    |
-| Lead          | 0.6    |
-| Pad chord     | 0.5    |
-| Hi-hat        | 0.3    |
-| Riser FX      | 0.4    |
-| Perc top      | 0.3    |
+| Element      | Weight |
+| ------------ | ------ |
+| Kick         | 1.0    |
+| Sub bass     | 0.9    |
+| Bass-mid     | 0.7    |
+| Snare / clap | 0.6    |
+| Lead         | 0.6    |
+| Pad chord    | 0.5    |
+| Hi-hat       | 0.3    |
+| Riser FX     | 0.4    |
+| Perc top     | 0.3    |
 
-Normalize to 0-100% by dividing the sum by the max possible (all elements at full velocity + full density).
+Normalize to 0-100% by dividing the sum by the max possible (all elements at
+full velocity + full density).
 
-Use the formula as a check, not a goal. The number tells you whether bar 33 is actually higher than bar 32 — protects against "I think this builds" when the math says it's flat.
+Use the formula as a check, not a goal. The number tells you whether bar 33 is
+actually higher than bar 32 — protects against "I think this builds" when the
+math says it's flat.
 
 ## Three timing rules — the fractal grid
 
-Dance music repeats at 4 / 8 / 16 / 32 / 64 / 128 bars. Each scale wants a different kind of change.
+Dance music repeats at 4 / 8 / 16 / 32 / 64 / 128 bars. Each scale wants a
+different kind of change.
 
 ### Every-4 accent (small)
 
@@ -52,7 +63,8 @@ Every 4 bars, change ONE small thing. Examples:
 - Snare ghost note that wasn't in bars 1-3
 - Filter cutoff +5%
 
-Listener does not consciously notice but feels the bar 4 lift. Without this, 4-bar phrases feel like loops, not phrases.
+Listener does not consciously notice but feels the bar 4 lift. Without this,
+4-bar phrases feel like loops, not phrases.
 
 ### Every-8 structural shift (medium)
 
@@ -63,11 +75,13 @@ Every 8 bars, one element changes role OR a sub-element enters/exits. Examples:
 - New shaker layer enters
 - Lead motif octave-up
 
-This is the boundary listeners feel as "something just happened" without being able to name it.
+This is the boundary listeners feel as "something just happened" without being
+able to name it.
 
 ### Every-16 section change (large)
 
-Every 16 bars, full layer in or out. This is the visible structure: intro / build / main / breakdown. Examples:
+Every 16 bars, full layer in or out. This is the visible structure: intro /
+build / main / breakdown. Examples:
 
 - All percussion enters
 - Bass exits (breakdown)
@@ -78,59 +92,70 @@ These are the section boundaries the listener consciously tracks.
 
 ### Every-32 macro boundary
 
-Every 32 bars marks a macro section transition: intro → break → drop → break → drop → outro. Cross-genre rule. Track structure decisions live at this scale.
+Every 32 bars marks a macro section transition: intro → break → drop → break →
+drop → outro. Cross-genre rule. Track structure decisions live at this scale.
 
 ## Section-length conventions per genre
 
-All sections divisible by 8. DJ-friendly tracks need a 16+ bar percussive intro and outro for mixing.
+All sections divisible by 8. DJ-friendly tracks need a 16+ bar percussive intro
+and outro for mixing.
 
-| Genre | BPM | Intro | Breakdown | Build | Drop A | Drop B |
-|-------|-----|-------|-----------|-------|--------|--------|
-| Tech house | 124-128 | 32 | 16-32 | 8 | 32 | 32 |
-| Peak-time techno | 130-138 | 32-64 | 16 | 8-16 | 32-64 | 32-64 |
-| Melodic techno | 122-128 | 16-32 | 32 | 8-16 | 32 | 32 |
-| Indie dance | 118-124 | 16-32 | 16-32 | 8 | 32 (16 bass + 16 melodic B-part) | 32 |
-| Progressive psy | 138-142 | 32-64 | 4-8 | 8-16 | 64-128 | 64-128 |
-| Full-on psy | 142-148 | 16-32 | 8-16 | 8 | 32-64 | 32-64 |
+| Genre            | BPM     | Intro | Breakdown | Build | Drop A                           | Drop B |
+| ---------------- | ------- | ----- | --------- | ----- | -------------------------------- | ------ |
+| Tech house       | 124-128 | 32    | 16-32     | 8     | 32                               | 32     |
+| Peak-time techno | 130-138 | 32-64 | 16        | 8-16  | 32-64                            | 32-64  |
+| Melodic techno   | 122-128 | 16-32 | 32        | 8-16  | 32                               | 32     |
+| Indie dance      | 118-124 | 16-32 | 16-32     | 8     | 32 (16 bass + 16 melodic B-part) | 32     |
+| Progressive psy  | 138-142 | 32-64 | 4-8       | 8-16  | 64-128                           | 64-128 |
+| Full-on psy      | 142-148 | 16-32 | 8-16      | 8     | 32-64                            | 32-64  |
 
 Use as a default skeleton. Diverge intentionally, not by accident.
 
 ## The 1-9 reference scoring scale
 
-Quick way to compare your in-progress arrangement to a reference track without building a full energy table.
+Quick way to compare your in-progress arrangement to a reference track without
+building a full energy table.
 
 Method:
 
 1. Pick a reference track and divide it into 8-bar blocks.
-2. Score each 8-bar block from 1 (silence / atmospheric only) to 9 (peak — every element at full velocity).
-3. Write the sequence as a number string. Example reference (Innellea-style melodic techno):
+2. Score each 8-bar block from 1 (silence / atmospheric only) to 9 (peak — every
+   element at full velocity).
+3. Write the sequence as a number string. Example reference (Innellea-style
+   melodic techno):
    ```
    2-3-4-5-7-9-3-8-9-5
    ```
-   Reads as: quiet intro climbing, breakdown to 3, build to 8, peak at 9, outro back to 5.
+   Reads as: quiet intro climbing, breakdown to 3, build to 8, peak at 9, outro
+   back to 5.
 4. Score your own track the same way.
-5. Compare. If yours is `5-5-5-5-7-7-5-5-5-5` → flat-curve problem. If yours is `2-9-2-9-2-9-2-9` → too oscillating, no arc.
+5. Compare. If yours is `5-5-5-5-7-7-5-5-5-5` → flat-curve problem. If yours is
+   `2-9-2-9-2-9-2-9` → too oscillating, no arc.
 
-A good track has a sequence that rises, peaks once or twice, and falls. The numbers form a shape, not a line.
+A good track has a sequence that rises, peaks once or twice, and falls. The
+numbers form a shape, not a line.
 
 ## How to read an existing track's energy curve
 
 Bar-by-bar listening method (use on reference tracks):
 
 1. Open the reference track in your DAW with bar grid aligned.
-2. For each bar 1-32 (then sample every 8 bars after), write down which elements are playing.
+2. For each bar 1-32 (then sample every 8 bars after), write down which elements
+   are playing.
 3. Estimate velocity_avg per element (loud/medium/soft → 100/75/50).
 4. Compute energy(bar). Round to nearest 5%.
 5. Plot. Look for:
    - Where does the curve climb? (build sections)
    - Where does it drop suddenly? (breakdown entry, hard cuts)
    - Where does it spike? (drops)
-   - Are there flat 16+ bar stretches with no every-4 or every-8 movement? (probably not — that's why it sounds good)
+   - Are there flat 16+ bar stretches with no every-4 or every-8 movement?
+     (probably not — that's why it sounds good)
 6. Steal the shape, not the notes.
 
 ## Sample 128-bar indie-dance energy curve
 
-Target reference: Innellea Spectrum V2 / Adam Ten "Marrakech" hybrid. Indie-dance, 124 BPM.
+Target reference: Innellea Spectrum V2 / Adam Ten "Marrakech" hybrid.
+Indie-dance, 124 BPM.
 
 ```
 Section      | Bar | Energy% | Element delta (what changed this bar)
@@ -171,25 +196,40 @@ Outro        | 125 |    50   | every-16: lead exits, drum solo
              | 128 |    20   | tail: only kick fading
 ```
 
-Two complete arc shapes (rise → drop → fall) in 128 bars. Drop 2 (bar 109) is 5% higher than drop 1 (bar 61) — second drop must be bigger or equal, never lower.
+Two complete arc shapes (rise → drop → fall) in 128 bars. Drop 2 (bar 109) is 5%
+higher than drop 1 (bar 61) — second drop must be bigger or equal, never lower.
 
 ## Common failures
 
-- **Flat 16-bar stretches**: same elements at same velocity bars 33-48 → loop, not phrase. Add every-4 or every-8 movement.
-- **Drop lower than build peak**: build climbs to 85% then drop is 80% → drop feels like a release, not a peak. Drop must equal or exceed the highest build energy.
-- **Drop 2 = Drop 1**: identical energy at bars 61 and 109 → no second-drop payoff. Drop 2 needs +5-10% (new element, octave-up lead, fuller perc).
-- **Breakdown to 0%**: full silence in breakdown → loses the listener. Keep at least pad + one melodic element at 30-40% energy.
-- **Build flat then sudden drop**: 50% bars 1-48, 95% bar 49 → drop feels arbitrary because there was no curve climbing into it.
+- **Flat 16-bar stretches**: same elements at same velocity bars 33-48 → loop,
+  not phrase. Add every-4 or every-8 movement.
+- **Drop lower than build peak**: build climbs to 85% then drop is 80% → drop
+  feels like a release, not a peak. Drop must equal or exceed the highest build
+  energy.
+- **Drop 2 = Drop 1**: identical energy at bars 61 and 109 → no second-drop
+  payoff. Drop 2 needs +5-10% (new element, octave-up lead, fuller perc).
+- **Breakdown to 0%**: full silence in breakdown → loses the listener. Keep at
+  least pad + one melodic element at 30-40% energy.
+- **Build flat then sudden drop**: 50% bars 1-48, 95% bar 49 → drop feels
+  arbitrary because there was no curve climbing into it.
 
 ## When to use
 
-- Plotting an arrangement before writing clips. Sketch the curve, then place elements to match the curve shape.
-- Diagnosing a track that "feels boring" — compute the curve, find the flat stretches, add every-4 movement.
-- Comparing your track to a reference track — plot both, see where shapes diverge.
-- Confirming a drop is actually a drop. If energy(drop_bar) is not the highest point in the section → not a drop.
+- Plotting an arrangement before writing clips. Sketch the curve, then place
+  elements to match the curve shape.
+- Diagnosing a track that "feels boring" — compute the curve, find the flat
+  stretches, add every-4 movement.
+- Comparing your track to a reference track — plot both, see where shapes
+  diverge.
+- Confirming a drop is actually a drop. If energy(drop_bar) is not the highest
+  point in the section → not a drop.
 
 ## Validated in
 
-- Reference analysis: Innellea Spectrum V2 (full template — every-4/8/16 rules visible across all sections).
-- Failure mode source: 2026-05-08 indie-dance jam where every layer played every bar = flat 80% line for 16 bars = "no story." Computing the curve made the flatness obvious.
-- Curve table cross-checked against `pre-drop-fill-formula` (bar 49-60 of sample = same Build B → silence → drop pattern).
+- Reference analysis: Innellea Spectrum V2 (full template — every-4/8/16 rules
+  visible across all sections).
+- Failure mode source: 2026-05-08 indie-dance jam where every layer played every
+  bar = flat 80% line for 16 bars = "no story." Computing the curve made the
+  flatness obvious.
+- Curve table cross-checked against `pre-drop-fill-formula` (bar 49-60 of sample
+  = same Build B → silence → drop pattern).

--- a/workspace/findings/technique/lead-stab-plus-sustain-roles.md
+++ b/workspace/findings/technique/lead-stab-plus-sustain-roles.md
@@ -1,19 +1,23 @@
 ---
 name: lead-stab-plus-sustain-roles
-description: Two-lead call/response groove rule — Lead A = rhythmic stabs in bass empty zones, Lead B = long sustained tail. Different roles, not duplicate voices.
+description:
+  Two-lead call/response groove rule — Lead A = rhythmic stabs in bass empty
+  zones, Lead B = long sustained tail. Different roles, not duplicate voices.
 type: technique
 ---
 
 # Two-lead call/response — stab + sustain roles
 
-Doc rule: "one lead is enough; two layers overcomplicates." Workaround that actually works in Maccabi House: two leads with **distinct roles** — never two stabs or two sustains.
+Doc rule: "one lead is enough; two layers overcomplicates." Workaround that
+actually works in Maccabi House: two leads with **distinct roles** — never two
+stabs or two sustains.
 
 ## The roles
 
-| Voice | Role | Notes | Durations | Position vs bass |
-|-------|------|-------|-----------|------------------|
-| **Lead A (call)** | rhythmic stab cluster | 4-5 notes per 2-bar phrase | mostly t/8 (16ths) | lands in bass empty zones (e.g., 2.5-3.5 area) |
-| **Lead B (response)** | sustained sweep | 1-2 notes per 2-bar phrase | t3-t4 long holds | enters bar after Lead A finishes, sustains across |
+| Voice                 | Role                  | Notes                      | Durations          | Position vs bass                                  |
+| --------------------- | --------------------- | -------------------------- | ------------------ | ------------------------------------------------- |
+| **Lead A (call)**     | rhythmic stab cluster | 4-5 notes per 2-bar phrase | mostly t/8 (16ths) | lands in bass empty zones (e.g., 2.5-3.5 area)    |
+| **Lead B (response)** | sustained sweep       | 1-2 notes per 2-bar phrase | t3-t4 long holds   | enters bar after Lead A finishes, sustains across |
 
 ## Why dull leads happen
 
@@ -24,14 +28,20 @@ Doc rule: "one lead is enough; two layers overcomplicates." Workaround that actu
 
 ## How to fix it
 
-1. **Map bass hits per bar first**, identify empty zones. For Maccabi House foundational bass: bass hits 1, 1.5, 2, 3.5, 4.25, 4.5, 4.75. Empty: 1.75, 2.25, 2.5, 2.75, 3, 3.25, 4
-2. **Stab voice** lands clusters in empty zones, mirrors bass roll energy with /8 16ths
-3. **Sustain voice** doesn't compete rhythmically — long t3-t4 hold during stab voice's silent bar
-4. Vary per chord section but keep role consistent — stabs always stabs, sustain always sustain
+1. **Map bass hits per bar first**, identify empty zones. For Maccabi House
+   foundational bass: bass hits 1, 1.5, 2, 3.5, 4.25, 4.5, 4.75. Empty: 1.75,
+   2.25, 2.5, 2.75, 3, 3.25, 4
+2. **Stab voice** lands clusters in empty zones, mirrors bass roll energy with
+   /8 16ths
+3. **Sustain voice** doesn't compete rhythmically — long t3-t4 hold during stab
+   voice's silent bar
+4. Vary per chord section but keep role consistent — stabs always stabs, sustain
+   always sustain
 
 ## Example pattern (Cm context, 4-bar phrase)
 
 **Lead A stab cluster** (bars 1-2):
+
 ```
 v100 t/8 G4 1|2.5
 v95 t/8 Bb4 1|2.75
@@ -45,6 +55,7 @@ v85 t/8 Bb4 2|3.5
 ```
 
 **Lead B sustain** (bars 3-4) — enters as A goes silent:
+
 ```
 v90 t4 Eb5 3|1
 v100 t3 C5 4|2
@@ -54,7 +65,8 @@ v100 t3 C5 4|2
 
 - Pan A and B opposite (-0.35 / +0.35) for stereo width
 - Both → reverb at -15 dB for cohesion
-- Variation across chord sections: shift pitches to chord tones, keep rhythm template
+- Variation across chord sections: shift pitches to chord tones, keep rhythm
+  template
 - Velocity climb across full section to peak (e.g., bars 29-32 hit v125-127)
 
 ## When to use
@@ -65,12 +77,22 @@ v100 t3 C5 4|2
 
 ## Mental model — piano voices, not synth layers
 
-Don't think "two synth tracks." Think **two pianists having a conversation**. One asks a quick rhythmic question (stab cluster), the other answers with a sustained line. They never speak at the same time. The silence of one is the space for the other.
+Don't think "two synth tracks." Think **two pianists having a conversation**.
+One asks a quick rhythmic question (stab cluster), the other answers with a
+sustained line. They never speak at the same time. The silence of one is the
+space for the other.
 
-This is what makes leads feel like they're **dancing together** instead of fighting. Lead B doesn't enter while Lead A is still talking. Lead A doesn't interrupt Lead B's sustain.
+This is what makes leads feel like they're **dancing together** instead of
+fighting. Lead B doesn't enter while Lead A is still talking. Lead A doesn't
+interrupt Lead B's sustain.
 
-If you can hum the call, then hum the response (separated in time), the leads will groove. If you can't separate them when humming, they're stacked too tightly.
+If you can hum the call, then hum the response (separated in time), the leads
+will groove. If you can't separate them when humming, they're stacked too
+tightly.
 
 ## Validated in
 
-- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "way better... seems like an actual piano question and response but they are dancing together." Earlier attempts with same-role leads got "dull and robotic."
+- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "way
+  better... seems like an actual piano question and response but they are
+  dancing together." Earlier attempts with same-role leads got "dull and
+  robotic."

--- a/workspace/findings/technique/lead-stab-plus-sustain-roles.md
+++ b/workspace/findings/technique/lead-stab-plus-sustain-roles.md
@@ -1,0 +1,76 @@
+---
+name: lead-stab-plus-sustain-roles
+description: Two-lead call/response groove rule — Lead A = rhythmic stabs in bass empty zones, Lead B = long sustained tail. Different roles, not duplicate voices.
+type: technique
+---
+
+# Two-lead call/response — stab + sustain roles
+
+Doc rule: "one lead is enough; two layers overcomplicates." Workaround that actually works in Maccabi House: two leads with **distinct roles** — never two stabs or two sustains.
+
+## The roles
+
+| Voice | Role | Notes | Durations | Position vs bass |
+|-------|------|-------|-----------|------------------|
+| **Lead A (call)** | rhythmic stab cluster | 4-5 notes per 2-bar phrase | mostly t/8 (16ths) | lands in bass empty zones (e.g., 2.5-3.5 area) |
+| **Lead B (response)** | sustained sweep | 1-2 notes per 2-bar phrase | t3-t4 long holds | enters bar after Lead A finishes, sustains across |
+
+## Why dull leads happen
+
+- Same rhythm placement every bar (e.g., always 1.25) → predictable, robotic
+- All same duration → monotone, no breath
+- Notes stack on bass hits → muddy, no groove
+- Two leads doing the same job → cluttered, no conversation
+
+## How to fix it
+
+1. **Map bass hits per bar first**, identify empty zones. For Maccabi House foundational bass: bass hits 1, 1.5, 2, 3.5, 4.25, 4.5, 4.75. Empty: 1.75, 2.25, 2.5, 2.75, 3, 3.25, 4
+2. **Stab voice** lands clusters in empty zones, mirrors bass roll energy with /8 16ths
+3. **Sustain voice** doesn't compete rhythmically — long t3-t4 hold during stab voice's silent bar
+4. Vary per chord section but keep role consistent — stabs always stabs, sustain always sustain
+
+## Example pattern (Cm context, 4-bar phrase)
+
+**Lead A stab cluster** (bars 1-2):
+```
+v100 t/8 G4 1|2.5
+v95 t/8 Bb4 1|2.75
+v115 t/8 G4 1|3
+v90 t/8 Bb4 1|3.25
+v95 t/8 G4 2|2.5
+v110 t/8 Bb4 2|2.75
+v100 t/8 G4 2|3
+v120 t/8 C5 2|3.25
+v85 t/8 Bb4 2|3.5
+```
+
+**Lead B sustain** (bars 3-4) — enters as A goes silent:
+```
+v90 t4 Eb5 3|1
+v100 t3 C5 4|2
+```
+
+## Production notes
+
+- Pan A and B opposite (-0.35 / +0.35) for stereo width
+- Both → reverb at -15 dB for cohesion
+- Variation across chord sections: shift pitches to chord tones, keep rhythm template
+- Velocity climb across full section to peak (e.g., bars 29-32 hit v125-127)
+
+## When to use
+
+- Maccabi House / Adam Ten / Mita Gami Main A drop sections
+- Indie dance with 32-bar groove that needs melodic interest
+- Whenever leads feel "robotic" or "on top of each other"
+
+## Mental model — piano voices, not synth layers
+
+Don't think "two synth tracks." Think **two pianists having a conversation**. One asks a quick rhythmic question (stab cluster), the other answers with a sustained line. They never speak at the same time. The silence of one is the space for the other.
+
+This is what makes leads feel like they're **dancing together** instead of fighting. Lead B doesn't enter while Lead A is still talking. Lead A doesn't interrupt Lead B's sustain.
+
+If you can hum the call, then hum the response (separated in time), the leads will groove. If you can't separate them when humming, they're stacked too tightly.
+
+## Validated in
+
+- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "way better... seems like an actual piano question and response but they are dancing together." Earlier attempts with same-role leads got "dull and robotic."

--- a/workspace/findings/technique/pre-drop-fill-formula.md
+++ b/workspace/findings/technique/pre-drop-fill-formula.md
@@ -1,12 +1,16 @@
 ---
 name: pre-drop-fill-formula
-description: 16-bar Build B → Drop transition formula — snare 16ths velocity ramp + kick drops last 2 bars + 32nd snare blast in final bar
+description:
+  16-bar Build B → Drop transition formula — snare 16ths velocity ramp + kick
+  drops last 2 bars + 32nd snare blast in final bar
 type: technique
 ---
 
 # Pre-drop fill formula (Build B → Peak transition)
 
-The transition from Build B (16 bars) to Peak/Main B is where energy peaks before release. Three layered moves create the classic indie dance / Maccabi House drop tension.
+The transition from Build B (16 bars) to Peak/Main B is where energy peaks
+before release. Three layered moves create the classic indie dance / Maccabi
+House drop tension.
 
 ## The formula
 
@@ -21,7 +25,8 @@ v100 t/16 E1 1|1.75
 // Then transform: E1: velocity = ramp(30, 115)
 ```
 
-Ramp velocity from v30 (almost inaudible) to v115 across all 16 bars. Listener feels tension build without consciously tracking individual hits.
+Ramp velocity from v30 (almost inaudible) to v115 across all 16 bars. Listener
+feels tension build without consciously tracking individual hits.
 
 ### 2. Kick drops bars 15-16
 
@@ -31,11 +36,13 @@ Use a transform to delete kick in last 2 bars:
 15|1-16|4.75 C1: velocity = 0
 ```
 
-Sudden absence of kick = anticipation. The groove has been hammered for 14 bars; removing it creates a vacuum the drop fills.
+Sudden absence of kick = anticipation. The groove has been hammered for 14 bars;
+removing it creates a vacuum the drop fills.
 
 ### 3. 32nd snare blast in bar 16 only
 
-Replace bar 16 snare with 32nd notes (twice the density), velocity ramping per beat:
+Replace bar 16 snare with 32nd notes (twice the density), velocity ramping per
+beat:
 
 ```
 v60 t/16 E1 16|1,1.125,1.25,1.375,1.5,1.625,1.75,1.875
@@ -48,23 +55,28 @@ v120 t/16 E1 16|4,4.125,4.25,4.375,4.5,4.625,4.75,4.875
 
 ## Why this works
 
-- **16-bar ramp** = subconscious tension, listener doesn't notice the snare individually
-- **Kick drop** = silence creates the "where's the kick?" anxiety that makes the drop hit harder
+- **16-bar ramp** = subconscious tension, listener doesn't notice the snare
+  individually
+- **Kick drop** = silence creates the "where's the kick?" anxiety that makes the
+  drop hit harder
 - **32nd blast** = surface-level tension peaks right before resolution
 - All three layered = the body knows the drop is coming before the brain does
 
 ## Production notes
 
 - Snare on E1 pad in Drum Rack
-- Pad continues throughout (sustained Cm chord with velocity ramp v75→v110 across 16 bars)
+- Pad continues throughout (sustained Cm chord with velocity ramp v75→v110
+  across 16 bars)
 - Bass continues full pattern — only kick drops, not bass
 
 ## When to use
 
 - Any 16-bar Build B before a Peak/Main B drop
-- Before a return from Breakdown (combine: breakdown ring-out + this fill = strong transition)
+- Before a return from Breakdown (combine: breakdown ring-out + this fill =
+  strong transition)
 - Anywhere the energy needs to climax + release
 
 ## Validated in
 
-- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "way better." Earlier Build B without these fills lacked transition tension.
+- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "way
+  better." Earlier Build B without these fills lacked transition tension.

--- a/workspace/findings/technique/pre-drop-fill-formula.md
+++ b/workspace/findings/technique/pre-drop-fill-formula.md
@@ -1,0 +1,70 @@
+---
+name: pre-drop-fill-formula
+description: 16-bar Build B → Drop transition formula — snare 16ths velocity ramp + kick drops last 2 bars + 32nd snare blast in final bar
+type: technique
+---
+
+# Pre-drop fill formula (Build B → Peak transition)
+
+The transition from Build B (16 bars) to Peak/Main B is where energy peaks before release. Three layered moves create the classic indie dance / Maccabi House drop tension.
+
+## The formula
+
+### 1. Snare 16th velocity ramp (full 16 bars)
+
+```
+v60 t/16 E1 1|1
+v80 t/16 E1 1|1.25
+v90 t/16 E1 1|1.5
+v100 t/16 E1 1|1.75
+... (16 16ths per bar, tile @2-16=1)
+// Then transform: E1: velocity = ramp(30, 115)
+```
+
+Ramp velocity from v30 (almost inaudible) to v115 across all 16 bars. Listener feels tension build without consciously tracking individual hits.
+
+### 2. Kick drops bars 15-16
+
+Use a transform to delete kick in last 2 bars:
+
+```
+15|1-16|4.75 C1: velocity = 0
+```
+
+Sudden absence of kick = anticipation. The groove has been hammered for 14 bars; removing it creates a vacuum the drop fills.
+
+### 3. 32nd snare blast in bar 16 only
+
+Replace bar 16 snare with 32nd notes (twice the density), velocity ramping per beat:
+
+```
+v60 t/16 E1 16|1,1.125,1.25,1.375,1.5,1.625,1.75,1.875
+v75 t/16 E1 16|2,2.125,2.25,2.375,2.5,2.625,2.75,2.875
+v95 t/16 E1 16|3,3.125,3.25,3.375,3.5,3.625,3.75,3.875
+v120 t/16 E1 16|4,4.125,4.25,4.375,4.5,4.625,4.75,4.875
+```
+
+32 hits in 1 bar at climbing velocity = climax pressure right before drop.
+
+## Why this works
+
+- **16-bar ramp** = subconscious tension, listener doesn't notice the snare individually
+- **Kick drop** = silence creates the "where's the kick?" anxiety that makes the drop hit harder
+- **32nd blast** = surface-level tension peaks right before resolution
+- All three layered = the body knows the drop is coming before the brain does
+
+## Production notes
+
+- Snare on E1 pad in Drum Rack
+- Pad continues throughout (sustained Cm chord with velocity ramp v75→v110 across 16 bars)
+- Bass continues full pattern — only kick drops, not bass
+
+## When to use
+
+- Any 16-bar Build B before a Peak/Main B drop
+- Before a return from Breakdown (combine: breakdown ring-out + this fill = strong transition)
+- Anywhere the energy needs to climax + release
+
+## Validated in
+
+- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "way better." Earlier Build B without these fills lacked transition tension.

--- a/workspace/findings/technique/progressive-pad-reveal.md
+++ b/workspace/findings/technique/progressive-pad-reveal.md
@@ -1,12 +1,16 @@
 ---
 name: progressive-pad-reveal
-description: 16-bar intro pad that builds Cm chord one note at a time over 4-bar phases — drone → fifth → triad → octave
+description:
+  16-bar intro pad that builds Cm chord one note at a time over 4-bar phases —
+  drone → fifth → triad → octave
 type: technique
 ---
 
 # Progressive pad reveal (16-bar intro)
 
-For dreamy melodic intros (Adam Ten / indie dance), build pad chord progressively across 16 bars instead of dropping full chord at bar 1. Each 4-bar phase adds one chord tone, so the harmonic content thickens organically.
+For dreamy melodic intros (Adam Ten / indie dance), build pad chord
+progressively across 16 bars instead of dropping full chord at bar 1. Each 4-bar
+phase adds one chord tone, so the harmonic content thickens organically.
 
 ## Pattern (C minor, 4-bar phases)
 
@@ -29,14 +33,17 @@ v70 t16 C3 13|1 Eb3 13|1 G3 13|1 C4 13|1 // bars 13-16: + octave on top
 - No melodic decisions needed — pure mood/texture.
 - Listener feels harmony fill in over time without conscious tracking.
 - Pairs with kick from bar 1 — pad provides atmosphere, kick provides pulse.
-- 4-bar phase length aligns with phrasing — listener subconsciously expects change.
+- 4-bar phase length aligns with phrasing — listener subconsciously expects
+  change.
 
 ## When to use
 
 - Dreamy intro section (16 bars).
 - Any "atmospheric build" without melody.
-- When you want chord progression complexity without writing one — single Cm sustained the whole time, complexity comes from voicing reveal.
+- When you want chord progression complexity without writing one — single Cm
+  sustained the whole time, complexity comes from voicing reveal.
 
 ## Validated in
 
-- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "I dig this one, has a nice progressive feel."
+- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "I dig this
+  one, has a nice progressive feel."

--- a/workspace/findings/technique/progressive-pad-reveal.md
+++ b/workspace/findings/technique/progressive-pad-reveal.md
@@ -1,0 +1,42 @@
+---
+name: progressive-pad-reveal
+description: 16-bar intro pad that builds Cm chord one note at a time over 4-bar phases — drone → fifth → triad → octave
+type: technique
+---
+
+# Progressive pad reveal (16-bar intro)
+
+For dreamy melodic intros (Adam Ten / indie dance), build pad chord progressively across 16 bars instead of dropping full chord at bar 1. Each 4-bar phase adds one chord tone, so the harmonic content thickens organically.
+
+## Pattern (C minor, 4-bar phases)
+
+```
+v55 t16 C3 1|1                          // bars 1-4: root drone
+v60 t16 C3 5|1 G3 5|1                   // bars 5-8: + fifth
+v65 t16 C3 9|1 Eb3 9|1 G3 9|1           // bars 9-12: full triad
+v70 t16 C3 13|1 Eb3 13|1 G3 13|1 C4 13|1 // bars 13-16: + octave on top
+```
+
+## Settings
+
+- Note duration `t16` = 4 bars per sustain. One retrigger per phase.
+- Velocity ramps v55 → v70 across phases (subtle dynamic build).
+- Send to A-Reverb at -12 dB for dreamy wash.
+- Works with Drift on a pad preset (default pluck preset = wrong sound).
+
+## Why it works
+
+- No melodic decisions needed — pure mood/texture.
+- Listener feels harmony fill in over time without conscious tracking.
+- Pairs with kick from bar 1 — pad provides atmosphere, kick provides pulse.
+- 4-bar phase length aligns with phrasing — listener subconsciously expects change.
+
+## When to use
+
+- Dreamy intro section (16 bars).
+- Any "atmospheric build" without melody.
+- When you want chord progression complexity without writing one — single Cm sustained the whole time, complexity comes from voicing reveal.
+
+## Validated in
+
+- Project: chill-sunday-with-my-adj-pal (2026-04-26). User reaction: "I dig this one, has a nice progressive feel."


### PR DESCRIPTION
### **User description**
Closes #120.

## Summary

Encodes 3 missing track-construction findings as `workspace/findings/` entries so future sessions auto-pick up the rules when relevant tasks match their globs:

- `technique/drop-mechanics.md` — 3 drop types (subtractive / additive / contrast), build → silence → release timing, kick-return rules, sub-bass-first-hit psychology, bar-by-bar worked example for an indie-dance subtractive drop.
- `technique/energy-curve-math.md` — 0-100% per-bar energy formula, every-4 accent / every-8 structural shift / every-16 section change rules, sample 128-bar indie-dance curve table.
- `genre/indie-dance-microsection-arc.md` (stretch goal) — 4-microsection arc inside an 8-bar loop (intro/lift/peak/resolution every 2 bars), with `adj-update-clip` velocity transform snippets to silence elements per bar range.

`workspace/findings/INDEX.md` updated with all three new entries + globs.

## Tracking change

`workspace/` was fully gitignored (line 62), which made it impossible to ship validated findings via PR. This PR narrows the ignore to:

```
workspace/*
!workspace/findings/
```

So `workspace/findings/` is now tracked, but `workspace/projects/`, `workspace/AI.md`, `workspace/genres/`, `workspace/techniques/` stay private (per-user session data). This also pulls in the pre-existing personal findings (maccabi-house-*, lead-stab-plus-sustain-roles, breakdown-lead-chord-aligned, pre-drop-fill-formula, progressive-pad-reveal) plus `HOW-TO-WRITE.md` and `INDEX.md` so the structure is shareable across users from this point forward.

## Test plan

- [x] `workspace/findings/technique/drop-mechanics.md` written with bar-by-bar worked example
- [x] `workspace/findings/technique/energy-curve-math.md` written with sample 128-bar energy curve table
- [x] `workspace/findings/genre/indie-dance-microsection-arc.md` written with `adj-update-clip` transform snippets
- [x] All three findings listed in `workspace/findings/INDEX.md` with accurate globs
- [x] All three findings follow `HOW-TO-WRITE.md` template (front-matter + Fact/Evidence/Apply-when style, with extended sections for worked examples)
- [ ] Validation pending: fresh AI session given indie-dance + drop prompt produces result with clear story arc without manual correction. Note outcome in each finding's `validated in:` field after next session.

## Out of scope (follow-up issues)

Items 3-10 from issue #120 gap list — motif development arc, Kraftwerk minimalism, fill grammar, tension/release catalogs, fractal storytelling, reference-analysis methodology, hook anatomy.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduces new music production findings for AI.

- Details drop mechanics, energy curve math, and indie-dance microsection arcs.

- Enables tracking of `workspace/findings/` for shareable knowledge.

- Incorporates existing validated music production techniques.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A[AI Session] --> B{workspace/findings/INDEX.md}
    B -- "references" --> C[technique/drop-mechanics.md]
    B -- "references" --> D[technique/energy-curve-math.md]
    B -- "references" --> E[genre/indie-dance-microsection-arc.md]
    C -- "defines" --> F[Drop Types & Timing]
    D -- "defines" --> G[Energy Formula & Rules]
    E -- "defines" --> H[8-Bar Microsection Arc]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>HOW-TO-WRITE.md</strong><dd><code>Adds guidelines for writing music production findings</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/121/files#diff-38f4a3d0e14d6917a7e7605340a5b56372c5e19d387e3115f3f5f7a94182bf09">+141/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>INDEX.md</strong><dd><code>Updates index with new and existing music findings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/121/files#diff-d224046496e0b5694b41151dd93a56c278f014281d42513d337104847330ebdf">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>indie-dance-microsection-arc.md</strong><dd><code>Adds finding for 8-bar indie-dance microsection arc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/121/files#diff-539b80b2635910b6eb2e40eee6ed526d738b6e018d93b8dc9b416aa6a65f8e00">+129/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>maccabi-house-foundational-bass.md</strong><dd><code>Adds finding for Maccabi House foundational bass pattern</code>&nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/121/files#diff-9dc116a85369a9acfb3a844428238a4541ec51dd1246faaf2123b769ddbc3e1a">+59/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>maccabi-house-percussion-stack.md</strong><dd><code>Adds finding for Maccabi House percussion stack</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/121/files#diff-6e131f15a9eecaceec71b04b9131ff676eb172c1b017208b6cf8914971949983">+70/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>breakdown-lead-chord-aligned.md</strong><dd><code>Adds finding for chord-aligned lead placement in breakdowns</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/121/files#diff-6adbaad39e48a518de515507fd52f4fce7ca079384f0d1629c80437b0e56d72d">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>drop-mechanics.md</strong><dd><code>Adds finding detailing drop construction mechanics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/121/files#diff-da66c9f69029083c171690176c315ff2dbcf3400188e2d250fb616cd61991818">+138/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>energy-curve-math.md</strong><dd><code>Adds finding for measurable energy curve calculation and rules</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/121/files#diff-0f46dc8836fbdde252259dab0ba61a6a6a5ffe33fd1a09638b4f712e65be9aea">+158/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>lead-stab-plus-sustain-roles.md</strong><dd><code>Adds finding for two-lead call/response roles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/121/files#diff-42aaf7a906fb5d61ef8db97418bc39c24689fd18752876790e97452653251966">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pre-drop-fill-formula.md</strong><dd><code>Adds finding for pre-drop fill transition formula</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/121/files#diff-6e9cde7bf08d14f47eadc39b010a1c2ab998aa204284ea8c9f276d87f40dbd9f">+70/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>progressive-pad-reveal.md</strong><dd><code>Adds finding for progressive pad reveal in intros</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/121/files#diff-245235ec6beac79a3ee0abcc304cbafaee9ca4765c7d2503cb12d35dfde931f8">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

