### PR TITLE
feat(adj-microsection-mute): wrap velocity-by-bar transforms for 4-microsection arc

### DIFF
--- a/e2e/tests/clip/adj-microsection-mute.test.ts
+++ b/e2e/tests/clip/adj-microsection-mute.test.ts
@@ -1,0 +1,221 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * E2E tests for adj-microsection-mute tool
+ *
+ * Creates an 8-bar MIDI clip with notes on multiple pitches across all bars,
+ * applies a microsection mute map, and verifies the right notes get
+ * velocity=0 in the right bar ranges.
+ *
+ * Uses: e2e-test-set — t8 "9-MIDI" empty slot.
+ *
+ * Run with: npm run e2e:mcp -- --run e2e/tests/clip/adj-microsection-mute.test.ts
+ */
+import { describe, expect, it } from "vitest";
+import {
+  parseToolResult,
+  type ReadClipResult,
+  setupMcpTestContext,
+  sleep,
+} from "../mcp-test-helpers";
+
+const ctx = setupMcpTestContext();
+
+const emptyMidiTrack = 8;
+
+interface NoteRecord {
+  pitch: string;
+  start: string;
+  velocity: number;
+}
+
+interface ReadClipNotes extends ReadClipResult {
+  notes?: string;
+}
+
+/**
+ * Parse the `notes` string emitted by adj-read-clip into structured records.
+ * Format per token: `<pitch> <bar>|<beat> v<velocity> ...`. Tokens separated
+ * by newlines. We only need pitch/start/velocity for assertions.
+ */
+function parseNotes(notesString: string | undefined): NoteRecord[] {
+  if (!notesString) return [];
+
+  const records: NoteRecord[] = [];
+
+  for (const line of notesString.split(/\r?\n/)) {
+    const trimmed = line.trim();
+
+    if (trimmed.length === 0) continue;
+
+    const parts = trimmed.split(/\s+/);
+
+    if (parts.length < 2) continue;
+
+    let pitch: string | null = null;
+    let start: string | null = null;
+    let velocity = 100;
+
+    for (const tok of parts) {
+      if (/^v\d+$/.test(tok)) {
+        velocity = Number.parseInt(tok.slice(1), 10);
+        continue;
+      }
+
+      if (/\|/.test(tok)) {
+        start = tok;
+        continue;
+      }
+
+      if (pitch === null) pitch = tok;
+    }
+
+    if (pitch != null && start != null) {
+      records.push({ pitch, start, velocity });
+    }
+  }
+
+  return records;
+}
+
+function notesAt(
+  records: NoteRecord[],
+  pitch: string,
+  bar: number,
+): NoteRecord[] {
+  return records.filter(
+    (n) => n.pitch === pitch && n.start.startsWith(`${bar}|`),
+  );
+}
+
+describe("adj-microsection-mute", () => {
+  it("zeroes velocity for muted pitches in the right bar ranges", async () => {
+    // Setup: 8-bar clip with Eb1 + F#1 hits on bar 1 of every bar (1..8).
+    const noteLines: string[] = [];
+
+    for (let bar = 1; bar <= 8; bar++) {
+      noteLines.push(`v100 Eb1 ${bar}|1`);
+      noteLines.push(`v100 F#1 ${bar}|1`);
+    }
+
+    const createResult = await ctx.client!.callTool({
+      name: "adj-create-clip",
+      arguments: {
+        slot: `${emptyMidiTrack}/0`,
+        notes: noteLines.join("\n"),
+        length: "8:0.0",
+      },
+    });
+    const clip = parseToolResult<{ id: string }>(createResult);
+
+    await sleep(100);
+
+    // Apply 4-microsection arc:
+    //   1-2 intro:      mute Eb1 (clap)
+    //   3-4 lift:       mute F#1 (open hat)
+    //   5-6 peak:       no mute
+    //   7-8 resolution: mute all
+    await ctx.client!.callTool({
+      name: "adj-microsection-mute",
+      arguments: {
+        clipIds: clip.id,
+        microsections: ["1-2: Eb1", "3-4: F#1", "5-6:", "7-8: all"].join("\n"),
+      },
+    });
+
+    await sleep(100);
+
+    const readResult = await ctx.client!.callTool({
+      name: "adj-read-clip",
+      arguments: { clipId: clip.id, include: ["notes"] },
+    });
+    const readClip = parseToolResult<ReadClipNotes>(readResult);
+    const records = parseNotes(readClip.notes);
+
+    // Bars 1-2: Eb1 muted (v=0), F#1 unchanged (v=100)
+    for (const bar of [1, 2]) {
+      for (const eb of notesAt(records, "Eb1", bar)) {
+        expect(eb.velocity, `Eb1 bar ${bar} should be muted`).toBe(0);
+      }
+
+      for (const fSharp of notesAt(records, "F#1", bar)) {
+        expect(
+          fSharp.velocity,
+          `F#1 bar ${bar} should not be muted`,
+        ).toBeGreaterThan(0);
+      }
+    }
+
+    // Bars 3-4: F#1 muted, Eb1 unchanged
+    for (const bar of [3, 4]) {
+      for (const eb of notesAt(records, "Eb1", bar)) {
+        expect(
+          eb.velocity,
+          `Eb1 bar ${bar} should not be muted`,
+        ).toBeGreaterThan(0);
+      }
+
+      for (const fSharp of notesAt(records, "F#1", bar)) {
+        expect(fSharp.velocity, `F#1 bar ${bar} should be muted`).toBe(0);
+      }
+    }
+
+    // Bars 5-6 peak: nothing muted
+    for (const bar of [5, 6]) {
+      for (const eb of notesAt(records, "Eb1", bar)) {
+        expect(eb.velocity, `Eb1 bar ${bar} should play`).toBeGreaterThan(0);
+      }
+
+      for (const fSharp of notesAt(records, "F#1", bar)) {
+        expect(fSharp.velocity, `F#1 bar ${bar} should play`).toBeGreaterThan(
+          0,
+        );
+      }
+    }
+
+    // Bars 7-8 resolution: everything muted ('all')
+    for (const bar of [7, 8]) {
+      for (const eb of notesAt(records, "Eb1", bar)) {
+        expect(eb.velocity, `Eb1 bar ${bar} should be muted (all)`).toBe(0);
+      }
+
+      for (const fSharp of notesAt(records, "F#1", bar)) {
+        expect(fSharp.velocity, `F#1 bar ${bar} should be muted (all)`).toBe(0);
+      }
+    }
+  });
+
+  it("returns transformsApplied count and transforms string", async () => {
+    const createResult = await ctx.client!.callTool({
+      name: "adj-create-clip",
+      arguments: {
+        slot: `${emptyMidiTrack}/1`,
+        notes: "v100 Eb1 1|1\nv100 F#1 1|1",
+        length: "4:0.0",
+      },
+    });
+    const clip = parseToolResult<{ id: string }>(createResult);
+
+    await sleep(100);
+
+    const muteResult = await ctx.client!.callTool({
+      name: "adj-microsection-mute",
+      arguments: {
+        clipIds: clip.id,
+        microsections: "1-2: Eb1, F#1\n3-4:",
+      },
+    });
+    const summary = parseToolResult<{
+      clipsUpdated: number;
+      transformsApplied: number;
+      transforms: string;
+    }>(muteResult);
+
+    expect(summary.clipsUpdated).toBe(1);
+    expect(summary.transformsApplied).toBe(2);
+    expect(summary.transforms).toContain("Eb1 1|1-2|4.999: velocity = 0");
+    expect(summary.transforms).toContain("F#1 1|1-2|4.999: velocity = 0");
+  });
+});

