### PR TITLE
feat: expose track freeze and flatten

### DIFF
--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -50,6 +50,7 @@ state.
 
 - `include: ["session-clips", "arrangement-clips", "devices", "routings"]`
 - `trackIndex` — zero-based track index
+- `isFrozen` — included (true) when the track is frozen
 
 ### `adj-create-track`
 
@@ -62,6 +63,14 @@ Create a new MIDI, audio, or return track.
 
 Update track properties: name, color, volume, pan, mute, solo, arm, routing,
 folded (group tracks only).
+
+- `freeze: true | false` — freeze (render to audio, frees CPU) or unfreeze.
+  Async in Live: response reports `isFrozen` once confirmed, or
+  `freezeStatus: "in_progress"` if still rendering — follow up with
+  `adj-read-track`
+- `flatten: true` — commit frozen audio permanently and remove devices.
+  **Irreversible.** Requires the track to already be frozen (combine with
+  `freeze: true` to freeze then flatten in one call)
 
 ---
 

--- a/docs/contributing/Read-Tool-Includes.md
+++ b/docs/contributing/Read-Tool-Includes.md
@@ -134,6 +134,7 @@ Returns track overview by default. Use `include` to add detail.
 | `isGroupMember`        | `true`   | Only present when inside a group                              |
 | `isGrouped`            | `true`   | Only present when inside a group (alias of `isGroupMember`)   |
 | `isFolded`             | `true`   | Only present when a group track is folded                     |
+| `isFrozen`             | `true`   | Only present when the track is frozen                         |
 | `playingSlotIndex`     | `number` | 0-based playing clip slot (only when >= 0)                    |
 | `firedSlotIndex`       | `number` | 0-based triggered clip slot (only when >= 0)                  |
 | `state`                | `string` | Only present when not "ACTIVE" (e.g., muted, soloed)          |

--- a/src/tools/track/read/helpers/read-track-helpers.ts
+++ b/src/tools/track/read/helpers/read-track-helpers.ts
@@ -184,6 +184,12 @@ export function addOptionalBooleanProperties(
   if (isFolded) {
     result.isFolded = isFolded;
   }
+
+  const isFrozen = (track.getProperty("is_frozen") as number) > 0;
+
+  if (isFrozen) {
+    result.isFrozen = isFrozen;
+  }
 }
 
 /**

--- a/src/tools/track/read/tests/read-track-basic.test.ts
+++ b/src/tools/track/read/tests/read-track-basic.test.ts
@@ -209,6 +209,38 @@ describe("readTrack", () => {
     expect(result.isGroupMember).toBeUndefined();
   });
 
+  it("returns isFrozen when the track is frozen", () => {
+    setupTrackPathMappedMocks({
+      trackId: "track1",
+      objects: {
+        Track: createSoloedMidiTrackProperties({ is_frozen: 1 }),
+      },
+    });
+
+    const result = readTrack({ trackIndex: 0 });
+
+    expect(result).toStrictEqual({
+      ...expectedSoloedMidiTrackResult(),
+      isArmed: true,
+      isFrozen: true,
+      playingSlotIndex: 2,
+      firedSlotIndex: 3,
+    });
+  });
+
+  it("omits isFrozen when the track is not frozen", () => {
+    setupTrackPathMappedMocks({
+      trackId: "track1",
+      objects: {
+        Track: createSoloedMidiTrackProperties({ is_frozen: 0 }),
+      },
+    });
+
+    const result = readTrack({ trackIndex: 0 });
+
+    expect(result).not.toHaveProperty("isFrozen");
+  });
+
   it("should detect Ableton DJ MCP host track", () => {
     mockThisDeviceOnTrack1();
 

--- a/src/tools/track/update/helpers/update-track-freeze-helpers.ts
+++ b/src/tools/track/update/helpers/update-track-freeze-helpers.ts
@@ -1,0 +1,114 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import * as console from "#src/shared/v8-max-console.ts";
+import { waitUntil } from "#src/shared/v8-sleep.ts";
+import { isDeadlineExceeded } from "#src/tools/clip/helpers/loop-deadline.ts";
+import { type UpdateTrackResult } from "../update-track.ts";
+
+/** Polling cadence while waiting for Live to finish an async freeze/unfreeze. */
+const FREEZE_POLL_INTERVAL_MS = 200;
+
+/** Upper bound on poll attempts per track (200ms * 50 = 10s ceiling). */
+const FREEZE_POLL_MAX_RETRIES = 50;
+
+/**
+ * Read the track's current frozen state.
+ * @param track - Track object
+ * @returns True if the track is currently frozen
+ */
+function isTrackFrozen(track: LiveAPI): boolean {
+  return (track.getProperty("is_frozen") as number) > 0;
+}
+
+/**
+ * Set freeze/unfreeze and flatten on a track, mutating the result object.
+ *
+ * Freezing is asynchronous in Live: setting `freeze` starts the operation and
+ * `is_frozen` only flips once rendering completes. This polls for completion
+ * with a bounded timeout (mirrors waitForPlayheadPosition's poll-then-warn
+ * shape in update-live-set-locator-helpers.ts). If the overall request
+ * deadline is close - likely when freezing many tracks in one call - the poll
+ * is skipped for this track and `freezeStatus: "in_progress"` is reported
+ * instead of blocking; the AI can confirm completion with adj-read-track.
+ *
+ * @param track - Track object
+ * @param freeze - Desired freeze state (true = freeze, false = unfreeze), or undefined to skip
+ * @param flatten - Whether to flatten (commit frozen audio, remove devices)
+ * @param deadline - Absolute deadline from computeLoopDeadline, or null
+ * @param result - Per-track result object to mutate with outcome fields
+ */
+export async function applyFreezeAndFlatten(
+  track: LiveAPI,
+  freeze: boolean | undefined,
+  flatten: boolean | undefined,
+  deadline: number | null,
+  result: UpdateTrackResult,
+): Promise<void> {
+  if (freeze != null) {
+    await applyFreeze(track, freeze, deadline, result);
+  }
+
+  if (flatten) {
+    applyFlatten(track, result);
+  }
+}
+
+/**
+ * Set the freeze property and poll for Live to confirm completion.
+ * @param track - Track object
+ * @param freeze - Desired freeze state
+ * @param deadline - Absolute deadline from computeLoopDeadline, or null
+ * @param result - Per-track result object to mutate with outcome fields
+ */
+async function applyFreeze(
+  track: LiveAPI,
+  freeze: boolean,
+  deadline: number | null,
+  result: UpdateTrackResult,
+): Promise<void> {
+  track.set("freeze", freeze);
+
+  const confirmed =
+    !isDeadlineExceeded(deadline) &&
+    (await waitUntil(() => isTrackFrozen(track) === freeze, {
+      pollingInterval: FREEZE_POLL_INTERVAL_MS,
+      maxRetries: FREEZE_POLL_MAX_RETRIES,
+    }));
+
+  if (confirmed) {
+    result.isFrozen = freeze;
+
+    return;
+  }
+
+  console.warn(
+    `updateTrack: track ${track.id} did not confirm ${freeze ? "freeze" : "unfreeze"} within the polling window`,
+  );
+  result.freezeStatus = "in_progress";
+}
+
+/**
+ * Flatten a frozen track: commits frozen audio permanently and removes
+ * devices. Skips with a warning if the track isn't frozen.
+ * @param track - Track object
+ * @param result - Per-track result object to mutate with outcome fields
+ */
+function applyFlatten(track: LiveAPI, result: UpdateTrackResult): void {
+  if (!isTrackFrozen(track)) {
+    console.warn(
+      `updateTrack: track ${track.id} must be frozen before flatten, skipping`,
+    );
+
+    return;
+  }
+
+  track.call("flatten");
+  result.flattened = true;
+
+  result.$meta ??= [];
+  result.$meta.push(
+    "Flatten is irreversible: devices were removed and frozen audio was committed as clips.",
+  );
+}

