### PR TITLE
docs: stop telling contributors to run /update-docs, it's personal tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,10 @@ For each INDEX line, match the bracketed globs against your task's file paths.
 Read the linked file ONLY if matched. Skip if no match — the INDEX line itself
 is the lookup key.
 
-To capture a new validated finding, run `/update-docs` (loads
-`docs/findings/HOW-TO-WRITE.md`).
+To capture a new validated finding, follow the format in
+`docs/findings/HOW-TO-WRITE.md` and add it directly. (The maintainer uses a
+personal Claude Code slash command to automate this — it's local tooling, not
+part of this repo, so don't expect it to exist on a fresh clone.)
 
 ## Tools
 

--- a/workspace.template/AI.md
+++ b/workspace.template/AI.md
@@ -134,9 +134,11 @@ fades, sessions get long.
 
 ### How to capture
 
-Run `/update-docs` in your AI client. It loads
-`workspace/findings/HOW-TO-WRITE.md` for the format spec, then scans the
-conversation, dedups against INDEX, and writes only validated findings.
+Ask your AI client to write a finding following the format in
+`workspace/findings/HOW-TO-WRITE.md` — scan the conversation, dedup against
+INDEX, write only validated findings. (If you've set up your own automation for
+this, e.g. a custom slash command, use that instead — there's no built-in one
+shipped with this repo.)
 
 For tool issues: ask the AI to file a GitHub issue with concrete reproduction
 steps.


### PR DESCRIPTION
### **User description**
## Summary
`CLAUDE.md` and `workspace.template/AI.md` both instructed users to run `/update-docs`, a Claude Code slash command. That command only ever existed in the maintainer's personal `~/.claude/commands/` -- `.claude/` is blanket-gitignored in this repo, so it was never shipped and never reachable from a fresh clone.

Worse: `workspace.template/AI.md` is the scaffold every new user gets via `npm run init:workspace` -- brand-new users following the workspace setup would hit this immediately.

## Why not ship the command instead
Considered tracking `.claude/commands/` so the command travels with the repo. Rejected: it hardcodes `gabrielpulga` as the PR assignee for anything it commits -- that's maintainer-specific workflow, not something a contributor should inherit by default just by cloning.

## Fix
Reworded both docs to point at `docs/findings/HOW-TO-WRITE.md` directly (the actual format spec, already tracked and fully usable manually) and note the automation is personal tooling, not part of this repo.

## Test plan
- [x] \`npm run check\` -- lint, typecheck, format, duplication, full test suite (3819 tests) all pass


___

### **PR Type**
Documentation


___

### **Description**
- Remove references to `/update-docs` command.

- Direct users to `HOW-TO-WRITE.md` for findings.

- Clarify automation is personal tooling.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Update finding capture instructions and clarify personal tooling</code></dd></summary>
<hr>

CLAUDE.md

<ul><li>Removed instructions to run the <code>/update-docs</code> slash command.<br> <li> Added guidance to follow the format in <code>docs/findings/HOW-TO-WRITE.md</code> <br>directly.<br> <li> Clarified that the maintainer's automation is personal tooling and not <br>part of the repo.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/248/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AI.md</strong><dd><code>Revise AI client finding capture instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

workspace.template/AI.md

<ul><li>Replaced instructions to run <code>/update-docs</code> with a directive to ask the <br>AI client to follow the format.<br> <li> Pointed users to <code>workspace/findings/HOW-TO-WRITE.md</code> for the format <br>specification.<br> <li> Noted that custom automation is not built-in or shipped with the <br>repository.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/248/files#diff-c65c867b8a8e0071898da41ae32e6196ca07924457b7a0d3bb51f6b2841aafcf">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