--- a/src/live-api-adapter/live-api-adapter.ts
+++ b/src/live-api-adapter/live-api-adapter.ts
@@ -19,6 +19,7 @@ import * as console from "#src/shared/v8-max-console.ts";
 import { isNewerVersion } from "#src/shared/version-check.ts";
 import { MIN_LIVE_VERSION, VERSION } from "#src/shared/version.ts";
 import { createClip } from "#src/tools/clip/create/create-clip.ts";
+import { microsectionMute } from "#src/tools/clip/microsection-mute/microsection-mute.ts";
 import { readClip } from "#src/tools/clip/read/read-clip.ts";
 import { updateClip } from "#src/tools/clip/update/update-clip.ts";
 import { playback } from "#src/tools/control/playback.ts";
@@ -91,6 +92,11 @@ const tools: Record<string, (args: unknown) => unknown> = {
     initHoldingArea();
 
     return updateClip(args as any, context);
+  },
+  "adj-microsection-mute": (args) => {
+    initHoldingArea();
+
+    return microsectionMute(args as any, context);
   },
   "adj-create-device": (args) => createDevice(args as any, context),
   "adj-read-device": (args) => readDevice(args as any, context),

--- a/src/mcp-server/create-mcp-server.ts
+++ b/src/mcp-server/create-mcp-server.ts
@@ -6,6 +6,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { VERSION } from "#src/shared/version.ts";
 import { toolDefBrowse } from "#src/tools/browse/browse.def.ts";
 import { toolDefCreateClip } from "#src/tools/clip/create/create-clip.def.ts";
