### PR TITLE
fix: track freeze hangs indefinitely instead of returning freezeStatus

### DIFF
--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -9,6 +9,14 @@ subdirs (see `HOW-TO-WRITE.md`).
 
 ## dev
 
+- [track-freeze-missing-from-lom](dev/track-freeze-missing-from-lom.md)
+  [src/tools/track/update/helpers/update-track-freeze-helpers.ts] — Live Object
+  Model has no freeze/flatten trigger on Track, only get/observe can_be_frozen
+  and is_frozen
+- [v8-task-needs-persistent-ref](dev/v8-task-needs-persistent-ref.md)
+  [src/shared/v8-sleep.ts, src/live-api-adapter/**] — inline
+  `new Task(cb).schedule(ms)` with no stored reference risks GC before it fires
+
 ### notation
 
 - [barbeat-notation-order](dev/notation/barbeat-notation-order.md)

--- a/docs/findings/dev/track-freeze-missing-from-lom.md
+++ b/docs/findings/dev/track-freeze-missing-from-lom.md
@@ -1,0 +1,28 @@
+---
+title: track-freeze-missing-from-lom
+domain: dev
+validated: 2026-08-02
+evidence: docs.cycling74.com/apiref/lom/track/ (unverified live against Live)
+---
+
+## Fact
+
+Ableton's Live Object Model does not document any way to trigger freeze or
+flatten on a Track. Only `can_be_frozen` (access: get) and `is_frozen` (access:
+getobserve) exist. `track.set("freeze", freeze)` and `track.call("flatten")` in
+`update-track-freeze-helpers.ts` target API surface that isn't documented to
+exist, so freeze/unfreeze/flatten may silently never complete against real Live
+regardless of polling logic.
+
+## Evidence
+
+docs.cycling74.com/apiref/lom/track/: `can_be_frozen` — "1 = the track can be
+frozen, 0 = otherwise" (get only); `is_frozen` — "1 = the track is currently
+frozen" (getobserve). No `freeze` or `flatten` entry exists on Track. Multiple
+Cycling '74 forum threads asking how to freeze/flatten via the API report the
+same absence. Not yet confirmed against a running Live instance.
+
+## Apply when
+
+Touching `src/tools/track/update/helpers/update-track-freeze-helpers.ts`, or
+adding a tool action described as freeze/flatten/bounce-in-place on a track.

--- a/docs/findings/dev/v8-task-needs-persistent-ref.md
+++ b/docs/findings/dev/v8-task-needs-persistent-ref.md
@@ -1,0 +1,31 @@
+---
+title: v8-task-needs-persistent-ref
+domain: dev
+validated: 2026-08-02
+evidence:
+  docs.cycling74.com/max8/vignettes/jstaskobject;
+  src/shared/tests/v8-sleep.test.ts "Task retention" suite
+---
+
+## Fact
+
+A Max `Task` created and scheduled inline with no other reference
+(`new Task(cb).schedule(ms)`) risks garbage collection before its callback
+fires. `sleep()` in `src/shared/v8-sleep.ts` used exactly that pattern, so any
+`waitUntil()` poll loop (track freeze confirmation, locator playhead wait) could
+hang past its coded timeout instead of resolving.
+
+## Evidence
+
+Cycling '74 Task docs: "Task objects persist beyond their code scope (otherwise,
+the object could be garbage collected before its scheduled function is called),"
+shown fixed via `var tsk = new Task(cb); tsk.schedule(200)`. Fixed by keeping
+every in-flight Task in a module-level `Set` until its callback fires; retention
+verified by `getPendingSleepTaskCount()` assertions in
+`src/shared/tests/v8-sleep.test.ts`.
+
+## Apply when
+
+Writing V8 Live API adapter code (`src/live-api-adapter/**`) that schedules a
+Max `Task` directly, or that calls `sleep()`/`waitUntil()` in
+`src/shared/v8-sleep.ts`.

--- a/src/shared/tests/v8-sleep.test.ts
+++ b/src/shared/tests/v8-sleep.test.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { waitUntil } from "#src/shared/v8-sleep.ts";
+import { getPendingSleepTaskCount, waitUntil } from "#src/shared/v8-sleep.ts";
 
 const g = globalThis as Record<string, unknown>;
 
@@ -78,6 +78,59 @@ describe("v8-sleep", () => {
       const result = await waitUntil(predicate);
 
       expect(result).toBe(true);
+    });
+  });
+
+  // Real Max Tasks can be garbage collected before their scheduled callback
+  // fires unless something keeps referencing them (see Cycling '74's Task
+  // docs). Node's GC won't reproduce that nondeterministically in a test, so
+  // these assert the retention mechanism itself: a Task must stay reachable
+  // for as long as its sleep() is outstanding, and get released once it
+  // fires - otherwise every wait either hangs forever (unreleased Task never
+  // called back) or leaks Tasks indefinitely (never removed from tracking).
+  describe("Task retention", () => {
+    it("keeps the Task referenced while waiting and releases it once it fires", async () => {
+      expect(getPendingSleepTaskCount()).toBe(0);
+
+      let callCount = 0;
+      const predicate = vi.fn().mockImplementation(() => {
+        callCount++;
+
+        return callCount >= 2;
+      });
+
+      const resultPromise = waitUntil(predicate, { pollingInterval: 10 });
+
+      // The first (false) predicate check runs synchronously, which starts a
+      // sleep() before any timer has advanced - the underlying Task must
+      // already be tracked at this point, or it would be eligible for
+      // premature collection in the real M4L runtime.
+      expect(getPendingSleepTaskCount()).toBe(1);
+
+      await vi.runAllTimersAsync();
+
+      const result = await resultPromise;
+
+      expect(result).toBe(true);
+      expect(getPendingSleepTaskCount()).toBe(0);
+    });
+
+    it("tracks multiple concurrent sleeps independently", async () => {
+      const first = waitUntil(() => false, {
+        pollingInterval: 10,
+        maxRetries: 1,
+      });
+      const second = waitUntil(() => false, {
+        pollingInterval: 20,
+        maxRetries: 1,
+      });
+
+      expect(getPendingSleepTaskCount()).toBe(2);
+
+      await vi.runAllTimersAsync();
+      await Promise.all([first, second]);
+
+      expect(getPendingSleepTaskCount()).toBe(0);
     });
   });
 });

--- a/src/shared/v8-sleep.ts
+++ b/src/shared/v8-sleep.ts
@@ -13,12 +13,49 @@ declare const Task: new (callback: () => void) => {
 };
 
 /**
+ * Keeps in-flight sleep Tasks reachable so the Max v8 engine can't
+ * garbage-collect them before their scheduled callback fires.
+ *
+ * Per Cycling '74's Task documentation, "Task objects persist beyond their
+ * code scope (otherwise, the object could be garbage collected before its
+ * scheduled function is called)." Their own example assigns the Task to a
+ * variable that outlives the creating function
+ * (`var tsk = new Task(cb); tsk.schedule(200)`) for exactly this reason.
+ * Creating and scheduling a Task inline with no other reference - e.g.
+ * `new Task(cb).schedule(ms)` - is the unsafe pattern the docs warn against:
+ * once the enclosing function returns, nothing keeps the Task alive, so it
+ * can be collected before it ever fires, leaving the Promise permanently
+ * unresolved. This module-level Set is that persistent reference for every
+ * in-flight `sleep()` call.
+ */
+const pendingSleepTasks = new Set<object>();
+
+/**
  * Sleep for the specified number of milliseconds
  * @param ms - Milliseconds to sleep
  * @returns Resolves after the delay
  */
 const sleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => new Task(resolve).schedule(ms));