--- a/src/tools/track/update/helpers/update-track-routing-helpers.ts
+++ b/src/tools/track/update/helpers/update-track-routing-helpers.ts
@@ -1,0 +1,51 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+export interface RoutingParams {
+  inputRoutingTypeId?: string;
+  inputRoutingChannelId?: string;
+  outputRoutingTypeId?: string;
+  outputRoutingChannelId?: string;
+}
+
+/**
+ * Apply routing properties to a track
+ * @param track - Track object
+ * @param params - Routing properties
+ */
+export function applyRoutingProperties(
+  track: LiveAPI,
+  params: RoutingParams,
+): void {
+  const {
+    inputRoutingTypeId,
+    inputRoutingChannelId,
+    outputRoutingTypeId,
+    outputRoutingChannelId,
+  } = params;
+
+  if (inputRoutingTypeId != null) {
+    track.setProperty("input_routing_type", {
+      identifier: Number(inputRoutingTypeId),
+    });
+  }
+
+  if (inputRoutingChannelId != null) {
+    track.setProperty("input_routing_channel", {
+      identifier: Number(inputRoutingChannelId),
+    });
+  }
+
+  if (outputRoutingTypeId != null) {
+    track.setProperty("output_routing_type", {
+      identifier: Number(outputRoutingTypeId),
+    });
+  }
+
+  if (outputRoutingChannelId != null) {
+    track.setProperty("output_routing_channel", {
+      identifier: Number(outputRoutingChannelId),
+    });
+  }
+}

--- a/src/tools/track/update/tests/update-track-freeze.test.ts
+++ b/src/tools/track/update/tests/update-track-freeze.test.ts
@@ -1,0 +1,145 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import {
+  type RegisteredMockObject,
+  registerMockObject,
+} from "#src/test/mocks/mock-registry.ts";
+import { updateTrack } from "../update-track.ts";
+import "#src/live-api-adapter/live-api-extensions.ts";
+
+const FLATTEN_WARNING =
+  "Flatten is irreversible: devices were removed and frozen audio was committed as clips.";
+
+describe("updateTrack - freeze and flatten", () => {
+  let track123: RegisteredMockObject;
+
+  beforeEach(() => {
+    track123 = registerMockObject("123", { path: livePath.track(0) });
+    registerMockObject("456", { path: livePath.track(1) });
+  });
+
+  /**
+   * Wire track123's set/get mocks so `is_frozen` reflects the last value
+   * written via `freeze`, simulating Live confirming the operation on the
+   * very next poll.
+   * @param initiallyFrozen - Starting frozen state before any `set` call
+   */
+  function mockFreezeConfirmsImmediately(initiallyFrozen: boolean): void {
+    let frozen = initiallyFrozen;
+
+    track123.set.mockImplementation((prop: string, value: unknown) => {
+      if (prop === "freeze") {
+        frozen = Boolean(value);
+      }
+    });
+    track123.get.mockImplementation((prop: string) => {
+      if (prop === "is_frozen") return [frozen ? 1 : 0];
+
+      return [0];
+    });
+  }
+
+  it("should freeze a track and report isFrozen once confirmed", async () => {
+    mockFreezeConfirmsImmediately(false);
+
+    const result = await updateTrack({ ids: "123", freeze: true });
+
+    expect(track123.set).toHaveBeenCalledWith("freeze", true);
+    expect(result).toStrictEqual({ id: "123", isFrozen: true });
+  });
+
+  it("should unfreeze a track and report isFrozen once confirmed", async () => {
+    mockFreezeConfirmsImmediately(true);
+
+    const result = await updateTrack({ ids: "123", freeze: false });
+
+    expect(track123.set).toHaveBeenCalledWith("freeze", false);
+    expect(result).toStrictEqual({ id: "123", isFrozen: false });
+  });
+
+  it("should report freezeStatus in_progress when Live doesn't confirm within the polling window", async () => {
+    // is_frozen stays at the default (0) no matter what freeze is set to,
+    // simulating a freeze that hasn't finished rendering yet.
+    const result = await updateTrack({ ids: "123", freeze: true });
+
+    expect(track123.set).toHaveBeenCalledWith("freeze", true);
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "updateTrack: track 123 did not confirm freeze within the polling window",
+    );
+    expect(result).toStrictEqual({ id: "123", freezeStatus: "in_progress" });
+  });
+
+  it("should skip polling and report in_progress once the request deadline has passed", async () => {
+    mockFreezeConfirmsImmediately(false);
+
+    // timeoutMs: 0 puts the computed deadline in the past, so the freeze is
+    // set but completion is never polled for.
+    const result = await updateTrack(
+      { ids: "123", freeze: true },
+      { timeoutMs: 0 },
+    );
+
+    expect(track123.set).toHaveBeenCalledWith("freeze", true);
+    expect(result).toStrictEqual({ id: "123", freezeStatus: "in_progress" });
+  });
+
+  it("should skip flatten and warn when the track isn't frozen", async () => {
+    const result = await updateTrack({ ids: "123", flatten: true });
+
+    expect(track123.call).not.toHaveBeenCalledWith("flatten");
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "updateTrack: track 123 must be frozen before flatten, skipping",
+    );
+    expect(result).toStrictEqual({ id: "123" });
+  });
+
+  it("should flatten a frozen track and surface an irreversibility warning", async () => {
+    track123.get.mockImplementation((prop: string) => {
+      if (prop === "is_frozen") return [1];
+
+      return [0];
+    });
+
+    const result = await updateTrack({ ids: "123", flatten: true });
+
+    expect(track123.call).toHaveBeenCalledWith("flatten");
+    expect(result).toStrictEqual({
+      id: "123",
+      flattened: true,
+      $meta: [FLATTEN_WARNING],
+    });
+  });
+
+  it("should freeze then flatten in a single call", async () => {
+    mockFreezeConfirmsImmediately(false);
+
+    const result = await updateTrack({
+      ids: "123",
+      freeze: true,
+      flatten: true,
+    });
+
+    expect(track123.set).toHaveBeenCalledWith("freeze", true);
+    expect(track123.call).toHaveBeenCalledWith("flatten");
+    expect(result).toStrictEqual({
+      id: "123",
+      isFrozen: true,
+      flattened: true,
+      $meta: [FLATTEN_WARNING],
+    });
+  });
+
+  it("should not touch freeze state when neither freeze nor flatten is provided", async () => {
+    const result = await updateTrack({ ids: "123", name: "Untouched" });
+
+    expect(track123.set).not.toHaveBeenCalledWith("freeze", expect.anything());
+    expect(track123.call).not.toHaveBeenCalledWith("flatten");
+    expect(result).toStrictEqual({ id: "123" });
+  });
+});