+import { toolDefMicrosectionMute } from "#src/tools/clip/microsection-mute/microsection-mute.def.ts";
 import { toolDefReadClip } from "#src/tools/clip/read/read-clip.def.ts";
 import { toolDefUpdateClip } from "#src/tools/clip/update/update-clip.def.ts";
 import { toolDefPlayback } from "#src/tools/control/playback.def.ts";
@@ -48,6 +49,7 @@ export const STANDARD_TOOL_DEFS: ToolDefFunction[] = [
   toolDefReadClip,
   toolDefCreateClip,
   toolDefUpdateClip,
+  toolDefMicrosectionMute,
   toolDefReadDevice,
   toolDefCreateDevice,
   toolDefUpdateDevice,

--- a/src/mcp-server/tests/create-express-app.test.ts
+++ b/src/mcp-server/tests/create-express-app.test.ts
@@ -120,6 +120,7 @@ describe("MCP Express App", () => {
         "adj-read-clip",
         "adj-create-clip",
         "adj-update-clip",
+        "adj-microsection-mute",
         "adj-read-device",
         "adj-create-device",
         "adj-update-device",

--- a/src/tools/clip/microsection-mute/microsection-mute.def.ts
+++ b/src/tools/clip/microsection-mute/microsection-mute.def.ts
@@ -1,0 +1,40 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { z } from "zod";
+import { defineTool } from "#src/tools/shared/tool-framework/define-tool.ts";
+
+export const toolDefMicrosectionMute = defineTool("adj-microsection-mute", {
+  title: "Microsection Mute",
+  description:
+    "Silence pitches in bar ranges via velocity=0 transforms. Encodes the 4-microsection arc (intro/lift/peak/resolution) without per-element transform calls. See finding indie-dance-microsection-arc.",
+
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+  },
+
+  inputSchema: {
+    clipIds: z.coerce
+      .string()
+      .describe("comma-separated clip ID(s) to apply the mute map to"),
+    microsections: z
+      .string()
+      .describe(
+        [
+          "multi-line mute map. One line per microsection.",
+          "Format: '<barStart>-<barEnd>: <pitch1>, <pitch2>, ...'",
+          "  - pitches: MIDI note names (Eb1, F#3, C-1) or numbers (39, 54)",
+          "  - 'all' mutes whole clip across the bar range",
+          "  - empty list = no mute (peak microsection, declaratively present)",
+          "Lines starting with # are comments. Empty lines ignored.",
+          "Example:",
+          "  1-2: Eb1, F#1   # intro: mute clap + open hat",
+          "  3-4: F#1        # lift: mute open hat only",
+          "  5-6:            # peak: everything plays",
+          "  7-8: all        # resolution: silence the whole clip",
+        ].join("\n"),
+      ),
+  },
+});

--- a/src/tools/clip/microsection-mute/microsection-mute.ts
+++ b/src/tools/clip/microsection-mute/microsection-mute.ts
@@ -1,0 +1,230 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { updateClip } from "#src/tools/clip/update/update-clip.ts";
+
+interface MicrosectionMuteArgs {
+  clipIds?: string;
+  microsections?: string;
+}
+
+interface ParsedMicrosection {
+  barStart: number;
+  barEnd: number;
+  /** Empty array = peak (no mute). null = "all" (whole clip range). */
+  pitches: string[] | null;
+  /** Original line for error messages. */
+  raw: string;
+  lineNumber: number;
+}
+
+interface MicrosectionMuteResult {
+  clipsUpdated: number;
+  transformsApplied: number;
+  transforms: string;
+}
+
+/**
+ * Apply a microsection mute map to one or more clips.
+ *
+ * Builds a `transforms` string of `velocity = 0` rules over bar ranges and
+ * delegates to `adj-update-clip` (merge mode) so existing notes are preserved
+ * but velocity-zeroed in the requested ranges. Velocity=0 (not delete) is used
+ * deliberately so humanized notes (timing nudged off-grid) still get caught.
+ *
+ * @param args - Tool arguments
+ * @param args.clipIds - Comma-separated clip ID(s) to update
+ * @param args.microsections - Multi-line mute map (see def for grammar)
+ * @param context - Tool execution context (forwarded to updateClip)
+ * @returns Summary of clips updated and transforms applied
+ */
+export async function microsectionMute(
+  { clipIds, microsections }: MicrosectionMuteArgs = {},
+  context: Partial<ToolContext> = {},
+): Promise<MicrosectionMuteResult> {
+  if (!clipIds) {
+    throw new Error("microsectionMute failed: clipIds is required");
+  }
+
+  if (!microsections) {
+    throw new Error("microsectionMute failed: microsections is required");
+  }
+
+  const parsed = parseMicrosections(microsections);
+  const transforms = buildTransforms(parsed);
+
+  if (transforms.length === 0) {
+    return {
+      clipsUpdated: 0,
+      transformsApplied: 0,
+      transforms: "",
+    };
+  }
+
+  const transformString = transforms.join("\n");
+
+  const updateResult = await updateClip(
+    {
+      ids: clipIds,
+      transforms: transformString,
+      noteUpdateMode: "merge",
+    },
+    context,
+  );
+
+  const clipsUpdated = Array.isArray(updateResult) ? updateResult.length : 1;
+
+  return {
+    clipsUpdated,
+    transformsApplied: transforms.length,
+    transforms: transformString,
+  };
+}
+
+const COMMENT_PREFIX = "#";
+const ALL_TOKEN = "all";
+
+/**
+ * Parse the multi-line microsections grammar into structured entries.
+ *
+ * Per-line format:
+ *   <barStart>-<barEnd>: <pitch1>, <pitch2>, ...
+ *   <barStart>-<barEnd>: all
+ *   <barStart>-<barEnd>:
+ *
+ * @param input - Raw microsections string from the tool arg
+ * @returns Parsed microsection entries in declaration order
+ */
+export function parseMicrosections(input: string): ParsedMicrosection[] {
+  const result: ParsedMicrosection[] = [];
+
+  const lines = input.split(/\r?\n/);
+
+  for (let i = 0; i < lines.length; i++) {
+    const lineNumber = i + 1;
+
+    const stripped = stripInlineComment(lines[i] as string).trim();
+
+    if (stripped.length === 0) continue;
+
+    const colonIdx = stripped.indexOf(":");
+
+    if (colonIdx === -1) {
+      throw new Error(
+        `microsectionMute failed: line ${lineNumber} missing ':' — expected '<barStart>-<barEnd>: <pitch list>'. Got: '${stripped}'`,
+      );
+    }
+
+    const rangePart = stripped.slice(0, colonIdx).trim();
+    const mutePart = stripped.slice(colonIdx + 1).trim();
+
+    const { barStart, barEnd } = parseBarRange(rangePart, lineNumber);
+    const pitches = parsePitchList(mutePart);
+
+    result.push({
+      barStart,
+      barEnd,
+      pitches,
+      raw: stripped,
+      lineNumber,
+    });
+  }
+
+  return result;
+}
+
+function stripInlineComment(line: string): string {
+  // '#' is a comment marker only at line-start or after whitespace.
+  // Sharp note names (F#1, C#3, etc.) use '#' immediately after a letter,
+  // so we leave those alone.
+  for (let i = 0; i < line.length; i++) {
+    if (line[i] !== COMMENT_PREFIX) continue;
+
+    if (i === 0) return "";
+
+    const prev = line[i - 1] as string;
+
+    if (prev === " " || prev === "\t") return line.slice(0, i);
+  }
+
+  return line;
+}
+
+function parseBarRange(
+  rangePart: string,
+  lineNumber: number,
+): { barStart: number; barEnd: number } {
+  const dashIdx = rangePart.indexOf("-");
+
+  if (dashIdx === -1) {
+    throw new Error(
+      `microsectionMute failed: line ${lineNumber} bar range missing '-' separator. Got: '${rangePart}'`,
+    );
+  }
+
+  const startStr = rangePart.slice(0, dashIdx).trim();
+  const endStr = rangePart.slice(dashIdx + 1).trim();
+
+  const barStart = Number.parseInt(startStr, 10);
+  const barEnd = Number.parseInt(endStr, 10);
+
+  if (!Number.isFinite(barStart) || barStart < 1) {
+    throw new Error(
+      `microsectionMute failed: line ${lineNumber} barStart must be a positive integer. Got: '${startStr}'`,
+    );
+  }
+
+  if (!Number.isFinite(barEnd) || barEnd < barStart) {
+    throw new Error(
+      `microsectionMute failed: line ${lineNumber} barEnd must be >= barStart. Got: '${endStr}'`,
+    );
+  }
+
+  return { barStart, barEnd };
+}
+
+function parsePitchList(mutePart: string): string[] | null {
+  if (mutePart.length === 0) return [];
+
+  if (mutePart.toLowerCase() === ALL_TOKEN) return null;
+
+  return mutePart
+    .split(",")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
+
+/**
+ * Convert parsed microsections to transform strings consumable by
+ * `adj-update-clip`.
+ *
+ * End-bar coverage uses `<barEnd>|4.999` to include the last 16th of the
+ * final bar (transform time-range filter is inclusive). Assumes 4/4 time.
+ * For non-4/4 clips, lower beat counts still match correctly because the
+ * filter clamps against the actual note position; the upper bound of 4.999
+ * just defines a generous "everything in this bar" envelope.
+ *
+ * @param microsections - Parsed microsection entries
+ * @returns Transform expression strings, one per pitch × range
+ */
+export function buildTransforms(microsections: ParsedMicrosection[]): string[] {
+  const transforms: string[] = [];
+
+  for (const ms of microsections) {
+    if (ms.pitches !== null && ms.pitches.length === 0) continue;
+
+    const range = `${ms.barStart}|1-${ms.barEnd}|4.999`;
+
+    if (ms.pitches === null) {
+      transforms.push(`${range}: velocity = 0`);
+      continue;
+    }
+
+    for (const pitch of ms.pitches) {
+      transforms.push(`${pitch} ${range}: velocity = 0`);
+    }
+  }
+
+  return transforms;
+}

--- a/src/tools/clip/microsection-mute/tests/microsection-mute.test.ts
+++ b/src/tools/clip/microsection-mute/tests/microsection-mute.test.ts
@@ -1,0 +1,153 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { buildTransforms, parseMicrosections } from "../microsection-mute.ts";
+
+describe("parseMicrosections", () => {
+  it("parses a 4-microsection arc", () => {
+    const input = `
+      1-2: Eb1, F#1
+      3-4: F#1
+      5-6:
+      7-8: Eb1, F#1, G#1
+    `;
+
+    const parsed = parseMicrosections(input);
+
+    expect(parsed).toHaveLength(4);
+
+    expect(parsed[0]).toMatchObject({
+      barStart: 1,
+      barEnd: 2,
+      pitches: ["Eb1", "F#1"],
+    });
+
+    expect(parsed[1]).toMatchObject({
+      barStart: 3,
+      barEnd: 4,
+      pitches: ["F#1"],
+    });
+
+    expect(parsed[2]).toMatchObject({
+      barStart: 5,
+      barEnd: 6,
+      pitches: [],
+    });
+
+    expect(parsed[3]).toMatchObject({
+      barStart: 7,
+      barEnd: 8,
+      pitches: ["Eb1", "F#1", "G#1"],
+    });
+  });
+
+  it("treats 'all' as a whole-clip mute (pitches=null)", () => {
+    const parsed = parseMicrosections("1-4: all");
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.pitches).toBeNull();
+  });
+
+  it("accepts MIDI note numbers as pitches", () => {
+    const parsed = parseMicrosections("1-2: 39, 54");
+
+    expect(parsed[0]?.pitches).toStrictEqual(["39", "54"]);
+  });
+
+  it("supports single-bar ranges (barStart == barEnd)", () => {
+    const parsed = parseMicrosections("3-3: F#1");
+
+    expect(parsed[0]).toMatchObject({ barStart: 3, barEnd: 3 });
+  });
+
+  it("strips inline comments and skips comment-only lines", () => {
+    const input = `
+      # this is a comment line, should be ignored
+      1-2: Eb1   # mute clap during intro
+      3-4: F#1
+    `;
+
+    const parsed = parseMicrosections(input);
+
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0]?.pitches).toStrictEqual(["Eb1"]);
+  });
+
+  it("ignores empty lines and extra whitespace", () => {
+    const parsed = parseMicrosections("\n\n  1-2:   Eb1  ,  F#1  \n\n");
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.pitches).toStrictEqual(["Eb1", "F#1"]);
+  });
+
+  it("throws when a line has no colon", () => {
+    expect(() => parseMicrosections("1-2 Eb1")).toThrow(/missing ':'/);
+  });
+
+  it("throws when bar range has no dash", () => {
+    expect(() => parseMicrosections("12: Eb1")).toThrow(
+      /missing '-' separator/,
+    );
+  });
+
+  it("throws when barStart is not a positive integer", () => {
+    expect(() => parseMicrosections("0-2: Eb1")).toThrow(/positive integer/);
+    expect(() => parseMicrosections("abc-2: Eb1")).toThrow(/positive integer/);
+  });
+
+  it("throws when barEnd < barStart", () => {
+    expect(() => parseMicrosections("4-2: Eb1")).toThrow(
+      /barEnd must be >= barStart/,
+    );
+  });
+});
+
+describe("buildTransforms", () => {
+  it("emits one transform per pitch with bar-range velocity = 0", () => {
+    const parsed = parseMicrosections("1-2: Eb1, F#1");
+
+    expect(buildTransforms(parsed)).toStrictEqual([
+      "Eb1 1|1-2|4.999: velocity = 0",
+      "F#1 1|1-2|4.999: velocity = 0",
+    ]);
+  });
+
+  it("emits a single whole-clip transform when pitches is 'all'", () => {
+    const parsed = parseMicrosections("7-8: all");
+
+    expect(buildTransforms(parsed)).toStrictEqual([
+      "7|1-8|4.999: velocity = 0",
+    ]);
+  });
+
+  it("emits no transform for an empty pitch list (peak microsection)", () => {
+    const parsed = parseMicrosections("5-6:");
+
+    expect(buildTransforms(parsed)).toStrictEqual([]);
+  });
+
+  it("combines all microsections in order", () => {
+    const input = `
+      1-2: Eb1
+      3-4: F#1
+      5-6:
+      7-8: all
+    `;
+
+    const transforms = buildTransforms(parseMicrosections(input));
+
+    expect(transforms).toStrictEqual([
+      "Eb1 1|1-2|4.999: velocity = 0",
+      "F#1 3|1-4|4.999: velocity = 0",
+      "7|1-8|4.999: velocity = 0",
+    ]);
+  });
+
+  it("uses 4.999 as end-beat to cover the full final bar", () => {
+    const transforms = buildTransforms(parseMicrosections("1-1: C3"));
+
+    expect(transforms[0]).toMatch(/-1\|4\.999:/);
+  });
+});


