### PR TITLE
ci: auto-rebuild dist on push, install:device reads straight from it

### DIFF
--- a/.github/workflows/rebuild-dist.yml
+++ b/.github/workflows/rebuild-dist.yml
@@ -1,0 +1,40 @@
+name: Rebuild dist
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+      - "config/rollup.config.mjs"
+
+permissions:
+  contents: write
+
+jobs:
+  rebuild-dist:
+    name: Rebuild dist
+    runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Commit dist if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dist/
+          if git diff --cached --quiet; then
+            echo "dist/ unchanged, nothing to commit"
+          else
+            git commit -m "chore: rebuild dist [skip ci]"
+            git push
+          fi

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -38,15 +38,22 @@ To add a new file with a hardcoded version:
 
 ## Deploying a new version locally
 
+`dist/` is kept up to date automatically: a CI workflow
+([`rebuild-dist.yml`](../.github/workflows/rebuild-dist.yml)) rebuilds and
+commits it on every push to `main` that touches `src/`, `package.json`,
+`package-lock.json`, or the rollup config. `npm run install:device` reads the
+built JS bundles directly from `dist/` (and the static `.amxd`/`.maxpat` assets
+from `max-for-live-device/`) — there's no manual copy step between them anymore.
+
 After a release lands on `main`:
 
 ```bash
 git checkout main && git pull
-npm run build
-cp dist/live-api-adapter.js max-for-live-device/live-api-adapter.js
-cp dist/mcp-server.mjs max-for-live-device/mcp-server.mjs
 npm run install:device   # refresh the copy in your Live User Library
 ```
