### PR TITLE
docs: fix stale macOS log path (Producer Pal -> Ableton DJ MCP)

### DIFF
--- a/docs/contributing/Development-Tools.md
+++ b/docs/contributing/Development-Tools.md
@@ -214,7 +214,7 @@ ENABLE_LOGGING=true VERBOSE_LOGGING=true node scripts/test/test-claude-desktop-e
 **macOS:**
 
 ```bash
-tail -f ~/Library/Logs/Producer\ Pal/*.log
+tail -f ~/Library/Logs/Ableton\ DJ\ MCP/*.log
 ```
 
 **Windows:**


### PR DESCRIPTION
### **User description**
## Summary
- Leftover from the project rename: `docs/contributing/Development-Tools.md` line 217 told macOS users to `tail -f ~/Library/Logs/Producer\ Pal/*.log`. The Windows path two lines below already correctly said "Ableton DJ MCP" -- only macOS was stale.
- `src/portal/file-logger.ts:17` confirms `APP_NAME = "Ableton DJ MCP"` is the actual runtime log directory name.

## Test plan
N/A -- doc-only fix, verified against the source constant.


___

### **PR Type**
Documentation


___

### **Description**
- Update macOS log path in development documentation


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Development-Tools.md</strong><dd><code>Update macOS log file path in development documentation</code>&nbsp; &nbsp; </dd></summary>
<hr>

docs/contributing/Development-Tools.md

<ul><li>Corrected the macOS log file path from <code>~/Library/Logs/Producer\ </code><br><code>Pal/*.log</code> to <code>~/Library/Logs/Ableton\ DJ\ MCP/*.log</code>.<br> <li> Ensured consistency with the actual application name <code>Ableton DJ MCP</code> <br>used for logging.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/233/files#diff-eabef4b17c2dbc7c7890c039841db84865b1df6ebfb7db6ea41352d559d50ff0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