### PR DESCRIPTION
### **User description**
Closes #123. First feature of the action layer umbrella #122.

## Why

PR #121 landed the `indie-dance-microsection-arc` finding as docs. Doc says: to silence elements per microsection, write 4-8 `adj-update-clip` transform calls by hand. This wraps that into a single deterministic MCP call. The AI picks a microsection map, fires one tool, MCP executes — no per-element transform plumbing.

## API

```ts
adj-microsection-mute({
  clipIds: "5",                // comma-separated clip IDs
  microsections: `
    1-2: Eb1, F#1   # intro: mute clap + open hat
    3-4: F#1        # lift: mute open hat only
    5-6:            # peak: everything plays
    7-8: all        # resolution: silence the whole clip
  `,
})
```

Grammar:
- `<barStart>-<barEnd>: <pitch1>, <pitch2>, ...` — mute named pitches in range
- `<barStart>-<barEnd>: all` — mute whole clip across range
- `<barStart>-<barEnd>:` — no mute (peak microsection, declaratively present)
- Pitches: MIDI note names (`Eb1`, `F#3`, `C-1`) or numbers (`39`, `54`)
- `#` is a comment marker only at line-start or after whitespace — sharps inside note names (`F#1`) are preserved

## How it works

Builds a `transforms` string of `velocity = 0` rules and delegates to `adj-update-clip` in merge mode. Existing notes survive, only velocities in the requested ranges go to 0.

