### PR TITLE
feat: expose global groove amount get/set

### DIFF
--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -29,13 +29,15 @@ configured sample folder.
 
 ### `adj-read-live-set`
 
-Read the current Live Set overview: name, tempo, time signature, tracks, scenes.
+Read the current Live Set overview: name, tempo, time signature, groove amount,
+tracks, scenes.
 
 - `include: ["tracks", "scenes", "locators"]` for details
 
 ### `adj-update-live-set`
 
-Update Live Set properties: tempo, time signature, name, locators.
+Update Live Set properties: tempo, time signature, groove amount, name,
+locators.
 
 ---
 

--- a/src/tools/live-set/read-live-set.ts
+++ b/src/tools/live-set/read-live-set.ts
@@ -54,6 +54,7 @@ export function readLiveSet(
     ...(liveSetName ? { name: liveSetName } : {}),
     tempo: liveSet.getProperty("tempo"),
     timeSignature: liveSet.timeSignature,
+    grooveAmount: liveSet.getProperty("groove_amount"),
   };
 
   // Include full scene details or just the count

--- a/src/tools/live-set/tests/read-live-set-basic.test.ts
+++ b/src/tools/live-set/tests/read-live-set-basic.test.ts
@@ -144,6 +144,7 @@ describe("readLiveSet - basic reading", () => {
       isPlaying: true,
       tempo: 120,
       timeSignature: "4/4",
+      grooveAmount: 0,
       scale: "C Major",
       scalePitches: "C,D,E,F,G,A,B",
       returnTracks: [],
@@ -236,6 +237,7 @@ describe("readLiveSet - basic reading", () => {
           signature_numerator: 3,
           signature_denominator: 4,
           tempo: 100,
+          groove_amount: 0.6,
           tracks: [],
           return_tracks: children(),
           scenes: [],
@@ -252,6 +254,7 @@ describe("readLiveSet - basic reading", () => {
       name: "Empty Live Set",
       tempo: 100,
       timeSignature: "3/4",
+      grooveAmount: 0.6,
       tracks: [],
       returnTracks: [],
       masterTrack: expect.objectContaining({

--- a/src/tools/live-set/tests/update-live-set.test.ts
+++ b/src/tools/live-set/tests/update-live-set.test.ts
@@ -62,6 +62,26 @@ describe("updateLiveSet", () => {
     expect(result2).toStrictEqual({ id: "live_set_id" });
   });
 
+  it("should update groove amount", async () => {
+    const result = await updateLiveSet({ groove: 0.75 });
+
+    expect(liveSet.set).toHaveBeenCalledWith("groove_amount", 0.75);
+    expect(result).toStrictEqual({
+      id: "live_set_id",
+      groove: 0.75,
+    });
+  });
+
+  it("should update groove amount at boundary values", async () => {
+    const resultMin = await updateLiveSet({ groove: 0 });
+    const resultMax = await updateLiveSet({ groove: 1 });
+
+    expect(liveSet.set).toHaveBeenCalledWith("groove_amount", 0);
+    expect(liveSet.set).toHaveBeenCalledWith("groove_amount", 1);
+    expect(resultMin).toStrictEqual({ id: "live_set_id", groove: 0 });
+    expect(resultMax).toStrictEqual({ id: "live_set_id", groove: 1 });
+  });
+
   it("should update time signature", async () => {
     const result = await updateLiveSet({ timeSignature: "3/4" });
 

--- a/src/tools/live-set/update-live-set.def.ts
+++ b/src/tools/live-set/update-live-set.def.ts
@@ -15,6 +15,12 @@ export const toolDefUpdateLiveSet = defineTool("adj-update-live-set", {
   inputSchema: {
     tempo: z.coerce.number().min(20).max(999).optional().describe("BPM"),
     timeSignature: z.string().optional().describe("N/D (4/4)"),
+    groove: z.coerce
+      .number()
+      .min(0)
+      .max(1)
+      .optional()
+      .describe("Global groove pool amount (0.0-1.0)"),
     scale: z
       .string()
       .optional()

--- a/src/tools/live-set/update-live-set.ts
+++ b/src/tools/live-set/update-live-set.ts
@@ -27,6 +27,7 @@ import {
 interface UpdateLiveSetArgs {
   tempo?: number;
   timeSignature?: string;
+  groove?: number;
   scale?: string;
   locatorOperation?: string;
   locatorId?: string;
@@ -58,6 +59,7 @@ type UpdateLiveSetContext = Partial<ToolContext> & { silenceWavPath?: string };
  * @param args - The parameters
  * @param args.tempo - Set tempo in BPM (20.0-999.0)
  * @param args.timeSignature - Time signature in format "4/4"
+ * @param args.groove - Global groove pool amount (0.0-1.0)
  * @param args.scale - Scale in format "Root ScaleName"
  * @param args.locatorOperation - Locator operation: "create", "delete", or "rename"
  * @param args.locatorId - Locator ID for delete/rename
@@ -71,6 +73,7 @@ export async function updateLiveSet(
   {
     tempo,
     timeSignature,
+    groove,
     scale,
     locatorOperation,
     locatorId,
@@ -97,6 +100,11 @@ export async function updateLiveSet(
     liveSet.set("signature_numerator", parsed.numerator);
     liveSet.set("signature_denominator", parsed.denominator);
     result.timeSignature = `${parsed.numerator}/${parsed.denominator}`;
+  }
+
+  if (groove != null) {
+    liveSet.set("groove_amount", groove);
+    result.groove = groove;
   }
 
   if (scale != null) {


### PR DESCRIPTION
### **User description**
## Summary
- `groove` param on `adj-update-live-set` (0.0-1.0) -> `song.groove_amount`
- `grooveAmount` in `adj-read-live-set` response, always present alongside `tempo`/`timeSignature`
- Follows the existing `tempo` pattern exactly (same schema shape, same inline handling in `updateLiveSet`)

## Why
Groove is one of the most important feel parameters in electronic music. Genre skills already reference specific swing/groove targets (House 52-55%, Tech House 50-52%, etc) but the AI had no way to actually set the groove pool strength before this -- it could only describe the target, not apply it.

Closes #27

## Test plan
- [x] `npm run check` -- lint, typecheck, format, duplication, full test suite (3780 tests) all pass
- [x] Added unit tests: groove set (including 0/1 boundary values), and a read-side test verifying passthrough of a nonzero `groove_amount` mock value (not just the default)
- [x] Updated `docs/Tools-Reference.md`


___

### **PR Type**
Enhancement


___

### **Description**
- Expose global groove amount for Live Set.

- Add `groove` parameter to `adj-update-live-set`.

- Include `grooveAmount` in `adj-read-live-set` response.

- Add unit tests and update documentation.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  AI["AI/User"] --> UpdateTool["adj-update-live-set"]
  UpdateTool -- "set groove (0.0-1.0)" --> LiveSet["Ableton Live Set"]
  LiveSet -- "read grooveAmount" --> ReadTool["adj-read-live-set"]
  ReadTool --> AI
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>read-live-set.ts</strong><dd><code>Add `grooveAmount` to Live Set read response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/live-set/read-live-set.ts

<ul><li>Adds <code>grooveAmount</code> property to the <code>readLiveSet</code> function's result <br>object.<br> <li> Retrieves the <code>grooveAmount</code> value from <br><code>liveSet.getProperty("groove_amount")</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/236/files#diff-f31d9be76df9a8c4adbcc9a68375b0d694e9a93ad20f2eda59a8e83efd46d8e1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update-live-set.def.ts</strong><dd><code>Define `groove` parameter for `adj-update-live-set` input</code></dd></summary>
<hr>

src/tools/live-set/update-live-set.def.ts

<ul><li>Adds a new <code>groove</code> property to the <code>inputSchema</code> for the <br><code>adj-update-live-set</code> tool.<br> <li> Defines <code>groove</code> as a number between <code>0</code> and <code>1</code> with a descriptive label.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/236/files#diff-1cffc3001d38910471e1c1adda6b75aeb1e93456fb046a692c9b5c73c390ce95">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update-live-set.ts</strong><dd><code>Implement setting global groove amount in `updateLiveSet`</code></dd></summary>
<hr>

src/tools/live-set/update-live-set.ts

<ul><li>Adds <code>groove</code> as an optional parameter to the <code>UpdateLiveSetArgs</code> <br>interface and the <code>updateLiveSet</code> function.<br> <li> Implements logic to set <code>liveSet.set("groove_amount", groove)</code> when the <br><code>groove</code> parameter is provided.<br> <li> Includes the <code>groove</code> value in the function's result.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/236/files#diff-83a1464ec4149aed54896ae474b733d100bb0e92c27e9b06015ee7babb8c06ea">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>read-live-set-basic.test.ts</strong><dd><code>Add tests for reading Live Set groove amount</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/live-set/tests/read-live-set-basic.test.ts

<ul><li>Updates existing test expectations to include <code>grooveAmount: 0</code>.<br> <li> Adds a new test case to verify <code>grooveAmount</code> is correctly read when the <br>mock <code>liveSet</code> has a non-default <code>groove_amount</code> value.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/236/files#diff-3e773aa3593cefc020918b77dd724cc3b6c41042deafbf51738398dcc093e912">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update-live-set.test.ts</strong><dd><code>Add tests for updating Live Set groove amount</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/live-set/tests/update-live-set.test.ts

<ul><li>Adds unit tests to verify <code>updateLiveSet</code> correctly sets the <br><code>groove_amount</code> property on the <code>liveSet</code> object.<br> <li> Includes tests for a standard value (<code>0.75</code>) and boundary values (<code>0</code> and <br><code>1</code>).<br> <li> Asserts the <code>updateLiveSet</code> result includes the <code>groove</code> value.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/236/files#diff-1ed74745e0d7b17c36d86fda72b8e7852bdd64a118b06a630ce3e9b8698aa78d">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Tools-Reference.md</strong><dd><code>Update documentation for groove amount in Live Set tools</code>&nbsp; </dd></summary>
<hr>

docs/Tools-Reference.md

<ul><li>Updates the descriptions for <code>adj-read-live-set</code> and <br><code>adj-update-live-set</code>.<br> <li> Explicitly mentions the new "groove amount" functionality in the tool <br>references.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/236/files#diff-1144a39ffd998b6c8832a8e6e38fae79a98231f8e64046307c61134a0b297194">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

