### PR TITLE
feat: expose Ableton Link controls and tempo nudge

### DIFF
--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -30,14 +30,14 @@ configured sample folder.
 ### `adj-read-live-set`
 
 Read the current Live Set overview: name, tempo, time signature, groove amount,
-tracks, scenes.
+Ableton Link status, tracks, scenes.
 
 - `include: ["tracks", "scenes", "locators"]` for details
 
 ### `adj-update-live-set`
 
-Update Live Set properties: tempo, time signature, groove amount, name,
-locators.
+Update Live Set properties: tempo, time signature, groove amount, Ableton Link
+(enable/disable, force beat time), name, locators.
 
 ---
 
@@ -207,6 +207,7 @@ Control transport, session clips, and Live set history.
   - `"capture-scene"` — snapshot playing session clips into a new scene
   - `"record"` — toggle arrangement record mode
   - `"re-enable-automation"` — re-engage automation overridden by manual edits
+  - `"nudge-tempo"` — brief tempo bump for beat matching (requires `nudge`)
 - Response includes `playing`, `currentTime`, optional `arrangementLoop`.
 - For `"undo"` / `"redo"` / `"save"`, response also includes `canUndo` and
   `canRedo` booleans — check these before calling undo/redo to avoid no-ops.

--- a/src/tools/control/helpers/playback-helpers.ts
+++ b/src/tools/control/helpers/playback-helpers.ts
@@ -299,7 +299,8 @@ export type StandalonePlaybackAction =
   | "capture-midi"
   | "capture-scene"
   | "record"