End-bar coverage uses `<barEnd>|4.999` to catch the final 16th in 4/4. Velocity = 0 (not delete) is intentional so humanized notes with timing nudged off-grid still get caught — see CLAUDE.md root rule "v0 won't delete humanized notes."

## Files

- `src/tools/clip/microsection-mute/microsection-mute.def.ts` — zod schema + tool annotations
- `src/tools/clip/microsection-mute/microsection-mute.ts` — handler with parser + transform builder
- `src/tools/clip/microsection-mute/tests/microsection-mute.test.ts` — 15 unit tests
- `src/mcp-server/create-mcp-server.ts` — register `toolDefMicrosectionMute`
- `src/live-api-adapter/live-api-adapter.ts` — dispatch to handler
- `src/mcp-server/tests/create-express-app.test.ts` — add tool name to expected list

## Test plan

- [x] 15 new unit tests cover parser grammar (4-microsection arc, `all`, `#` comments, sharp-note edge case, errors) and transform-string builder
- [x] Full suite passes (3778 / 3778)
- [x] Lint, typecheck, format clean
- [ ] Live e2e: apply to a humanized indie-dance drum clip in Ableton, confirm muted bars play silent and non-muted bars unchanged. (Requires manual check — no Ableton in CI.)

## Out of scope (follow-ups in #122)