+
+If you're testing local changes that haven't been pushed to `main` yet (and
+therefore haven't gone through the auto-rebuild), run `npm run build` first.
 
 Then in Ableton Live:
 
@@ -80,23 +87,27 @@ Edits to V8-only paths (`live-api-adapter.ts`) don't trigger Max to respawn the
 v8 engine — click the device's reload button or eject + reinsert if you don't
 see the new version line in the console.
 
-This script is dev-only. Releases still go through the manual flow above so the
-committed `dist/` artefacts match the tag.
+This script is dev-only and writes to your local `max-for-live-device/`
+(gitignored) for fast iteration. `dist/` itself is kept current on `main` by the
+CI rebuild, independent of this loop.
 
-## Why the manual copy step
+## Why max-for-live-device/ still exists
 
 The `.amxd` references sibling JS files via relative path
-(`v8 ./live-api-adapter.js`, `node.script ./mcp-server.mjs`). Rollup writes to
-`dist/`. Live loads from `max-for-live-device/`. Bridging them is currently
-manual. Tracked in
-[#78](https://github.com/gabrielpulga/ableton-dj-mcp/issues/78) (smoother
-install UX).
+(`v8 ./live-api-adapter.js`, `node.script ./mcp-server.mjs`). If you drag
+`max-for-live-device/Ableton_DJ_MCP.amxd` directly onto a track (the manual
+install fallback in [Setup.md](Setup.md), instead of running
+`npm run install:device`), those JS siblings need to physically exist next to it
+— that's what `npm run dev:hot`'s watcher keeps populated during active
+development. `npm run install:device` doesn't need this bridging: it reads the
+built JS straight from `dist/` and only pulls the static `.amxd`/`.maxpat` files
+from `max-for-live-device/`.
 
 ## Verifying a release end-to-end
 
 ```bash
-# Confirm bundle has the expected version baked in
-grep -o '1\.[0-9]\.[0-9]' max-for-live-device/live-api-adapter.js | sort -u
+# Confirm the bundle has the expected version baked in
+grep -o '1\.[0-9]\.[0-9]' dist/live-api-adapter.js | sort -u
 ```
 
 Should match the version in `package.json`.

--- a/docs/findings/workflow/device-deploy-flow.md
+++ b/docs/findings/workflow/device-deploy-flow.md
@@ -7,10 +7,17 @@ evidence: live deploy 1.6.0 → 1.8.0 → 1.8.1 in conversation 2026-04-25
 
 ## Fact
 
-The `.amxd` device references sibling JS files via relative path. Build
-artefacts must be copied from `dist/` into `max-for-live-device/` for new code
-to take effect. Live caches V8 bytecode per session — restart Live (or eject +
-reinsert device) to load updated JS.
+The `.amxd` device references sibling JS files via relative path. Live caches V8
+bytecode per session — restart Live (or eject + reinsert device) to load updated
+JS.
+
+`npm run install:device` (the primary deploy path) reads the built JS straight
+from `dist/`, kept fresh automatically by the `rebuild-dist.yml` CI workflow on
+every push to `main` — no manual copy needed. The manual `dist/` →
+`max-for-live-device/` copy only matters if you drag
+`max-for-live-device/Ableton_DJ_MCP.amxd` directly onto a track instead of using
+`install:device` — `npm run dev:hot`'s watcher handles that copy automatically
+during active development.
 
 ## Evidence
 
@@ -28,9 +35,7 @@ Deploy commands:
 
 ```bash
 git checkout main && git pull
-npm run build
-cp dist/live-api-adapter.js max-for-live-device/live-api-adapter.js
-cp dist/mcp-server.mjs max-for-live-device/mcp-server.mjs
+npm run install:device
 # Then restart Live OR eject + reinsert .amxd
 ```
 

--- a/scripts/install-device.ts
+++ b/scripts/install-device.ts
@@ -5,13 +5,13 @@
 // Installs the Max for Live device into Ableton's User Library so it shows up
 // in the browser permanently. Eliminates the per-session Finder drag.
 //
-// Source:  max-for-live-device/Ableton_DJ_MCP.amxd (+ sibling JS bundles)
+// Source:  max-for-live-device/Ableton_DJ_MCP.amxd + *.maxpat (static assets)
+//          dist/live-api-adapter.js + dist/mcp-server.mjs (built bundles)
 // Dest:    <Live User Library>/Presets/MIDI Effects/Max MIDI Effect/
 //
 // Idempotent: overwrites existing files of the same name.
 
-import { createHash } from "node:crypto";
-import { copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
 import { platform } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -22,63 +22,41 @@ const repoRoot = resolve(here, "..");
 const sourceDir = join(repoRoot, "max-for-live-device");
 const distDir = join(repoRoot, "dist");
 
-const DEVICE_FILES = [
+const STATIC_FILES = [
   "Ableton_DJ_MCP.amxd",
-  "live-api-adapter.js",
-  "mcp-server.mjs",
   "server-status.maxpat",
   "tab-main.maxpat",
   "tab-context.maxpat",
   "tab-setup.maxpat",
 ] as const;
 
+const BUILT_FILES = ["live-api-adapter.js", "mcp-server.mjs"] as const;
+
+const DEVICE_FILES = [
+  ...STATIC_FILES.map((file) => ({ file, dir: sourceDir })),
+  ...BUILT_FILES.map((file) => ({ file, dir: distDir })),
+];
+
 /**
- * Verify the source files exist and warn if dist/ has drifted from
- * max-for-live-device/ (which would mean we're about to install stale code).
+ * Verify all source files exist before copying.
  */
-function assertSourceFresh(): void {
-  for (const file of DEVICE_FILES) {
-    const sourcePath = join(sourceDir, file);
+function assertSourcesExist(): void {
+  for (const { file, dir } of DEVICE_FILES) {
+    const sourcePath = join(dir, file);
 
     if (!existsSync(sourcePath)) {
       console.error(`install-device failed: missing ${sourcePath}`);
-      console.error("Run `npm run build` first.");
+      console.error(
+        dir === distDir
+          ? "Run `npm run build` first."
+          : "max-for-live-device/ is missing a tracked asset — check your clone.",
+      );
       process.exit(1);
     }
   }
-
-  for (const file of ["live-api-adapter.js", "mcp-server.mjs"]) {
-    const distPath = join(distDir, file);
-    const sourcePath = join(sourceDir, file);
-
-    if (!existsSync(distPath)) {
-      continue;
-    }
-
-    if (hashFile(distPath) !== hashFile(sourcePath)) {
-      console.warn(
-        `install-device: WARNING — dist/${file} differs from ` +
-          `max-for-live-device/${file}. The device will install with stale code.`,
-      );
-      console.warn(
-        "  Run: cp dist/live-api-adapter.js dist/mcp-server.mjs " +
-          "max-for-live-device/",
-      );
-      console.warn("  Then re-run this script.");
-    }
-  }
 }
 
-/**
- * Hash a file's contents (sha256) for cheap drift detection.
- * @param path - Absolute path to the file
- * @returns Hex-encoded sha256 digest
- */
-function hashFile(path: string): string {
-  return createHash("sha256").update(readFileSync(path)).digest("hex");
-}
-
-assertSourceFresh();
+assertSourcesExist();
 
 const targetDir = resolveUserLibraryDir();
 
@@ -95,8 +73,8 @@ if (!existsSync(targetDir)) {
   console.log(`install-device: created ${targetDir}`);
 }
 
-for (const file of DEVICE_FILES) {
-  const sourcePath = join(sourceDir, file);
+for (const { file, dir } of DEVICE_FILES) {
+  const sourcePath = join(dir, file);
   const targetPath = join(targetDir, file);
 
   copyFileSync(sourcePath, targetPath);


### PR DESCRIPTION
## Summary
Root cause of #245 (dist/ silently going stale across six feature PRs): nothing enforced dist/ stayed in sync with src/, and each PR's own dist diff looked cosmetic against its own base. Two changes that fix this properly:

- **`.github/workflows/rebuild-dist.yml`** — rebuilds and commits `dist/` on every push to `main` that touches `src/`, `package.json`, `package-lock.json`, or the rollup config. Path-scoped so the bot's own dist-only commit can't re-trigger itself, no loop-detection hacks needed.
- **`scripts/install-device.ts`** — reads `live-api-adapter.js`/`mcp-server.mjs` directly from `dist/` instead of `max-for-live-device/`, static `.amxd`/`.maxpat` assets still come from `max-for-live-device/` as before. Removes the hash-based drift-warning entirely since there's only one source of truth for the built JS now.

Together: `git pull && npm run install:device` is now the entire deploy flow, no manual `cp` step. `npm run dev:hot` is unaffected -- still copies into `max-for-live-device/` for fast iteration when the device is loaded directly from there.

Docs updated: `docs/Releasing.md`, `docs/findings/workflow/device-deploy-flow.md`.

## Test plan
- [x] `npm run check` -- lint, typecheck, format, duplication, full test suite (3819 tests) all pass
- [x] Ran `node scripts/install-device.ts` manually -- confirmed it correctly pulls the two JS files from `dist/` and the rest from `max-for-live-device/`
- [x] Verified the missing-file error path (moved `dist/live-api-adapter.js` aside, confirmed the script errors with the right message instead of silently installing stale/missing content)
- [x] Validated the new workflow YAML syntax