--- a/src/tools/track/update/tests/update-track-mixer.test.ts
+++ b/src/tools/track/update/tests/update-track-mixer.test.ts
@@ -43,8 +43,8 @@ describe("updateTrack - mixer properties", () => {
     });
   });
 
-  it("should update gain only", () => {
-    updateTrack({
+  it("should update gain only", async () => {
+    await updateTrack({
       ids: "123",
       gainDb: -6,
     });
@@ -52,8 +52,8 @@ describe("updateTrack - mixer properties", () => {
     expect(volumeParam1.set).toHaveBeenCalledWith("display_value", -6);
   });
 
-  it("should update pan only", () => {
-    updateTrack({
+  it("should update pan only", async () => {
+    await updateTrack({
       ids: "123",
       pan: 0.5,
     });
@@ -61,8 +61,8 @@ describe("updateTrack - mixer properties", () => {
     expect(panningParam1.set).toHaveBeenCalledWith("value", 0.5);
   });
 
-  it("should update both gain and pan", () => {
-    updateTrack({
+  it("should update both gain and pan", async () => {
+    await updateTrack({
       ids: "123",
       gainDb: -3,
       pan: -0.25,
@@ -72,8 +72,8 @@ describe("updateTrack - mixer properties", () => {
     expect(panningParam1.set).toHaveBeenCalledWith("value", -0.25);
   });
 
-  it("should update gain/pan with other properties", () => {
-    updateTrack({
+  it("should update gain/pan with other properties", async () => {
+    await updateTrack({
       ids: "123",
       name: "Test Track",
       gainDb: -12,
@@ -87,8 +87,8 @@ describe("updateTrack - mixer properties", () => {
     expect(track123.set).toHaveBeenCalledWith("mute", true);
   });
 
-  it("should handle minimum gain value", () => {
-    updateTrack({
+  it("should handle minimum gain value", async () => {
+    await updateTrack({
       ids: "123",
       gainDb: -70,
     });
@@ -96,8 +96,8 @@ describe("updateTrack - mixer properties", () => {
     expect(volumeParam1.set).toHaveBeenCalledWith("display_value", -70);
   });
 
-  it("should handle maximum gain value", () => {
-    updateTrack({
+  it("should handle maximum gain value", async () => {
+    await updateTrack({
       ids: "123",
       gainDb: 6,
     });
@@ -105,8 +105,8 @@ describe("updateTrack - mixer properties", () => {
     expect(volumeParam1.set).toHaveBeenCalledWith("display_value", 6);
   });
 
-  it("should handle minimum pan value (full left)", () => {
-    updateTrack({
+  it("should handle minimum pan value (full left)", async () => {
+    await updateTrack({
       ids: "123",
       pan: -1,
     });
@@ -114,8 +114,8 @@ describe("updateTrack - mixer properties", () => {
     expect(panningParam1.set).toHaveBeenCalledWith("value", -1);
   });
 
-  it("should handle maximum pan value (full right)", () => {
-    updateTrack({
+  it("should handle maximum pan value (full right)", async () => {
+    await updateTrack({
       ids: "123",
       pan: 1,
     });
@@ -123,8 +123,8 @@ describe("updateTrack - mixer properties", () => {
     expect(panningParam1.set).toHaveBeenCalledWith("value", 1);
   });
 
-  it("should handle zero gain and center pan", () => {
-    updateTrack({
+  it("should handle zero gain and center pan", async () => {
+    await updateTrack({
       ids: "123",
       gainDb: 0,
       pan: 0,
@@ -134,8 +134,8 @@ describe("updateTrack - mixer properties", () => {
     expect(panningParam1.set).toHaveBeenCalledWith("value", 0);
   });
 
-  it("should update mixer properties for multiple tracks", () => {
-    updateTrack({
+  it("should update mixer properties for multiple tracks", async () => {
+    await updateTrack({
       ids: "123,456",
       gainDb: -6,
       pan: 0.5,
@@ -147,13 +147,13 @@ describe("updateTrack - mixer properties", () => {
     expect(panningParam2.set).toHaveBeenCalledWith("value", 0.5);
   });
 
-  it("should handle missing mixer device gracefully", () => {
+  it("should handle missing mixer device gracefully", async () => {
     // Override mixer to be non-existent for this test
     registerMockObject("id 0", {
       path: livePath.track(0).mixerDevice(),
     });
 
-    updateTrack({
+    await updateTrack({
       ids: "123",
       gainDb: -6,
       pan: 0.5,
@@ -164,8 +164,8 @@ describe("updateTrack - mixer properties", () => {
     expect(panningParam1.set).not.toHaveBeenCalled();
   });
 
-  it("should set panning mode to split", () => {
-    updateTrack({
+  it("should set panning mode to split", async () => {
+    await updateTrack({
       ids: "123",
       panningMode: "split",
     });
@@ -173,8 +173,8 @@ describe("updateTrack - mixer properties", () => {
     expect(mixer1.set).toHaveBeenCalledWith("panning_mode", 1);
   });
 
-  it("should set panning mode to stereo", () => {
-    updateTrack({
+  it("should set panning mode to stereo", async () => {
+    await updateTrack({
       ids: "123",
       panningMode: "stereo",
     });
@@ -182,7 +182,7 @@ describe("updateTrack - mixer properties", () => {
     expect(mixer1.set).toHaveBeenCalledWith("panning_mode", 0);
   });
 
-  it("should update leftPan and rightPan in split mode", () => {
+  it("should update leftPan and rightPan in split mode", async () => {
     const { leftSplitParam1, rightSplitParam1 } = registerSplitPanParams();
 
     mixer1.get.mockImplementation((prop: string) => {
@@ -191,7 +191,7 @@ describe("updateTrack - mixer properties", () => {
       return [0];
     });
 
-    updateTrack({
+    await updateTrack({
       ids: "123",
       leftPan: -0.75,
       rightPan: 0.5,
@@ -201,7 +201,7 @@ describe("updateTrack - mixer properties", () => {
     expect(rightSplitParam1.set).toHaveBeenCalledWith("value", 0.5);
   });
 
-  it("should warn when setting pan in split mode", () => {
+  it("should warn when setting pan in split mode", async () => {
     const errorSpy = vi.spyOn(console, "warn");
 
     mixer1.get.mockImplementation((prop: string) => {
@@ -210,7 +210,7 @@ describe("updateTrack - mixer properties", () => {
       return [0];
     });
 
-    updateTrack({
+    await updateTrack({
       ids: "123",
       pan: 0.5,
     });
@@ -222,12 +222,12 @@ describe("updateTrack - mixer properties", () => {
     errorSpy.mockRestore();
   });
 
-  it("should warn when setting leftPan/rightPan in stereo mode", () => {
+  it("should warn when setting leftPan/rightPan in stereo mode", async () => {
     const errorSpy = vi.spyOn(console, "warn");
 
     // Default panning_mode is 0 (stereo) from createGetMock fallback
 
-    updateTrack({
+    await updateTrack({
       ids: "123",
       leftPan: -0.5,
       rightPan: 0.5,
@@ -242,12 +242,12 @@ describe("updateTrack - mixer properties", () => {
     errorSpy.mockRestore();
   });
 
-  it("should switch mode and update panning in one call", () => {
+  it("should switch mode and update panning in one call", async () => {
     const { leftSplitParam1, rightSplitParam1 } = registerSplitPanParams();
 
     // Start in stereo mode (default)
 
-    updateTrack({
+    await updateTrack({
       ids: "123",
       panningMode: "split",
       leftPan: -1,

--- a/src/tools/track/update/tests/update-track-send.test.ts
+++ b/src/tools/track/update/tests/update-track-send.test.ts
@@ -50,8 +50,8 @@ describe("updateTrack - send properties", () => {
     registerMockObject("send_4", {});
   });
 
-  it("should set send gain with exact return name", () => {
-    updateTrack({
+  it("should set send gain with exact return name", async () => {
+    await updateTrack({
       ids: "123",
       sendGainDb: -12,
       sendReturn: "A-Reverb",
@@ -60,8 +60,8 @@ describe("updateTrack - send properties", () => {
     expect(send1.set).toHaveBeenCalledWith("display_value", -12);
   });
 
-  it("should set send gain with letter prefix", () => {
-    updateTrack({
+  it("should set send gain with letter prefix", async () => {
+    await updateTrack({
       ids: "123",
       sendGainDb: -6,
       sendReturn: "A",
@@ -70,8 +70,8 @@ describe("updateTrack - send properties", () => {
     expect(send1.set).toHaveBeenCalledWith("display_value", -6);
   });
 
-  it("should set second send with letter prefix", () => {
-    updateTrack({
+  it("should set second send with letter prefix", async () => {
+    await updateTrack({
       ids: "123",
       sendGainDb: -3,
       sendReturn: "B",
@@ -80,8 +80,8 @@ describe("updateTrack - send properties", () => {
     expect(send2.set).toHaveBeenCalledWith("display_value", -3);
   });
 
-  it("should set send gain to minimum value", () => {
-    updateTrack({
+  it("should set send gain to minimum value", async () => {
+    await updateTrack({
       ids: "123",
       sendGainDb: -70,
       sendReturn: "A",
@@ -90,8 +90,8 @@ describe("updateTrack - send properties", () => {
     expect(send1.set).toHaveBeenCalledWith("display_value", -70);
   });
 
-  it("should set send gain to maximum value (0 dB)", () => {
-    updateTrack({
+  it("should set send gain to maximum value (0 dB)", async () => {
+    await updateTrack({
       ids: "123",
       sendGainDb: 0,
       sendReturn: "A",
@@ -100,9 +100,9 @@ describe("updateTrack - send properties", () => {
     expect(send1.set).toHaveBeenCalledWith("display_value", 0);
   });
 
-  it("should warn and skip when only sendGainDb is provided", () => {
+  it("should warn and skip when only sendGainDb is provided", async () => {
     // Should not throw, just warn and skip the send update
-    const result = updateTrack({
+    const result = await updateTrack({
       ids: "123",
       sendGainDb: -12,
     });
@@ -110,9 +110,9 @@ describe("updateTrack - send properties", () => {
     expect(result).toStrictEqual({ id: "123" });
   });
 
-  it("should warn and skip when only sendReturn is provided", () => {
+  it("should warn and skip when only sendReturn is provided", async () => {
     // Should not throw, just warn and skip the send update
-    const result = updateTrack({
+    const result = await updateTrack({
       ids: "123",
       sendReturn: "A",
     });
@@ -120,9 +120,9 @@ describe("updateTrack - send properties", () => {
     expect(result).toStrictEqual({ id: "123" });
   });
 
-  it("should warn and skip when return track not found", () => {
+  it("should warn and skip when return track not found", async () => {
     // Should not throw, just warn and skip the send update
-    const result = updateTrack({
+    const result = await updateTrack({
       ids: "123",
       sendGainDb: -12,
       sendReturn: "C",
@@ -131,7 +131,7 @@ describe("updateTrack - send properties", () => {
     expect(result).toStrictEqual({ id: "123" });
   });
 
-  it("should warn and skip when track has no sends", () => {
+  it("should warn and skip when track has no sends", async () => {
     // Override mixer_1 with empty sends for this test
     registerMockObject("mixer_1", {
       path: livePath.track(0).mixerDevice(),
@@ -139,7 +139,7 @@ describe("updateTrack - send properties", () => {
     });
 
     // Should not throw, just warn and skip the send update
-    const result = updateTrack({
+    const result = await updateTrack({
       ids: "123",
       sendGainDb: -12,
       sendReturn: "A",
@@ -148,8 +148,8 @@ describe("updateTrack - send properties", () => {
     expect(result).toStrictEqual({ id: "123" });
   });
 
-  it("should set sends on multiple tracks", () => {
-    updateTrack({
+  it("should set sends on multiple tracks", async () => {
+    await updateTrack({
       ids: "123,456",
       sendGainDb: -6,
       sendReturn: "A",
@@ -159,8 +159,8 @@ describe("updateTrack - send properties", () => {
     expect(send3.set).toHaveBeenCalledWith("display_value", -6);
   });
 
-  it("should combine send update with other properties", () => {
-    updateTrack({
+  it("should combine send update with other properties", async () => {
+    await updateTrack({
       ids: "123",
       name: "Test Track",
       sendGainDb: -12,
@@ -171,8 +171,8 @@ describe("updateTrack - send properties", () => {
     expect(send2.set).toHaveBeenCalledWith("display_value", -12);
   });
 
-  it("should not set send when neither param is provided", () => {
-    updateTrack({
+  it("should not set send when neither param is provided", async () => {
+    await updateTrack({
       ids: "123",
       name: "Test Track",
     });
@@ -182,14 +182,14 @@ describe("updateTrack - send properties", () => {
     expect(send2.set).not.toHaveBeenCalled();
   });
 
-  it("should warn and skip when mixer device does not exist", () => {
+  it("should warn and skip when mixer device does not exist", async () => {
     // Override mixer to be non-existent for this test
     registerMockObject("id 0", {
       path: livePath.track(0).mixerDevice(),
     });
 
     // Should not throw, just warn and skip the send update
-    const result = updateTrack({
+    const result = await updateTrack({
       ids: "123",
       sendGainDb: -12,
       sendReturn: "A",
@@ -198,7 +198,7 @@ describe("updateTrack - send properties", () => {
     expect(result).toStrictEqual({ id: "123" });
   });
 
-  it("should warn and skip when send index exceeds available sends", () => {
+  it("should warn and skip when send index exceeds available sends", async () => {
     // Setup: 3 return tracks but only 2 sends
     registerMockObject("liveSet", {
       path: livePath.liveSet,
@@ -212,7 +212,7 @@ describe("updateTrack - send properties", () => {
     });
 
     // Should not throw, just warn and skip the send update
-    const result = updateTrack({
+    const result = await updateTrack({
       ids: "123",
       sendGainDb: -12,
       sendReturn: "C", // Matches return track at index 2

--- a/src/tools/track/update/tests/update-track.test.ts
+++ b/src/tools/track/update/tests/update-track.test.ts
@@ -24,8 +24,8 @@ describe("updateTrack", () => {
     track789 = registerMockObject("789", { path: livePath.track(2) });
   });
 
-  it("should update a single track by ID", () => {
-    const result = updateTrack({
+  it("should update a single track by ID", async () => {
+    const result = await updateTrack({
       ids: "123",
       name: "Updated Track",
       color: "#FF0000",
@@ -42,8 +42,8 @@ describe("updateTrack", () => {
     expect(result).toStrictEqual({ id: "123" });
   });
 
-  it("should update multiple tracks by comma-separated IDs", () => {
-    const result = updateTrack({
+  it("should update multiple tracks by comma-separated IDs", async () => {
+    const result = await updateTrack({
       ids: "123, 456",
       color: "#00FF00",
       mute: true,
@@ -57,8 +57,8 @@ describe("updateTrack", () => {
     expect(result).toStrictEqual([{ id: "123" }, { id: "456" }]);
   });
 
-  it("should handle 'id ' prefixed track IDs", () => {
-    const result = updateTrack({
+  it("should handle 'id ' prefixed track IDs", async () => {
+    const result = await updateTrack({
       ids: "id 123",
       name: "Prefixed ID Track",
     });
@@ -67,8 +67,8 @@ describe("updateTrack", () => {
     expect(result).toStrictEqual({ id: "123" });
   });
 
-  it("should not update properties when not provided", () => {
-    const result = updateTrack({
+  it("should not update properties when not provided", async () => {
+    const result = await updateTrack({
       ids: "123",
       name: "Only Name Update",
     });
@@ -78,8 +78,8 @@ describe("updateTrack", () => {
     expect(result).toStrictEqual({ id: "123" });
   });
 
-  it("should handle boolean false values correctly", () => {
-    const result = updateTrack({
+  it("should handle boolean false values correctly", async () => {
+    const result = await updateTrack({
       ids: "123",
       mute: false,
       solo: false,
@@ -92,21 +92,21 @@ describe("updateTrack", () => {
     expect(result).toStrictEqual({ id: "123" });
   });
 
-  it("should throw error when ids is missing", () => {
-    expect(() =>
+  it("should throw error when ids is missing", async () => {
+    await expect(
       updateTrack({} as unknown as Parameters<typeof updateTrack>[0]),
-    ).toThrow("updateTrack failed: ids is required");
-    expect(() =>
+    ).rejects.toThrow("updateTrack failed: ids is required");
+    await expect(
       updateTrack({ name: "Test" } as unknown as Parameters<
         typeof updateTrack
       >[0]),
-    ).toThrow("updateTrack failed: ids is required");
+    ).rejects.toThrow("updateTrack failed: ids is required");
   });
 
-  it("should log warning when track ID doesn't exist", () => {
+  it("should log warning when track ID doesn't exist", async () => {
     mockNonExistentObjects();
 
-    const result = updateTrack({ ids: "nonexistent" });
+    const result = await updateTrack({ ids: "nonexistent" });
 
     expect(result).toStrictEqual([]);
     expect(outlet).toHaveBeenCalledWith(
@@ -115,10 +115,10 @@ describe("updateTrack", () => {
     );
   });
 
-  it("should skip invalid track IDs in comma-separated list and update valid ones", () => {
+  it("should skip invalid track IDs in comma-separated list and update valid ones", async () => {
     mockNonExistentObjects();
 
-    const result = updateTrack({ ids: "123, nonexistent", name: "Test" });
+    const result = await updateTrack({ ids: "123, nonexistent", name: "Test" });
 
     expect(result).toStrictEqual({ id: "123" });
     expect(outlet).toHaveBeenCalledWith(
@@ -128,16 +128,19 @@ describe("updateTrack", () => {
     expect(track123.set).toHaveBeenCalledWith("name", "Test");
   });
 
-  it("should return single object for single ID and array for comma-separated IDs", () => {
-    const singleResult = updateTrack({ ids: "123", name: "Single" });
-    const arrayResult = updateTrack({ ids: "123, 456", name: "Multiple" });
+  it("should return single object for single ID and array for comma-separated IDs", async () => {
+    const singleResult = await updateTrack({ ids: "123", name: "Single" });
+    const arrayResult = await updateTrack({
+      ids: "123, 456",
+      name: "Multiple",
+    });
 
     expect(singleResult).toStrictEqual({ id: "123" });
     expect(arrayResult).toStrictEqual([{ id: "123" }, { id: "456" }]);
   });
 
-  it("should handle whitespace in comma-separated IDs", () => {
-    const result = updateTrack({
+  it("should handle whitespace in comma-separated IDs", async () => {
+    const result = await updateTrack({
       ids: " 123 , 456 , 789 ",
       color: "#0000FF",
     });
@@ -145,8 +148,8 @@ describe("updateTrack", () => {
     expect(result).toStrictEqual([{ id: "123" }, { id: "456" }, { id: "789" }]);
   });
 
-  it("should filter out empty IDs from comma-separated list", () => {
-    const result = updateTrack({
+  it("should filter out empty IDs from comma-separated list", async () => {
+    const result = await updateTrack({
       ids: "123,,456,  ,789",
       name: "Filtered",
     });
@@ -158,8 +161,8 @@ describe("updateTrack", () => {
   });
 
   describe("routing properties", () => {
-    it("should update routing properties when provided", () => {
-      const result = updateTrack({
+    it("should update routing properties when provided", async () => {
+      const result = await updateTrack({
         ids: "123",
         inputRoutingTypeId: "17",
         inputRoutingChannelId: "1",
@@ -187,8 +190,8 @@ describe("updateTrack", () => {
       expect(result).toStrictEqual({ id: "123" });
     });
 
-    it("should update monitoring state when provided", () => {
-      const result = updateTrack({
+    it("should update monitoring state when provided", async () => {
+      const result = await updateTrack({
         ids: "123",
         monitoringState: MONITORING_STATE.AUTO,
       });
@@ -198,25 +201,25 @@ describe("updateTrack", () => {
       expect(result).toStrictEqual({ id: "123" });
     });
 
-    it("should update monitoring state for all valid values", () => {
+    it("should update monitoring state for all valid values", async () => {
       // Test IN state
-      updateTrack({
+      await updateTrack({
         ids: "123",
         monitoringState: MONITORING_STATE.IN,
       });
       expect(track123.set).toHaveBeenCalledWith("current_monitoring_state", 0);
 
       // Test OFF state
-      updateTrack({
+      await updateTrack({
         ids: "456",
         monitoringState: MONITORING_STATE.OFF,
       });
       expect(track456.set).toHaveBeenCalledWith("current_monitoring_state", 2);
     });
 
-    it("should warn and skip for invalid monitoring state", () => {
+    it("should warn and skip for invalid monitoring state", async () => {
       // Should not throw, just warn and skip the monitoring state update
-      const result = updateTrack({
+      const result = await updateTrack({
         ids: "123",
         monitoringState: "invalid",
       });
@@ -224,8 +227,8 @@ describe("updateTrack", () => {
       expect(result).toStrictEqual({ id: "123" });
     });
 
-    it("should handle mixed routing and basic properties", () => {
-      const result = updateTrack({
+    it("should handle mixed routing and basic properties", async () => {
+      const result = await updateTrack({
         ids: "123",
         name: "Test Track",
         color: "#FF0000",
@@ -246,8 +249,8 @@ describe("updateTrack", () => {
       expect(result).toStrictEqual({ id: "123" });
     });
 
-    it("should handle routing properties in bulk operations", () => {
-      const result = updateTrack({
+    it("should handle routing properties in bulk operations", async () => {
+      const result = await updateTrack({
         ids: "123, 456",
         outputRoutingTypeId: "25",
         monitoringState: MONITORING_STATE.AUTO,
@@ -267,8 +270,8 @@ describe("updateTrack", () => {
       expect(result).toStrictEqual([{ id: "123" }, { id: "456" }]);
     });
 
-    it("should not update routing properties when not provided", () => {
-      const result = updateTrack({
+    it("should not update routing properties when not provided", async () => {
+      const result = await updateTrack({
         ids: "123",
         name: "Only Name Update",
       });
@@ -282,8 +285,8 @@ describe("updateTrack", () => {
   });
 
   describe("arrangementFollower parameter", () => {
-    it("should set arrangementFollower to true (track follows arrangement)", () => {
-      const result = updateTrack({
+    it("should set arrangementFollower to true (track follows arrangement)", async () => {
+      const result = await updateTrack({
         ids: "123",
         arrangementFollower: true,
       });
@@ -293,8 +296,8 @@ describe("updateTrack", () => {
       expect(result).toStrictEqual({ id: "123" });
     });
 
-    it("should set arrangementFollower to false (track doesn't follow arrangement)", () => {
-      const result = updateTrack({
+    it("should set arrangementFollower to false (track doesn't follow arrangement)", async () => {
+      const result = await updateTrack({
         ids: "123",
         arrangementFollower: false,
       });
@@ -304,8 +307,8 @@ describe("updateTrack", () => {
       expect(result).toStrictEqual({ id: "123" });
     });
 
-    it("should set arrangementFollower for multiple tracks", () => {
-      const result = updateTrack({
+    it("should set arrangementFollower for multiple tracks", async () => {
+      const result = await updateTrack({
         ids: "123,456",
         arrangementFollower: true,
       });
@@ -316,8 +319,8 @@ describe("updateTrack", () => {
       expect(result).toStrictEqual([{ id: "123" }, { id: "456" }]);
     });
 
-    it("should combine arrangementFollower with other parameters", () => {
-      const result = updateTrack({
+    it("should combine arrangementFollower with other parameters", async () => {
+      const result = await updateTrack({
         ids: "123",
         name: "Updated Track",
         mute: true,
@@ -333,12 +336,12 @@ describe("updateTrack", () => {
   });
 
   describe("folded parameter", () => {
-    it("should fold a group track", () => {
+    it("should fold a group track", async () => {
       track123.get.mockImplementation((prop: string) =>
         prop === "is_foldable" ? [1] : [0],
       );
 
-      const result = updateTrack({
+      const result = await updateTrack({
         ids: "123",
         folded: true,
       });
@@ -347,12 +350,12 @@ describe("updateTrack", () => {
       expect(result).toStrictEqual({ id: "123" });
     });
 
-    it("should unfold a group track", () => {
+    it("should unfold a group track", async () => {
       track123.get.mockImplementation((prop: string) =>
         prop === "is_foldable" ? [1] : [0],
       );
 
-      const result = updateTrack({
+      const result = await updateTrack({
         ids: "123",
         folded: false,
       });
@@ -361,15 +364,15 @@ describe("updateTrack", () => {
       expect(result).toStrictEqual({ id: "123" });
     });
 
-    it("should throw a descriptive error when folded is set on a non-foldable track", () => {
+    it("should throw a descriptive error when folded is set on a non-foldable track", async () => {
       // track123 defaults to is_foldable: 0 (not a group track)
-      expect(() => updateTrack({ ids: "123", folded: true })).toThrow(
+      await expect(updateTrack({ ids: "123", folded: true })).rejects.toThrow(
         "updateTrack failed: folded requires a group track (track 123 is not foldable)",
       );
     });
 
-    it("should not touch fold_state when folded is not provided", () => {
-      const result = updateTrack({
+    it("should not touch fold_state when folded is not provided", async () => {
+      const result = await updateTrack({
         ids: "123",
         name: "Only Name Update",
       });
@@ -381,7 +384,7 @@ describe("updateTrack", () => {
       expect(result).toStrictEqual({ id: "123" });
     });
 
-    it("should fold/unfold across multiple group tracks", () => {
+    it("should fold/unfold across multiple group tracks", async () => {
       track123.get.mockImplementation((prop: string) =>
         prop === "is_foldable" ? [1] : [0],
       );
@@ -389,7 +392,7 @@ describe("updateTrack", () => {
         prop === "is_foldable" ? [1] : [0],
       );
 
-      const result = updateTrack({
+      const result = await updateTrack({
         ids: "123,456",
         folded: true,
       });
@@ -414,7 +417,7 @@ describe("updateTrack", () => {
         return [0];
       });
 
-      updateTrack({
+      await updateTrack({
         ids: "123",
         color: "#FF0000",
       });
@@ -439,7 +442,7 @@ describe("updateTrack", () => {
         return [0];
       });
 
-      updateTrack({
+      await updateTrack({
         ids: "123",
         color: "#FF0000",
       });
@@ -464,7 +467,7 @@ describe("updateTrack", () => {
       track123.get.mockImplementation(colorMock);
       track456.get.mockImplementation(colorMock);
 
-      updateTrack({
+      await updateTrack({
         ids: "123,456",
         color: "#00FF00",
       });
@@ -486,7 +489,7 @@ describe("updateTrack", () => {
       const consoleModule = await import("#src/shared/v8-max-console.ts");
       const consoleSpy = vi.spyOn(consoleModule, "warn");
 
-      updateTrack({
+      await updateTrack({
         ids: "123",
         name: "No color update",
       });

--- a/src/tools/track/update/update-track.def.ts
+++ b/src/tools/track/update/update-track.def.ts
@@ -101,6 +101,18 @@ export const toolDefUpdateTrack = defineTool("adj-update-track", {
       .describe(
         'return track: exact name (e.g., "A-Reverb") or letter (e.g., "A")',
       ),
+    freeze: z
+      .boolean()
+      .optional()
+      .describe(
+        "freeze (render device chain to audio, frees CPU) or unfreeze the track. Async in Live - response reports isFrozen once confirmed, or freezeStatus: 'in_progress' if still rendering",
+      ),
+    flatten: z
+      .boolean()
+      .optional()
+      .describe(
+        "commit frozen audio permanently and remove devices. Irreversible. Requires the track to already be frozen (combine with freeze: true to freeze then flatten in one call)",
+      ),
   },
 
   smallModelModeConfig: {

--- a/src/tools/track/update/update-track.ts
+++ b/src/tools/track/update/update-track.ts
@@ -4,6 +4,7 @@
 
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import * as console from "#src/shared/v8-max-console.ts";
+import { computeLoopDeadline } from "#src/tools/clip/helpers/loop-deadline.ts";
 import {
   LIVE_API_MONITORING_STATE_AUTO,
   LIVE_API_MONITORING_STATE_IN,
@@ -25,13 +26,8 @@ import {
   getNameForIndex,
   parseNames,
 } from "#src/tools/shared/validation/name-utils.ts";
-
-interface RoutingParams {
-  inputRoutingTypeId?: string;
-  inputRoutingChannelId?: string;
-  outputRoutingTypeId?: string;
-  outputRoutingChannelId?: string;
-}
+import { applyFreezeAndFlatten } from "./helpers/update-track-freeze-helpers.ts";
+import { applyRoutingProperties } from "./helpers/update-track-routing-helpers.ts";
 
 interface MixerParams {
   gainDb?: number;
@@ -62,48 +58,16 @@ interface UpdateTrackArgs {
   arrangementFollower?: boolean;
   sendGainDb?: number;
   sendReturn?: string;
+  freeze?: boolean;
+  flatten?: boolean;
 }
 
-interface UpdateTrackResult {
+export interface UpdateTrackResult {
   id: string;
-}
-
-/**
- * Apply routing properties to a track
- * @param track - Track object
- * @param params - Routing properties
- */
-function applyRoutingProperties(track: LiveAPI, params: RoutingParams): void {
-  const {
-    inputRoutingTypeId,
-    inputRoutingChannelId,
-    outputRoutingTypeId,
-    outputRoutingChannelId,
-  } = params;
-
-  if (inputRoutingTypeId != null) {
-    track.setProperty("input_routing_type", {
-      identifier: Number(inputRoutingTypeId),
-    });
-  }
-
-  if (inputRoutingChannelId != null) {
-    track.setProperty("input_routing_channel", {
-      identifier: Number(inputRoutingChannelId),
-    });
-  }
-
-  if (outputRoutingTypeId != null) {
-    track.setProperty("output_routing_type", {
-      identifier: Number(outputRoutingTypeId),
-    });
-  }
-
-  if (outputRoutingChannelId != null) {
-    track.setProperty("output_routing_channel", {
-      identifier: Number(outputRoutingChannelId),
-    });
-  }
+  isFrozen?: boolean;
+  freezeStatus?: string;
+  flattened?: boolean;
+  $meta?: string[];
 }
 
 /**
@@ -368,10 +332,12 @@ function applyMixerProperties(track: LiveAPI, params: MixerParams): void {
  * @param args.arrangementFollower - Whether the track should follow the arrangement timeline
  * @param args.sendGainDb - Optional send gain in dB (-70 to 0), requires sendReturn
  * @param args.sendReturn - Optional return track name (exact or letter prefix), requires sendGainDb
- * @param _context - Internal context object (unused)
+ * @param args.freeze - Freeze (true) or unfreeze (false) the track. Freezing is async in Live
+ * @param args.flatten - Flatten a frozen track: irreversible, removes devices
+ * @param context - Internal context object, used for the freeze polling deadline
  * @returns Single track object or array of track objects
  */
-export function updateTrack(
+export async function updateTrack(
   {
     ids,
     name,
@@ -393,12 +359,16 @@ export function updateTrack(
     arrangementFollower,
     sendGainDb,
     sendReturn,
+    freeze,
+    flatten,
   }: UpdateTrackArgs,
-  _context: Partial<ToolContext> = {},
-): UpdateTrackResult | UpdateTrackResult[] {
+  context: Partial<ToolContext> = {},
+): Promise<UpdateTrackResult | UpdateTrackResult[]> {
   if (!ids) {
     throw new Error("updateTrack failed: ids is required");
   }
+
+  const deadline = computeLoopDeadline(context.timeoutMs);
 
   // Parse comma-separated string into array
   const trackIds = parseCommaSeparatedIds(ids);
@@ -470,9 +440,20 @@ export function updateTrack(
     applySendProperties(track, sendGainDb, sendReturn);
 
     // Build optimistic result object
-    updatedTracks.push({
-      id: track.id,
-    });
+    const trackResult: UpdateTrackResult = { id: track.id };
+
+    // Handle freeze/unfreeze and flatten (async: freeze completion is polled)
+    if (freeze != null || flatten) {
+      await applyFreezeAndFlatten(
+        track,
+        freeze,
+        flatten,
+        deadline,
+        trackResult,
+      );
+    }
+
+    updatedTracks.push(trackResult);
   }
 
   return unwrapSingleResult(updatedTracks);


### PR DESCRIPTION
### **User description**
## Summary
- `freeze: true | false` on `adj-update-track` -> `track.freeze` (async in Live: response reports `isFrozen` once `is_frozen` is confirmed by polling, or `freezeStatus: "in_progress"` if it hasn't finished rendering within the polling window)
- `flatten: true` on `adj-update-track` -> `track.call("flatten")`, only once the track is confirmed frozen (warns and skips otherwise); irreversible, so a successful flatten adds a `$meta` warning
- Both can be combined in one call (`freeze: true, flatten: true`) to freeze then flatten
- `adj-read-track` now returns `isFrozen` in the base response, following the existing `isArmed`/`isGroup` "only present when true" pattern

## Why
Complex sessions with many CPU-intensive devices need freezing. The AI should be able to manage this directly -- freeze tracks it's not editing, unfreeze when changes are needed, and flatten to print effects permanently before export.

Closes #30

## Implementation notes
- Freezing is async in Live: setting `track.freeze` starts rendering, `is_frozen` only flips once it's done. Polls `is_frozen` with a bounded timeout, mirroring `waitForPlayheadPosition`'s poll-then-warn shape (`update-live-set-locator-helpers.ts`), but with a wider window (200ms x 50 = 10s) since freeze can take much longer than a playhead move.
- Also respects the overall request deadline via `computeLoopDeadline`/`isDeadlineExceeded` (same helper `update-clip.ts` uses for its per-item loop) -- if the deadline has already passed, the freeze is set but polling is skipped, reporting `freezeStatus: "in_progress"` immediately instead of blocking.
- This makes `updateTrack` async (matching `updateLiveSet`/`updateClip`), so the three existing `update-track` test files were converted to `async`/`await`, including the two synchronous-throw assertions, which now use `.rejects.toThrow(...)` per `update-clip`'s established pattern.
- `update-track.ts` was pushed past the 325-line file cap by these additions on top of the just-merged fold/unfold feature (#239), so `applyRoutingProperties` was extracted into its own helper file alongside the new freeze/flatten helper -- pure move, no behavior change.

## Test plan
- [x] `npm run check` -- lint, typecheck, format, duplication, full test suite (3812 tests) all pass, coverage above thresholds
- [x] Added unit tests: freeze confirmed, unfreeze confirmed, freeze not confirmed in time (`freezeStatus: "in_progress"`), deadline-exceeded skips polling, flatten skipped when not frozen, flatten succeeds with `$meta` warning, freeze+flatten combined in one call, no-op when neither param is provided
- [x] Added read-side tests: `isFrozen` present when frozen, omitted when not


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add `freeze` and `flatten` parameters to `adj-update-track`.

- Expose `isFrozen` property in `adj-read-track` responses.

- Implement asynchronous freezing with polling for completion or `in_progress` status.

- Enable irreversible flattening of frozen tracks, with warnings.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["adj-update-track"] -- "freeze: boolean, flatten: boolean" --> B{Track Update Logic}
  B -- "Calls applyFreezeAndFlatten" --> C[applyFreezeAndFlatten Helper]
  C -- "Sets track.freeze" --> D{Freeze Async Operation}
  D -- "Polls is_frozen" --> E{Freeze Confirmed?}
  E -- "Yes" --> F[Result: isFrozen]
  E -- "No (timeout/deadline)" --> G[Result: freezeStatus: "in_progress"]
  C -- "If frozen, calls track.call('flatten')" --> H[Flatten Operation]
  H -- "Adds $meta warning" --> I[Result: flattened]
  J["adj-read-track"] -- "Reads track.is_frozen" --> K[Exposes isFrozen in Response]
  F & G & I & K --> L[Tool Response]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>read-track-helpers.ts</strong><dd><code>Add `isFrozen` property to track read results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/241/files#diff-18c529a62d371997ff680e0f554ce993204e259bd3eaf60b28e66a0dafc5af0d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-track-freeze-helpers.ts</strong><dd><code>Implement asynchronous freeze/unfreeze and flatten logic</code>&nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/241/files#diff-46bb0294f7878ff3302eeed2de67cb7441a4d114f0116d8d8c5680bea233b447">+114/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>update-track.def.ts</strong><dd><code>Add <code>freeze</code> and <code>flatten</code> parameters to <code>adj-update-track</code> definition</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/241/files#diff-fa426197dd69cac83acbc13c57782efea85a173613dfa4aee8476e00d3b74de8">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-track.ts</strong><dd><code>Integrate freeze/flatten logic and refactor routing properties</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/241/files#diff-9bda6aa29aafb0976fd98456c7b43de2ff2bd81fa0a93121b12deec8e0544d76">+34/-53</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>read-track-basic.test.ts</strong><dd><code>Add tests for `isFrozen` property in `readTrack`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/241/files#diff-7bd9013c10ad7d772cd49f28e71b977ccf66aed0c3eb0d5c10e27d2d4997e61a">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-track-freeze.test.ts</strong><dd><code>Add comprehensive tests for track freeze and flatten functionality</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/241/files#diff-2b5df75dad4c90f06363d1d64766b60322b6f889b8e7fdf83d5e7ad638f3bedc">+145/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>update-track-mixer.test.ts</strong><dd><code>Convert mixer property tests to async/await</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/241/files#diff-c1847039fcaefd511fb9766756480a4d02c4577f5a5f9620b5615cd0a32c2046">+34/-34</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>update-track-send.test.ts</strong><dd><code>Convert send property tests to async/await</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/241/files#diff-64b78f0e4583375e065de9c9beade96318333315404553aa6388dcd57ae1de4a">+28/-28</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>update-track.test.ts</strong><dd><code>Convert general <code>updateTrack</code> tests to async/await and update error <br>assertions</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/241/files#diff-613a35ff7f6bb3986495c73f3d370119ff113d9751ba4cd89a46469ac17139fd">+66/-63</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>update-track-routing-helpers.ts</strong><dd><code>Extract `applyRoutingProperties` into a dedicated helper file</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/241/files#diff-5abb8e225613f405f4209e543e2da36d35b7cd425daff8cf20c767116040eb45">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>Tools-Reference.md</strong><dd><code>Update documentation for `adj-read-track` and `adj-update-track`</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/241/files#diff-1144a39ffd998b6c8832a8e6e38fae79a98231f8e64046307c61134a0b297194">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Read-Tool-Includes.md</strong><dd><code>Document new `isFrozen` field for `adj-read-track`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/241/files#diff-99cea3c30bdf5fa09646592c8d702658226f339f92f0ed3c413d54d36123ae05">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