- Element-name layer (`pitchMap: { clap: "Eb1" }`) — defer to recipe RFC
- Auto-detection of microsection boundaries from arrangement analysis
- Genre presets (`indie-dance-default`, `melodic-techno-default`)
- Time-signature-aware end-bar coverage (currently assumes 4/4)


___

### **PR Type**
Enhancement


___

### **Description**
- Introduces `adj-microsection-mute` tool for clip muting.

- Mutes specific pitches or entire clips across bar ranges.

- Utilizes a multi-line `microsections` map for control.

- Delegates to `adj-update-clip` using `velocity = 0` transforms.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A[AI Session] -- "calls" --> B{adj-microsection-mute}
    B -- "input: clipIds, microsections map" --> C[microsection-mute.ts]
    C -- "parses & builds transforms" --> D[adj-update-clip]
    D -- "modifies" --> E[Ableton Live Clips]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>live-api-adapter.ts</strong><dd><code>Register `adj-microsection-mute` tool in adapter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/live-api-adapter/live-api-adapter.ts

<ul><li>Imports the new <code>microsectionMute</code> function.<br> <li> Registers <code>adj-microsection-mute</code> in the <code>tools</code> object.<br> <li> Ensures <code>initHoldingArea()</code> is called before <code>microsectionMute</code> execution.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/126/files#diff-c3a24f2d8f92d74167cb7edd9f305472348b32e132e241b7f654f7d993292a4d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>microsection-mute.def.ts</strong><dd><code>Define `adj-microsection-mute` tool schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/clip/microsection-mute/microsection-mute.def.ts

