### PR TITLE
feat: expose granular clip properties

### DIFF
--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -90,6 +90,7 @@ Read clip content and properties.
 - Session clip: `slot: "trackIndex/sceneIndex"` (e.g., `"0/3"`)
 - Arrangement clip: `trackIndex` + `arrangementStart`
 - `include: ["notes", "timing", "sample", "warp"]` for details
+- `playingPosition` in the response while the clip is playing
 
 ### `adj-create-clip`
 
@@ -105,7 +106,9 @@ Create MIDI or audio clips.
 Update existing clip content or properties.
 
 - Add/remove/transform notes via barbeat notation
-- Update name, color, loop settings, volume, pitch
+- Update name, color, loop settings, volume, pitch (`pitchShift` coarse,
+  `pitchFine` cents), `legato`, `muted`, `ramMode`, `velocityAmount` (MIDI)
+- `duplicateLoop: true` doubles the clip's loop length in-place
 - Transform expressions: `velocity *= 0.8`, `pitch += 12`
 
 ---

--- a/src/tools/clip/read/read-clip.ts
+++ b/src/tools/clip/read/read-clip.ts
@@ -63,6 +63,9 @@ export interface ReadClipResult {
   overdubbing?: boolean;
   muted?: boolean;
 
+  // Playback position (only present while playing)
+  playingPosition?: string;
+
   // Location properties
   slot?: string;
   trackIndex?: number | null;
@@ -140,6 +143,21 @@ export function readClip(
 
   // Add boolean state properties
   addBooleanStateProperties(result, clip);
+
+  // Playing position only makes sense while the clip is actually playing
+  if (result.playing) {
+    const timeSigNumerator = clip.getProperty("signature_numerator") as number;
+    const timeSigDenominator = clip.getProperty(
+      "signature_denominator",
+    ) as number;
+    const playingPositionBeats = clip.getProperty("playing_position") as number;
+
+    result.playingPosition = abletonBeatsToBarBeat(
+      playingPositionBeats,
+      timeSigNumerator,
+      timeSigDenominator,
+    );
+  }
 
   // Add location properties (arrangementLength gated behind timing)
   addClipLocationProperties(result, clip, isArrangementClip, includeTiming);

--- a/src/tools/clip/read/tests/read-clip-core.test.ts
+++ b/src/tools/clip/read/tests/read-clip-core.test.ts
@@ -252,6 +252,7 @@ describe("readClip", () => {
       end: "2|2", // loop_end (5 beats = 2|2)
       length: "1:0", // 1 bar
       playing: true,
+      playingPosition: "1|1", // mock defaults playing_position to 0
       gainDb: -70, // gain=0 maps to -70 dB
       sampleLength: 0,
       sampleRate: 0,

--- a/src/tools/clip/update/helpers/update-clip-audio-helpers.ts
+++ b/src/tools/clip/update/helpers/update-clip-audio-helpers.ts
@@ -22,10 +22,14 @@ interface AudioParams {
   gainDb?: number;
   /** Audio clip pitch shift in semitones (-48 to 48) */
   pitchShift?: number;
+  /** Audio clip fine pitch in cents (-100 to 100), independent of pitchShift's coarse component */
+  pitchFine?: number;
   /** Audio clip warp mode */
   warpMode?: string;
   /** Audio clip warping on/off */
   warping?: boolean;
+  /** Load full audio into RAM (prevents seek glitches on short loops) */
+  ramMode?: boolean;
 }
 
 /**
@@ -34,12 +38,14 @@ interface AudioParams {
  * @param params - Audio parameters
  * @param params.gainDb - Audio clip gain in decibels (-70 to 24)
  * @param params.pitchShift - Audio clip pitch shift in semitones (-48 to 48)
+ * @param params.pitchFine - Audio clip fine pitch in cents (-100 to 100)
  * @param params.warpMode - Audio clip warp mode
  * @param params.warping - Audio clip warping on/off
+ * @param params.ramMode - Load full audio into RAM
  */
 export function setAudioParameters(
   clip: LiveAPI,
-  { gainDb, pitchShift, warpMode, warping }: AudioParams,
+  { gainDb, pitchShift, pitchFine, warpMode, warping, ramMode }: AudioParams,
 ): void {
   if (gainDb !== undefined) {
     const liveGain = dbToLiveGain(gainDb);
@@ -49,10 +55,19 @@ export function setAudioParameters(
 
   if (pitchShift !== undefined) {
     const pitchCoarse = Math.floor(pitchShift);
-    const pitchFine = Math.round((pitchShift - pitchCoarse) * 100);
+    const pitchFineFromShift = Math.round((pitchShift - pitchCoarse) * 100);
 
     clip.set("pitch_coarse", pitchCoarse);
+    clip.set("pitch_fine", pitchFineFromShift);
+  }
+
+  // Applied after pitchShift so an explicit pitchFine always wins when both are given
+  if (pitchFine !== undefined) {
     clip.set("pitch_fine", pitchFine);
+  }
+
+  if (ramMode !== undefined) {
+    clip.set("clip_mode", ramMode ? 1 : 0);
   }
 
   if (warpMode !== undefined) {

--- a/src/tools/clip/update/helpers/update-clip-helpers.ts
+++ b/src/tools/clip/update/helpers/update-clip-helpers.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Gabriel Pulga
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import { type ClipContext } from "#src/notation/transform/helpers/transform-evaluator-helpers.ts";
 import * as console from "#src/shared/v8-max-console.ts";
 import { type NoteUpdateResult } from "#src/tools/clip/helpers/clip-result-helpers.ts";
 import { verifyColorQuantization } from "#src/tools/shared/color-verification-helpers.ts";
@@ -11,7 +12,10 @@ import {
   handleWarpMarkerOperation,
 } from "./update-clip-audio-helpers.ts";
 import { handleNoteUpdates } from "./update-clip-notes-helpers.ts";
-import { buildClipPropertiesToSet } from "./update-clip-properties-helpers.ts";
+import {
+  type BuildClipPropertiesArgs,
+  buildClipPropertiesToSet,
+} from "./update-clip-properties-helpers.ts";
 import { handleQuantization } from "./update-clip-quantization-helpers.ts";
 import { handlePositionOperations } from "./update-clip-session-helpers.ts";
 import {
@@ -29,6 +33,8 @@ interface ClipResult {
 export interface ClipAudioWarpQuantizeParams {
   gainDb?: number;
   pitchShift?: number;
+  pitchFine?: number;
+  ramMode?: boolean;
   warpMode?: string;
   warping?: boolean;
   warpOp?: string;
@@ -54,6 +60,10 @@ export interface ProcessSingleClipUpdateParams extends ClipAudioWarpQuantizePara
   length?: string;
   firstStart?: string;
   looping?: boolean;
+  legato?: boolean;
+  muted?: boolean;
+  velocityAmount?: number;
+  duplicateLoop?: boolean;
   arrangementLengthBeats?: number | null;
   arrangementStartBeats?: number | null;
   toSlot?: { trackIndex: number; sceneIndex: number } | null;
@@ -79,6 +89,12 @@ export interface ProcessSingleClipUpdateParams extends ClipAudioWarpQuantizePara
  * @param params.looping - Looping enabled
  * @param params.gainDb - Gain in decibels
  * @param params.pitchShift - Pitch shift amount
+ * @param params.pitchFine - Fine pitch in cents (-100 to 100)
+ * @param params.ramMode - Load full audio into RAM
+ * @param params.legato - Clip keeps playing when re-launched during playback
+ * @param params.muted - Mute individual clip
+ * @param params.velocityAmount - Scales all MIDI note velocities (MIDI clips only)
+ * @param params.duplicateLoop - Double the clip's loop length in-place
  * @param params.warpMode - Warp mode
  * @param params.warping - Warping enabled
  * @param params.warpOp - Warp operation type
@@ -111,8 +127,14 @@ export function processSingleClipUpdate(
     length,
     firstStart,
     looping,
+    legato,
+    muted,
+    velocityAmount,
+    duplicateLoop,
     gainDb,
     pitchShift,
+    pitchFine,
+    ramMode,
     warpMode,
     warping,
     warpOp,
@@ -142,36 +164,21 @@ export function processSingleClipUpdate(
     console.warn("firstStart parameter ignored for non-looping clips");
   }
 
-  // Calculate beat positions (includes end_marker bounds check for start_marker)
-  const { startBeats, endBeats, startMarkerBeats } = calculateBeatPositions({
+  applyTimingAndBasicProperties(clip, {
     start,
     length,
     firstStart,
     timeSigNumerator,
     timeSigDenominator,
-    clip,
     isLooping,
-  });
-
-  // Build and set clip properties
-  const currentLoopEnd = isLooping
-    ? (clip.getProperty("loop_end") as number)
-    : null;
-  const propsToSet = buildClipPropertiesToSet({
     name,
     color,
     timeSignature,
-    timeSigNumerator,
-    timeSigDenominator,
-    startMarkerBeats,
     looping,
-    isLooping,
-    startBeats,
-    endBeats,
-    currentLoopEnd,
+    legato,
+    muted,
+    duplicateLoop,
   });
-
-  clip.setAll(propsToSet);
 
   // Verify color quantization if color was set
   if (color != null) {
@@ -183,10 +190,16 @@ export function processSingleClipUpdate(
   // prettier-ignore
   const clipContext = buildClipContext(clip, clipIndex, clipCount, timeSigNumerator, timeSigDenominator);
 
-  if (isAudioClip) {
-    setAudioParameters(clip, { gainDb, pitchShift, warpMode, warping });
-    applyAudioTransforms(clip, transformString, clipContext);
-  }
+  applyAudioOrMidiParameters(clip, isAudioClip, clipContext, {
+    transformString,
+    gainDb,
+    pitchShift,
+    pitchFine,
+    warpMode,
+    warping,
+    ramMode,
+    velocityAmount,
+  });
 
   // Handle note updates (transforms already applied for audio clips above)
   noteResult = handleNoteUpdates(
@@ -230,4 +243,176 @@ export function processSingleClipUpdate(
     noteResult,
     isNonSurvivor: params.nonSurvivorClipIds?.has(clip.id) ?? false,
   });
+}
+
+/**
+ * Build and apply basic clip properties (name, color, timing, legato, muted)
+ * @param clip - The clip to update
+ * @param args - Property building arguments, forwarded to buildClipPropertiesToSet
+ */
+function applyBasicClipProperties(
+  clip: LiveAPI,
+  args: BuildClipPropertiesArgs,
+): void {
+  const propsToSet = buildClipPropertiesToSet(args);
+
+  clip.setAll(propsToSet);
+}
+
+interface TimingAndBasicPropertiesParams {
+  start?: string;
+  length?: string;
+  firstStart?: string;
+  timeSigNumerator: number;
+  timeSigDenominator: number;
+  isLooping: boolean;
+  name?: string;
+  color?: string;
+  timeSignature?: string;
+  looping?: boolean;
+  legato?: boolean;
+  muted?: boolean;
+  duplicateLoop?: boolean;
+}
+
+/**
+ * Calculate beat positions and apply name/color/timing/legato/muted, then
+ * optionally duplicate the loop
+ * @param clip - The clip to update
+ * @param params - Timing and basic property parameters
+ * @param params.start - Start position
+ * @param params.length - Clip length
+ * @param params.firstStart - First start position
+ * @param params.timeSigNumerator - Time signature numerator
+ * @param params.timeSigDenominator - Time signature denominator
+ * @param params.isLooping - Current looping state
+ * @param params.name - Clip name
+ * @param params.color - Clip color
+ * @param params.timeSignature - Time signature
+ * @param params.looping - Looping enabled
+ * @param params.legato - Clip keeps playing when re-launched during playback
+ * @param params.muted - Mute individual clip
+ * @param params.duplicateLoop - Double the clip's loop length in-place
+ */
+function applyTimingAndBasicProperties(
+  clip: LiveAPI,
+  {
+    start,
+    length,
+    firstStart,
+    timeSigNumerator,
+    timeSigDenominator,
+    isLooping,
+    name,
+    color,
+    timeSignature,
+    looping,
+    legato,
+    muted,
+    duplicateLoop,
+  }: TimingAndBasicPropertiesParams,
+): void {
+  // Calculate beat positions (includes end_marker bounds check for start_marker)
+  const { startBeats, endBeats, startMarkerBeats } = calculateBeatPositions({
+    start,
+    length,
+    firstStart,
+    timeSigNumerator,
+    timeSigDenominator,
+    clip,
+    isLooping,
+  });
+
+  const currentLoopEnd = isLooping
+    ? (clip.getProperty("loop_end") as number)
+    : null;
+
+  applyBasicClipProperties(clip, {
+    name,
+    color,
+    timeSignature,
+    timeSigNumerator,
+    timeSigDenominator,
+    startMarkerBeats,
+    looping,
+    isLooping,
+    startBeats,
+    endBeats,
+    currentLoopEnd,
+    legato,
+    muted,
+  });
+
+  if (duplicateLoop) {
+    applyDuplicateLoop(clip);
+  }
+}
+
+/**
+ * Double the clip's loop length in-place (Live's "Duplicate Loop" button)
+ * @param clip - The clip to update
+ */
+function applyDuplicateLoop(clip: LiveAPI): void {
+  const loopStart = clip.getProperty("loop_start") as number;
+  const loopEnd = clip.getProperty("loop_end") as number;
+  const loopLength = loopEnd - loopStart;
+
+  clip.set("loop_end", loopStart + loopLength * 2);
+}
+
+interface AudioOrMidiParams {
+  transformString?: string;
+  gainDb?: number;
+  pitchShift?: number;
+  pitchFine?: number;
+  warpMode?: string;
+  warping?: boolean;
+  ramMode?: boolean;
+  velocityAmount?: number;
+}
+
+/**
+ * Apply audio-specific parameters and transforms (audio clips) or
+ * velocityAmount (MIDI clips)
+ * @param clip - The clip to update
+ * @param isAudioClip - Whether the clip is an audio clip
+ * @param clipContext - Clip-level context for transform variables
+ * @param params - Audio/MIDI parameters
+ * @param params.transformString - Transform expressions
+ * @param params.gainDb - Gain in decibels
+ * @param params.pitchShift - Pitch shift in semitones
+ * @param params.pitchFine - Fine pitch in cents (-100 to 100)
+ * @param params.warpMode - Warp mode
+ * @param params.warping - Warping enabled
+ * @param params.ramMode - Load full audio into RAM
+ * @param params.velocityAmount - Scales all MIDI note velocities (MIDI clips only)
+ */
+function applyAudioOrMidiParameters(
+  clip: LiveAPI,
+  isAudioClip: boolean,
+  clipContext: ClipContext,
+  {
+    transformString,
+    gainDb,
+    pitchShift,
+    pitchFine,
+    warpMode,
+    warping,
+    ramMode,
+    velocityAmount,
+  }: AudioOrMidiParams,
+): void {
+  if (isAudioClip) {
+    setAudioParameters(clip, {
+      gainDb,
+      pitchShift,
+      pitchFine,
+      warpMode,
+      warping,
+      ramMode,
+    });
+    applyAudioTransforms(clip, transformString, clipContext);
+  } else if (velocityAmount != null) {
+    clip.set("velocity_amount", velocityAmount);
+  }
 }

--- a/src/tools/clip/update/helpers/update-clip-properties-helpers.ts
+++ b/src/tools/clip/update/helpers/update-clip-properties-helpers.ts
@@ -12,6 +12,8 @@ export interface ClipPropsToSet {
   loop_end?: number;
   start_marker?: number;
   end_marker?: number;
+  legato?: boolean;
+  muted?: boolean;
   [key: string]: string | number | boolean | null | undefined;
 }
 
@@ -66,6 +68,8 @@ export interface BuildClipPropertiesArgs {
   startBeats: number | null;
   endBeats: number | null;
   currentLoopEnd: number | null;
+  legato?: boolean;
+  muted?: boolean;
 }
 
 /**
@@ -82,6 +86,8 @@ export interface BuildClipPropertiesArgs {
  * @param args.startBeats - Start position in beats
  * @param args.endBeats - End position in beats
  * @param args.currentLoopEnd - Current loop end position in beats
+ * @param args.legato - Clip keeps playing when re-launched during playback
+ * @param args.muted - Mute individual clip (distinct from track mute)
  * @returns Properties object ready for clip.setAll()
  */
 export function buildClipPropertiesToSet({
@@ -96,6 +102,8 @@ export function buildClipPropertiesToSet({
   startBeats,
   endBeats,
   currentLoopEnd,
+  legato,
+  muted,
 }: BuildClipPropertiesArgs): ClipPropsToSet {
   // Must expand loop_end BEFORE setting loop_start when new start >= old end
   // (otherwise Live rejects with "Cannot set LoopStart behind LoopEnd")
@@ -113,6 +121,8 @@ export function buildClipPropertiesToSet({
     signature_numerator: timeSignature != null ? timeSigNumerator : null,
     signature_denominator: timeSignature != null ? timeSigDenominator : null,
     looping: looping,
+    legato: legato,
+    muted: muted,
   };
 
   // Set loop properties for looping clips (order matters!)

--- a/src/tools/clip/update/tests/update-clip-audio-helpers.test.ts
+++ b/src/tools/clip/update/tests/update-clip-audio-helpers.test.ts
@@ -125,6 +125,43 @@ describe("setAudioParameters", () => {
     expect(mockClip.set).toHaveBeenCalledWith("warping", 0);
   });
 
+  it("should set pitch_fine directly when pitchFine is provided alone", () => {
+    setAudioParameters(mockClip, { pitchFine: -25 });
+
+    expect(mockClip.set).toHaveBeenCalledWith("pitch_fine", -25);
+    expect(mockClip.set).not.toHaveBeenCalledWith(
+      "pitch_coarse",
+      expect.anything(),
+    );
+  });
+
+  it("should let pitchFine override pitchShift's derived fine value", () => {
+    setAudioParameters(mockClip, { pitchShift: 5.5, pitchFine: -25 });
+
+    expect(mockClip.set).toHaveBeenCalledWith("pitch_coarse", 5);
+    // pitch_fine called twice: 50 (from pitchShift), then -25 (explicit override wins)
+    const pitchFineCalls = mockClip.set.mock.calls.filter(
+      (call: unknown[]) => call[0] === "pitch_fine",
+    );
+
+    expect(pitchFineCalls).toStrictEqual([
+      ["pitch_fine", 50],
+      ["pitch_fine", -25],
+    ]);
+  });
+
+  it("should set clip_mode to 1 when ramMode is true", () => {
+    setAudioParameters(mockClip, { ramMode: true });
+
+    expect(mockClip.set).toHaveBeenCalledWith("clip_mode", 1);
+  });
+
+  it("should set clip_mode to 0 when ramMode is false", () => {
+    setAudioParameters(mockClip, { ramMode: false });
+
+    expect(mockClip.set).toHaveBeenCalledWith("clip_mode", 0);
+  });
+
   it("should not set any properties when no parameters provided", () => {
     setAudioParameters(mockClip, {});
 

--- a/src/tools/clip/update/tests/update-clip-properties.test.ts
+++ b/src/tools/clip/update/tests/update-clip-properties.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setupSelectMock } from "#src/test/focus-test-helpers.ts";
 import { mockNonExistentObjects } from "#src/test/mocks/mock-registry.ts";
 import {
+  setupAudioClipMock,
   setupMidiClipMock,
   setupUpdateClipMocks,
   type UpdateClipMocks,
@@ -68,6 +69,72 @@ describe("updateClip - Properties and ID handling", () => {
     });
 
     expect(mocks.clip123.set).toHaveBeenCalledWith("looping", false);
+    expect(result).toStrictEqual({ id: "123" });
+  });
+
+  it("should set legato", async () => {
+    setupMidiClipMock(mocks.clip123);
+
+    const result = await updateClip({
+      ids: "123",
+      legato: true,
+    });
+
+    expect(mocks.clip123.set).toHaveBeenCalledWith("legato", true);
+    expect(result).toStrictEqual({ id: "123" });
+  });
+
+  it("should set muted", async () => {
+    setupMidiClipMock(mocks.clip123);
+
+    const result = await updateClip({
+      ids: "123",
+      muted: true,
+    });
+
+    expect(mocks.clip123.set).toHaveBeenCalledWith("muted", true);
+    expect(result).toStrictEqual({ id: "123" });
+  });
+
+  it("should set velocityAmount on MIDI clips", async () => {
+    setupMidiClipMock(mocks.clip123);
+
+    const result = await updateClip({
+      ids: "123",
+      velocityAmount: 0.5,
+    });
+
+    expect(mocks.clip123.set).toHaveBeenCalledWith("velocity_amount", 0.5);
+    expect(result).toStrictEqual({ id: "123" });
+  });
+
+  it("should not set velocityAmount on audio clips", async () => {
+    setupAudioClipMock(mocks.clip123);
+
+    await updateClip({
+      ids: "123",
+      velocityAmount: 0.5,
+    });
+
+    expect(mocks.clip123.set).not.toHaveBeenCalledWith(
+      "velocity_amount",
+      expect.anything(),
+    );
+  });
+
+  it("should duplicate the loop, doubling loop_end from loop_start", async () => {
+    setupMidiClipMock(mocks.clip123, {
+      loop_start: 4,
+      loop_end: 8,
+    });
+
+    const result = await updateClip({
+      ids: "123",
+      duplicateLoop: true,
+    });
+
+    // loop length 4, doubled -> loop_start(4) + 4*2 = 12
+    expect(mocks.clip123.set).toHaveBeenCalledWith("loop_end", 12);
     expect(result).toStrictEqual({ id: "123" });
   });
 

--- a/src/tools/clip/update/update-clip.def.ts
+++ b/src/tools/clip/update/update-clip.def.ts
@@ -42,6 +42,28 @@ export const toolDefUpdateClip = defineTool("adj-update-clip", {
       .optional()
       .describe("duration in bar:beat (e.g., '4:0' = 4 bars)"),
     looping: z.boolean().optional().describe("enable looping for the clip"),
+
+    legato: z
+      .boolean()
+      .optional()
+      .describe("clip keeps playing when re-launched during playback"),
+    muted: z
+      .boolean()
+      .optional()
+      .describe("mute individual clip (distinct from track mute)"),
+    velocityAmount: z.coerce
+      .number()
+      .min(0)
+      .max(1)
+      .optional()
+      .describe("scales all MIDI note velocities (MIDI clips only)"),
+    duplicateLoop: z
+      .boolean()
+      .optional()
+      .describe(
+        "double the clip's loop length in-place (Live's Duplicate Loop)",
+      ),
+
     firstStart: z
       .string()
       .optional()
@@ -86,6 +108,21 @@ export const toolDefUpdateClip = defineTool("adj-update-clip", {
       .describe(
         "audio clip pitch shift in semitones, supports decimals (ignored for MIDI)",
       ),
+    pitchFine: z.coerce
+      .number()
+      .min(-100)
+      .max(100)
+      .optional()
+      .describe(
+        "audio clip fine pitch in cents, independent of pitchShift's coarse semitones (ignored for MIDI)",
+      ),
+    ramMode: z
+      .boolean()
+      .optional()
+      .describe(
+        "load full audio into RAM, prevents seek glitches on short loops (ignored for MIDI)",
+      ),
+
     warpMode: z
       .enum(["beats", "tones", "texture", "repitch", "complex", "pro"])
       .optional()

--- a/src/tools/clip/update/update-clip.ts
+++ b/src/tools/clip/update/update-clip.ts
@@ -50,6 +50,10 @@ interface UpdateClipArgs extends ClipAudioWarpQuantizeParams {
   length?: string;
   firstStart?: string;
   looping?: boolean;
+  legato?: boolean;
+  muted?: boolean;
+  velocityAmount?: number;
+  duplicateLoop?: boolean;
   arrangementStart?: string;
   arrangementLength?: string;
   toSlot?: string;
@@ -78,14 +82,20 @@ interface ClipResult {
  * @param args.length - Duration in bar:beat format. end = start + length
  * @param args.firstStart - Bar|beat position for initial playback start
  * @param args.looping - Enable looping for the clip
+ * @param args.legato - Clip keeps playing when re-launched during playback
+ * @param args.muted - Mute individual clip (distinct from track mute)
+ * @param args.velocityAmount - Scales all MIDI note velocities (MIDI clips only)
+ * @param args.duplicateLoop - Double the clip's loop length in-place
  * @param args.arrangementStart - Bar|beat position to move arrangement clip
  * @param args.arrangementLength - Bar:beat duration for arrangement span
  * @param args.toSlot - Session clip destination slot (trackIndex/sceneIndex)
  * @param args.split - Comma-separated bar|beat positions to split clip
  * @param args.gainDb - Audio clip gain in decibels (-70 to 24)
  * @param args.pitchShift - Audio clip pitch shift in semitones (-48 to 48)
+ * @param args.pitchFine - Audio clip fine pitch in cents (-100 to 100)
  * @param args.warpMode - Audio clip warp mode
  * @param args.warping - Audio clip warping on/off
+ * @param args.ramMode - Load full audio into RAM (audio clips only)
  * @param args.warpOp - Warp marker operation: add, move, remove
  * @param args.warpBeatTime - Beat time for warp marker operation
  * @param args.warpSampleTime - Sample time for warp marker operation
@@ -111,12 +121,18 @@ export async function updateClip(
     length,
     firstStart,
     looping,
+    legato,
+    muted,
+    velocityAmount,
+    duplicateLoop,
     arrangementStart,
     arrangementLength,
     toSlot,
     split,
     gainDb,
     pitchShift,
+    pitchFine,
+    ramMode,
     warpMode,
     warping,
     warpOp,
@@ -183,8 +199,14 @@ export async function updateClip(
       length,
       firstStart,
       looping,
+      legato,
+      muted,
+      velocityAmount,
+      duplicateLoop,
       gainDb,
       pitchShift,
+      pitchFine,
+      ramMode,
       warpMode,
       warping,
       warpOp,


### PR DESCRIPTION
### **User description**
## Summary

**Write via `adj-update-clip`:**
- `pitchFine` (cents, -100 to 100) -- independent of `pitchShift`'s coarse semitones; applied after `pitchShift` so an explicit `pitchFine` always wins when both are given
- `legato` -- clip keeps playing when re-launched during playback
- `ramMode` -- load full audio into RAM, prevents seek glitches on short loops
- `velocityAmount` (MIDI clips only) -- scales all MIDI note velocities
- `muted` -- mute individual clip, distinct from track mute
- `duplicateLoop` -- doubles the clip's loop length in-place (Live's "Duplicate Loop" button)

**Read via `adj-read-clip`:**
- `playingPosition` -- current playhead beat within the clip, only present while playing

`filePath` was already covered by the existing `sampleFile` field, and `muted` was already read via `addBooleanStateProperties` -- no new work needed for those two.

Closes #29

## Test plan
- [x] `npm run check` -- lint, typecheck, format, duplication, full test suite (3789 tests) all pass
- [x] Added unit tests: `pitchFine` alone and combined with `pitchShift` (override precedence), `ramMode`, `legato`, `muted`, `velocityAmount` (including that it's ignored on audio clips), `duplicateLoop`
- [x] Updated `docs/Tools-Reference.md`


___

### **PR Type**
Enhancement


___

### **Description**
- Expose `pitchFine`, `legato`, `ramMode`, `muted` for audio clips.

- Add `velocityAmount` for MIDI clips via `adj-update-clip`.

- Implement `duplicateLoop` action to double clip length.

- Expose `playingPosition` in `adj-read-clip` results.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["adj-update-clip"] --> B{"New Write Properties"};
  B --> C["pitchFine"];
  B --> D["legato"];
  B --> E["ramMode"];
  B --> F["muted"];
  B --> G["velocityAmount"];
  A --> H["duplicateLoop Action"];
  I["adj-read-clip"] --> J["playingPosition"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>read-clip.ts</strong><dd><code>Expose `playingPosition` in `adj-read-clip` results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/238/files#diff-43a346588f72a620abae52f323b93a292e0c27c6158f7b0f2795fefe358ff4f9">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-clip-audio-helpers.ts</strong><dd><code>Implement `pitchFine` and `ramMode` for audio clips</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/238/files#diff-5900b7940e59a0981dedd8acbddd9f6629cc95502f6c7ec76c60a7b8c8787b6e">+17/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-clip-helpers.ts</strong><dd><code>Refactor clip update logic; add new clip properties and actions</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/238/files#diff-276e6b5b5690233112518850d5a2f3d9886d26e7e4f3dc8a9cf2fa6244f0b052">+209/-24</a></td>

</tr>

<tr>
  <td><strong>update-clip-properties-helpers.ts</strong><dd><code>Add `legato` and `muted` to clip properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/238/files#diff-021f038af694b85d2255395d8f37aa917f0c218a5889766a69625e9174dc38e0">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-clip.ts</strong><dd><code>Integrate new granular clip properties into `updateClip` arguments</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/238/files#diff-91359af761bd52b53c5b8de8c5498568b97ec30fdf8e7a4ed13ba4d8379abe1b">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>read-clip-core.test.ts</strong><dd><code>Add test for `playingPosition` in `readClip`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/238/files#diff-22a7f405c8a70b21cafa46e3562bc15a7b2bdee3551ba635424a04b5c8200ce1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-clip-audio-helpers.test.ts</strong><dd><code>Add tests for `pitchFine` and `ramMode` audio parameters</code>&nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/238/files#diff-de73808b4e567523ba793720d4d451c851c59c03763855e37fe9a9cf660bb49c">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-clip-properties.test.ts</strong><dd><code>Add tests for new clip properties and `duplicateLoop` action</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/238/files#diff-1487c2cbe3855b47a8e385bf797d5c99dba356d32f0b7bfd51bcd3d3653b11c1">+67/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>update-clip.def.ts</strong><dd><code>Update `adj-update-clip` schema with new granular properties</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/238/files#diff-36d444a0f1c6e5fd5491dfad5000ad9980889304ddc6fc5cf3e47b8e9eec72b9">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Tools-Reference.md</strong><dd><code>Document new `adj-read-clip` and `adj-update-clip` properties</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/238/files#diff-1144a39ffd998b6c8832a8e6e38fae79a98231f8e64046307c61134a0b297194">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