-  | "re-enable-automation";
+  | "re-enable-automation"
+  | "nudge-tempo";
 
 interface StandalonePlaybackResult {
   playing: boolean;
@@ -310,13 +311,15 @@ interface StandalonePlaybackResult {
 /**
  * Handle standalone Live set workflow actions that don't take transport or
  * loop params (back-to-arranger, capture-midi, capture-scene, record,
- * re-enable-automation).
+ * re-enable-automation, nudge-tempo).
  *
  * @param action - The standalone action to perform
+ * @param nudge - Direction for nudge-tempo ("up" or "down")
  * @returns Current transport state plus optional recording flag for record
  */
 export function handleStandalonePlaybackAction(
   action: StandalonePlaybackAction,
+  nudge?: string,
 ): StandalonePlaybackResult {
   const liveSet = LiveAPI.from(livePath.liveSet);
   let recording: boolean | undefined;
@@ -343,6 +346,16 @@ export function handleStandalonePlaybackAction(
 
     case "re-enable-automation":
       liveSet.call("re_enable_automation");
+      break;
+
+    case "nudge-tempo":
+      if (nudge !== "up" && nudge !== "down") {
+        throw new Error(
+          'playback failed: nudge-tempo requires nudge param ("up" or "down")',
+        );
+      }
+
+      liveSet.call(nudge === "up" ? "nudge_up" : "nudge_down");
       break;
     default:
       throw new Error(

--- a/src/tools/control/playback.def.ts
+++ b/src/tools/control/playback.def.ts
@@ -32,6 +32,7 @@ export const toolDefPlayback = defineTool("adj-playback", {
         "capture-scene",
         "record",
         "re-enable-automation",
+        "nudge-tempo",
       ])
       .describe(
         `play-arrangement: from startTime
@@ -48,7 +49,8 @@ back-to-arranger: clear session override so arrangement resumes
 capture-midi: retroactively capture buffered MIDI into a clip
 capture-scene: capture currently playing session clips into a new scene
 record: toggle arrangement record mode (returns recording state)
-re-enable-automation: re-engage automation overridden by manual changes`,
+re-enable-automation: re-engage automation overridden by manual changes
+nudge-tempo: brief tempo bump for beat matching (requires nudge param)`,
       ),
     startTime: z
       .string()
@@ -87,6 +89,10 @@ re-enable-automation: re-engage automation overridden by manual changes`,
       .min(0)
       .optional()
       .describe("0-based scene index for play-scene"),
+    nudge: z
+      .enum(["up", "down"])
+      .optional()
+      .describe("Direction for nudge-tempo action"),
   },
 
   smallModelModeConfig: {

--- a/src/tools/control/playback.ts
+++ b/src/tools/control/playback.ts
@@ -44,6 +44,7 @@ interface PlaybackArgs {
   ids?: string;
   slots?: string;
   focus?: boolean;
+  nudge?: string;
 }
 
 interface PlaybackResult {
@@ -61,6 +62,7 @@ const STANDALONE_ACTIONS = new Set<StandalonePlaybackAction>([
   "capture-scene",
   "record",
   "re-enable-automation",
+  "nudge-tempo",
 ]);
 
 function isStandaloneAction(
@@ -95,6 +97,7 @@ interface BuildPlaybackResultParams {
  * @param args.ids - Comma-separated clip IDs for Session view operations
  * @param args.slots - Comma-separated trackIndex/sceneIndex slot positions
  * @param args.focus - Switch to arrangement or session view based on action
+ * @param args.nudge - Direction for nudge-tempo action ("up" or "down")
  * @param _context - Internal context object (unused, for consistent tool interface)
  * @returns Result with transport state
  */
@@ -112,6 +115,7 @@ export function playback(
     ids,
     slots,
     focus,
+    nudge,
   }: PlaybackArgs = {},
   _context: Partial<ToolContext> = {},
 ): PlaybackResult {
@@ -124,10 +128,10 @@ export function playback(
     return handleLiveSetHistory(action);
   }
 
-  // back-to-arranger, capture-midi, capture-scene, record, re-enable-automation
-  // are standalone workflow actions that bypass transport/loop param handling
+  // back-to-arranger, capture-midi, capture-scene, record, re-enable-automation,
+  // nudge-tempo are standalone workflow actions that bypass transport/loop param handling
   if (isStandaloneAction(action)) {
-    return handleStandalonePlaybackAction(action);
+    return handleStandalonePlaybackAction(action, nudge);
   }
 
   if (ids != null && slots != null) {

--- a/src/tools/control/tests/playback-basic.test.ts
+++ b/src/tools/control/tests/playback-basic.test.ts
@@ -719,6 +719,47 @@ describe("transport", () => {
     });
   });
 
+  it("should nudge tempo up", () => {
+    liveSet = setupPlaybackLiveSet({
+      is_playing: 1,
+      current_song_time: 0,
+    });
+
+    const result = playback({ action: "nudge-tempo", nudge: "up" });
+
+    expect(liveSet.call).toHaveBeenCalledWith("nudge_up");
+    expect(result).toStrictEqual({
+      playing: true,
+      currentTime: "1|1",
+    });
+  });
+
+  it("should nudge tempo down", () => {
+    liveSet = setupPlaybackLiveSet({
+      is_playing: 1,
+      current_song_time: 0,
+    });
+
+    const result = playback({ action: "nudge-tempo", nudge: "down" });
+
+    expect(liveSet.call).toHaveBeenCalledWith("nudge_down");
+    expect(result).toStrictEqual({
+      playing: true,
+      currentTime: "1|1",
+    });
+  });
+
+  it("should throw when nudge-tempo is missing nudge param", () => {
+    liveSet = setupPlaybackLiveSet({
+      is_playing: 1,
+      current_song_time: 0,
+    });
+
+    expect(() => playback({ action: "nudge-tempo" })).toThrow(
+      'nudge-tempo requires nudge param ("up" or "down")',
+    );
+  });
+
   it("should not touch transport or loop params for standalone actions", () => {
     liveSet = setupPlaybackLiveSet({
       is_playing: 0,

--- a/src/tools/live-set/read-live-set.ts
+++ b/src/tools/live-set/read-live-set.ts
@@ -55,6 +55,8 @@ export function readLiveSet(
     tempo: liveSet.getProperty("tempo"),
     timeSignature: liveSet.timeSignature,
     grooveAmount: liveSet.getProperty("groove_amount"),
+    linkEnabled: (liveSet.getProperty("link_enable") as number) > 0,
+    linkPeers: liveSet.getProperty("link_num_peers"),
   };
 
   // Include full scene details or just the count

--- a/src/tools/live-set/tests/read-live-set-basic.test.ts
+++ b/src/tools/live-set/tests/read-live-set-basic.test.ts
@@ -145,6 +145,8 @@ describe("readLiveSet - basic reading", () => {
       tempo: 120,
       timeSignature: "4/4",
       grooveAmount: 0,
+      linkEnabled: false,
+      linkPeers: 0,
       scale: "C Major",
       scalePitches: "C,D,E,F,G,A,B",
       returnTracks: [],
@@ -255,6 +257,8 @@ describe("readLiveSet - basic reading", () => {
       tempo: 100,
       timeSignature: "3/4",
       grooveAmount: 0.6,
+      linkEnabled: false,
+      linkPeers: 0,
       tracks: [],
       returnTracks: [],
       masterTrack: expect.objectContaining({

--- a/src/tools/live-set/tests/update-live-set.test.ts
+++ b/src/tools/live-set/tests/update-live-set.test.ts
@@ -82,6 +82,30 @@ describe("updateLiveSet", () => {
     expect(resultMax).toStrictEqual({ id: "live_set_id", groove: 1 });
   });
 
+  it("should enable Ableton Link", async () => {
+    const result = await updateLiveSet({ link: true });
+
+    expect(liveSet.set).toHaveBeenCalledWith("link_enable", true);
+    expect(result).toStrictEqual({ id: "live_set_id", link: true });
+  });
+
+  it("should disable Ableton Link", async () => {
+    const result = await updateLiveSet({ link: false });
+
+    expect(liveSet.set).toHaveBeenCalledWith("link_enable", false);
+    expect(result).toStrictEqual({ id: "live_set_id", link: false });
+  });
+
+  it("should force Link beat time", async () => {
+    const result = await updateLiveSet({ forceLinkBeatTime: 16.5 });
+
+    expect(liveSet.call).toHaveBeenCalledWith("force_link_beat_time", 16.5);
+    expect(result).toStrictEqual({
+      id: "live_set_id",
+      forceLinkBeatTime: 16.5,
+    });
+  });
+
   it("should update time signature", async () => {
     const result = await updateLiveSet({ timeSignature: "3/4" });
 

--- a/src/tools/live-set/update-live-set.def.ts
+++ b/src/tools/live-set/update-live-set.def.ts
@@ -21,6 +21,11 @@ export const toolDefUpdateLiveSet = defineTool("adj-update-live-set", {
       .max(1)
       .optional()
       .describe("Global groove pool amount (0.0-1.0)"),
+    link: z.boolean().optional().describe("Enable/disable Ableton Link"),
+    forceLinkBeatTime: z.coerce
+      .number()
+      .optional()
+      .describe("Force all Link peers to this beat time"),
     scale: z
       .string()
       .optional()

--- a/src/tools/live-set/update-live-set.ts
+++ b/src/tools/live-set/update-live-set.ts
@@ -28,6 +28,8 @@ interface UpdateLiveSetArgs {
   tempo?: number;
   timeSignature?: string;
   groove?: number;
+  link?: boolean;
+  forceLinkBeatTime?: number;
   scale?: string;
   locatorOperation?: string;
   locatorId?: string;
@@ -60,6 +62,8 @@ type UpdateLiveSetContext = Partial<ToolContext> & { silenceWavPath?: string };
  * @param args.tempo - Set tempo in BPM (20.0-999.0)
  * @param args.timeSignature - Time signature in format "4/4"
  * @param args.groove - Global groove pool amount (0.0-1.0)
+ * @param args.link - Enable/disable Ableton Link
+ * @param args.forceLinkBeatTime - Force all Link peers to this beat time
  * @param args.scale - Scale in format "Root ScaleName"
  * @param args.locatorOperation - Locator operation: "create", "delete", or "rename"
  * @param args.locatorId - Locator ID for delete/rename
@@ -74,6 +78,8 @@ export async function updateLiveSet(
     tempo,
     timeSignature,
     groove,
+    link,
+    forceLinkBeatTime,
     scale,
     locatorOperation,
     locatorId,
@@ -105,6 +111,16 @@ export async function updateLiveSet(
   if (groove != null) {
     liveSet.set("groove_amount", groove);
     result.groove = groove;
+  }
+
+  if (link != null) {
+    liveSet.set("link_enable", link);
+    result.link = link;
+  }
+
+  if (forceLinkBeatTime != null) {
+    liveSet.call("force_link_beat_time", forceLinkBeatTime);
+    result.forceLinkBeatTime = forceLinkBeatTime;
   }
 
   if (scale != null) {


### PR DESCRIPTION
### **User description**
## Summary
- `link: boolean` on `adj-update-live-set` -> `song.link_enable`
- `forceLinkBeatTime: number` on `adj-update-live-set` -> `song.force_link_beat_time(beat_time)`
- `linkEnabled` and `linkPeers` in `adj-read-live-set` response, always present alongside `tempo`/`grooveAmount`
- New `nudge-tempo` action on `adj-playback` with a `nudge: "up" | "down"` param -> `song.nudge_up()` / `song.nudge_down()`, implemented as a standalone action following the existing pattern (`back-to-arranger`, `record`, etc.)

## Why
This project is DJ and live performance focused. Ableton Link is the standard protocol for syncing Live with other devices on stage or in the studio. Nudge is specifically a DJ tool for correcting beat drift mid-set.

Closes #31

## Test plan
- [x] `npm run check` -- lint, typecheck, format, duplication, full test suite (3786 tests) all pass
- [x] Added unit tests: link enable/disable, force beat time, nudge up/down, and the missing-nudge-param error path
- [x] Updated `docs/Tools-Reference.md`


___

### **PR Type**
Enhancement


___

### **Description**
- Expose Ableton Link controls for enable/disable and force beat time.

- Add `nudge-tempo` action to `adj-playback` for beat matching.

- Return Ableton Link status (`linkEnabled`, `linkPeers`) in `adj-read-live-set`.

- Implement comprehensive unit tests for all new Link and Nudge features.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["adj-update-live-set"] -- "link: boolean, forceLinkBeatTime: number" --> B(LiveAPI);
  C["adj-playback"] -- "action: 'nudge-tempo', nudge: 'up' | 'down'" --> B;
  B -- "link_enable, link_num_peers" --> D["adj-read-live-set"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>playback-helpers.ts</strong><dd><code>Add `nudge-tempo` action and its implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/237/files#diff-05ab9cf559b1d3b4ed898c4131a96323572affe458c672ba9e61b975e146abab">+15/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>playback.ts</strong><dd><code>Integrate `nudge` parameter into playback action handling</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/237/files#diff-d57c15906519423ad1c1e4baf933a94f6dc25f5f7ee2a2a42411a60931cb09b8">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>read-live-set.ts</strong><dd><code>Include Ableton Link status in `adj-read-live-set` response</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/237/files#diff-f31d9be76df9a8c4adbcc9a68375b0d694e9a93ad20f2eda59a8e83efd46d8e1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-live-set.ts</strong><dd><code>Implement Ableton Link enable/disable and force beat time logic</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/237/files#diff-83a1464ec4149aed54896ae474b733d100bb0e92c27e9b06015ee7babb8c06ea">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>playback.def.ts</strong><dd><code>Define `nudge-tempo` action and `nudge` parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/237/files#diff-2bcfb6c4203d965090006ce841963f029354eb6a1f34c06cab68450faf4ebbe0">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-live-set.def.ts</strong><dd><code>Define `link` and `forceLinkBeatTime` parameters for update-live-set</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/237/files#diff-1cffc3001d38910471e1c1adda6b75aeb1e93456fb046a692c9b5c73c390ce95">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>playback-basic.test.ts</strong><dd><code>Add unit tests for `nudge-tempo` action and error handling</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/237/files#diff-2d8f54b27de5dc015c8e2be551e61f38b93d09b5e4159f43d6e006c66f7d1384">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>read-live-set-basic.test.ts</strong><dd><code>Update tests to reflect new Ableton Link status in read-live-set</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/237/files#diff-3e773aa3593cefc020918b77dd724cc3b6c41042deafbf51738398dcc093e912">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-live-set.test.ts</strong><dd><code>Add unit tests for Ableton Link enable/disable and force beat time</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/237/files#diff-1ed74745e0d7b17c36d86fda72b8e7852bdd64a118b06a630ce3e9b8698aa78d">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Tools-Reference.md</strong><dd><code>Update documentation for new Ableton Link and `nudge-tempo` features</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/237/files#diff-1144a39ffd998b6c8832a8e6e38fae79a98231f8e64046307c61134a0b297194">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