<ul><li>Defines the <code>adj-microsection-mute</code> tool with its title and description.<br> <li> Specifies <code>readOnlyHint: false</code> and <code>destructiveHint: true</code>.<br> <li> Defines the <code>inputSchema</code> for <code>clipIds</code> and <code>microsections</code>, including <br>detailed grammar.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/126/files#diff-f3045ed4c71485f1f8451ae59ec9d8501725df91cac5d2288ad53e929fed6a9d">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>microsection-mute.ts</strong><dd><code>Implement `microsectionMute` core logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/clip/microsection-mute/microsection-mute.ts

<ul><li>Implements the <code>microsectionMute</code> function to apply mute maps to clips.<br> <li> Includes helper functions for parsing <code>microsections</code> input and building <br>transform strings.<br> <li> Delegates to <code>adj-update-clip</code> in <code>merge</code> mode with <code>velocity = 0</code> <br>transforms.<br> <li> Handles error cases for missing <code>clipIds</code> or <code>microsections</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/126/files#diff-1e5dc365192cd4fd2468fafef83c7dcfc1c1e9b7b650b8253b5f2d85ebbd5c3d">+230/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-mcp-server.ts</strong><dd><code>Register `adj-microsection-mute` tool definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/mcp-server/create-mcp-server.ts