+  new Promise((resolve) => {
+    const task = new Task(() => {
+      pendingSleepTasks.delete(task);
+      resolve();
+    });
+
+    pendingSleepTasks.add(task);
+    task.schedule(ms);
+  });
+
+/**
+ * Number of Tasks currently scheduled and kept alive by `sleep()`.
+ * Real garbage collection is nondeterministic and can't be forced from a
+ * test, so this exposes the retention mechanism directly for assertions.
+ * @internal test-only
+ * @returns Count of Tasks awaiting their scheduled callback
+ */
+export function getPendingSleepTaskCount(): number {
+  return pendingSleepTasks.size;
+}
 
 interface WaitUntilOptions {
   pollingInterval?: number;

--- a/src/tools/track/update/helpers/update-track-freeze-helpers.ts
+++ b/src/tools/track/update/helpers/update-track-freeze-helpers.ts
@@ -33,6 +33,15 @@ function isTrackFrozen(track: LiveAPI): boolean {
  * is skipped for this track and `freezeStatus: "in_progress"` is reported
  * instead of blocking; the AI can confirm completion with adj-read-track.
  *
+ * KNOWN RISK: Cycling '74's published Track reference
+ * (docs.cycling74.com/apiref/lom/track/) only documents `can_be_frozen`
+ * (get) and `is_frozen` (getobserve) - no settable `freeze` property or
+ * callable `freeze`/`flatten` function is listed. `track.set("freeze", ...)`
+ * and `track.call("flatten")` below may be targeting API surface that
+ * doesn't exist, in which case this bounded poll will always end in
+ * `freezeStatus: "in_progress"` rather than ever confirming completion. See
+ * docs/findings/dev/track-freeze-missing-from-lom.md (unverified live).
+ *
  * @param track - Track object
  * @param freeze - Desired freeze state (true = freeze, false = unfreeze), or undefined to skip
  * @param flatten - Whether to flatten (commit frozen audio, remove devices)


### PR DESCRIPTION
## Summary

Live-testing `adj-update-track { freeze: true }` against a running Ableton
Live 12.4.3 instance timed out the MCP client after 30s with zero response -
not even the `freezeStatus: "in_progress"` fallback the code is supposed to
return within its own coded ~10s ceiling.

**Root cause**: `sleep()` in `src/shared/v8-sleep.ts` created its Max `Task`
inline with no persistent reference (`new Task(resolve).schedule(ms)`).
Cycling '74's own Task docs warn this exact pattern risks the M4L v8 engine
garbage-collecting the Task before it fires: *"Task objects persist beyond
their code scope (otherwise, the object could be garbage collected before
its scheduled function is called)"* - their fix example assigns it to a
variable that outlives the creating function. If that GC happens mid-poll,
`waitUntil()`'s promise never resolves, `applyFreeze`'s poll (and
`waitForPlayheadPosition` in `update-live-set-locator-helpers.ts`, which
shares the same `sleep()`) hangs indefinitely instead of bailing out at its
~10s ceiling, and no `mcp_response` is ever sent - matching the observed
30s client-side timeout with no output at all.

**Fix**: keep every in-flight Task referenced in a module-level `Set` until
its own callback fires and removes it - the same persistent-reference
pattern Cycling '74 documents, already used by this codebase's
`code-exec-v8-protocol.ts` for its own Task-based timeout. Added
`getPendingSleepTaskCount()` (test-only) so retention can be asserted
directly, since real GC is nondeterministic and can't be forced from a test.

**Locator helpers share the risk and the fix**: `waitForPlayheadPosition` in
`update-live-set-locator-helpers.ts` polls via the exact same `waitUntil`/
`sleep()` primitive, so it was equally exposed to the same hang and is fixed
by the same change - no separate code change needed there, but flagged in
this PR per your ask.

**Separate, lower-confidence finding (unverified live)**: Cycling '74's
official Track reference (`docs.cycling74.com/apiref/lom/track/`) lists no
settable `freeze` property and no callable `freeze`/`flatten` function on
Track - only get/observe `can_be_frozen`/`is_frozen`. `track.set("freeze",
...)` and `track.call("flatten")` in `update-track-freeze-helpers.ts` may be
targeting API surface that doesn't exist, which would mean the freeze
confirmation always ends in `freezeStatus: "in_progress"` rather than ever
completing - even after this hang fix. This is bigger than the "settable
property vs. callable function" question you asked me to check (5 min): I
found no evidence either form exists at all. I have **not** changed the
freeze/flatten trigger calls themselves - I can't test live Ableton from
here, and swapping in an unverified alternative felt riskier than flagging it
clearly. Documented in `docs/findings/dev/track-freeze-missing-from-lom.md`
for you to confirm/act on with real Live access. Also noted:
`docs/findings/dev/live-api-property-names-need-external-check.md` (referenced
in the task as already existing) isn't present on `main` in this checkout, so
this is a new finding rather than an extension of it.

## Test plan

- [x] `npx vitest run -c config/vitest.config.ts src/shared/tests/v8-sleep.test.ts` - new "Task retention" suite uses fake timers to assert the Set holds a Task while its sleep is outstanding and releases it once fired (not just synchronous mocks)
- [x] `npx vitest run -c config/vitest.config.ts src/tools/track/update/tests/update-track-freeze.test.ts src/tools/live-set/tests/update-live-set-locator-operations.test.ts src/tools/live-set/tests/read-live-set-locators.test.ts` - no regressions
- [x] `npm run check` - lint, typecheck, format, duplication, full coverage all pass (statements 98.31%, branches 94.67%, functions 98.45%, lines 98.53%)
- [ ] Live-validate `adj-update-track { ids, freeze: true }` against a running Live instance to confirm the hang is gone and to settle the freeze-property question definitively