<ul><li>Imports <code>toolDefMicrosectionMute</code>.<br> <li> Adds <code>toolDefMicrosectionMute</code> to the <code>STANDARD_TOOL_DEFS</code> array.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/126/files#diff-9aedb34621fd14bd2830d9f454c3b5fbf3fc108d294bcc60b01f4247cd306f04">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-express-app.test.ts</strong><dd><code>Add `adj-microsection-mute` to exposed tools test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/mcp-server/tests/create-express-app.test.ts

<ul><li>Adds <code>adj-microsection-mute</code> to the list of expected tool names.<br> <li> Verifies the new tool is exposed by the MCP Express app.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/126/files#diff-ba023da9e605a5eb98132a10ff03265f8f4a2a7037de25f2d4622fac0d85c0c9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>microsection-mute.test.ts</strong><dd><code>Add unit tests for `microsection-mute` parsing and transforms</code></dd></summary>
<hr>

src/tools/clip/microsection-mute/tests/microsection-mute.test.ts

<ul><li>Adds unit tests for <code>parseMicrosections</code> covering various input formats, <br>comments, and whitespace.<br> <li> Includes tests for <code>buildTransforms</code> to verify correct transform string <br>generation for pitches and whole clips.<br> <li> Tests error handling for invalid bar ranges or missing separators.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/126/files#diff-a00dfa60babe85d92cb62cf70c1fd5c012c9aa2733c7d171631a027f1bef0eeb">+153/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

