### PR TITLE
feat: session-validated automation findings + humanize skills rules

### DIFF
--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -50,6 +50,10 @@ subdirs (see `HOW-TO-WRITE.md`).
   [src/tools/clip/automate/**, live_browser_bridge/**] — clip envelope
   write/read is Python-remote-script-only (LOM whitelist gap); route through the
   bridge, reads must sample value_at_time
+- [clip-envelope-survives-duplicate](dev/device/clip-envelope-survives-duplicate.md)
+  [src/tools/clip/automate/**, src/tools/operations/duplicate/**] — envelopes
+  written on a session clip survive adj-duplicate to arrangement; only path to
+  arrangement automation (write → dup → clear source)
 - [drum-kit-uri-loads-full-rack](dev/device/drum-kit-uri-loads-full-rack.md)
   [src/tools/device/create/**, src/mcp-server/bridge-dispatcher.ts,
   live_browser_bridge/BrowserBridge.py] — load_item on a kit URI creates a
@@ -103,6 +107,9 @@ subdirs (see `HOW-TO-WRITE.md`).
 - [device-deploy-flow](workflow/device-deploy-flow.md) [max-for-live-device/**,
   dist/**, package.json] — build → copy bundles to max-for-live-device → restart
   Live to load new version
+- [portal-restart-exposes-new-tools](workflow/portal-restart-exposes-new-tools.md)
+  [src/portal/**, src/mcp-server/**, dist/**] — MCP tool list fixed at connect
+  time; tools added by a server update need an MCP reconnect to appear
 - [self-bootstrap-prereq](workflow/self-bootstrap-prereq.md)
   [src/portal/lazy-boot*, scripts/start-live.ts, docs/Setup.md] — lazy-boot only
   opens Live; device load needs "Save Live Set as Default Set" with device on

--- a/docs/findings/dev/device/clip-envelope-survives-duplicate.md
+++ b/docs/findings/dev/device/clip-envelope-survives-duplicate.md
@@ -1,0 +1,29 @@
+---
+title: clip-envelope-survives-duplicate
+domain: dev
+validated: 2026-08-02
+evidence: "user confirmed (Live 12.4.3, server 2.1.0)"
+---
+
+## Fact
+
+Clip envelopes written on a session clip survive `adj-duplicate` to the
+arrangement. Since the envelope API is session-clip-only (see
+clip-envelope-api-python-only), this is the only path to arrangement
+automation: write envelope on session source → duplicate to arrangement
+position → clear the source's envelope.
+
+## Evidence
+
+Live 12.4.3 session: `adj-automate` dub-throw recipe on session clip (19
+points, B-Delay send), `adj-duplicate` to arrangement 21|1, user confirmed the
+envelope visible in the arrangement clip's Envelopes box and audible as a delay
+throw. API read-back cannot verify — `adj-automate read` on the arrangement
+clip raises the session-clip error.
+
+## Apply when
+
+Generating arrangement automation via `src/tools/clip/automate/**` or
+`src/tools/operations/duplicate/**`. Caveats: the duplicate replaces the target
+tile wholesale (custom notes/transforms in that tile are lost — match session
+content first), and carried envelopes are invisible to the API afterward.

--- a/docs/findings/workflow/portal-restart-exposes-new-tools.md
+++ b/docs/findings/workflow/portal-restart-exposes-new-tools.md
@@ -1,0 +1,26 @@
+---
+title: portal-restart-exposes-new-tools
+domain: workflow
+validated: 2026-08-02
+evidence: "user confirmed (/mcp reconnect exposed adj-automate)"
+---
+
+## Fact
+
+The MCP client's tool list is fixed when the portal connection is established.
+A tool added by a server/portal update (e.g. `adj-automate` in v2.1.0) does not
+appear in an already-connected session even though `adj-connect` reports the
+new server version — the connection must be re-established.
+
+## Evidence
+
+Session on server 2.1.0 (build 82953bf1, which includes the adj-automate
+commit): `adj-connect` succeeded and reported v2.1.0, but adj-automate was
+absent from the tool registry and unresolvable. After the user ran `/mcp` →
+reconnect, the tool appeared and a dub-throw write succeeded on the first call.
+
+## Apply when
+
+A documented adj-* tool is missing from a live session, or after deploying a
+new server/portal build (`dist/**`, `src/portal/**`) — reconnect the MCP
+connection before debugging deeper.

--- a/src/skills/electronic-music.ts
+++ b/src/skills/electronic-music.ts
@@ -155,6 +155,8 @@ Add Simple Delay (~30% dry/wet) on FX tracks for echo tail. Use clip fade-out fo
 - **Stay scoped** -- only touch the section being discussed.
 - **Fills as dedicated clips** -- separate from groove clips for easier editing.
 - **Humanize everything**: \`timing += 0.02 * rand()\` and \`velocity += rand(-5, 5)\` on all parts.
+- **Humanize respects loop boundaries** -- never random-jitter a bar-1 downbeat (can land before clip start) or final-bar tails (can spill past the loop wrap); jitter can also merge same-pitch neighbors. For boundary-adjacent notes, bake humanization into positions instead (\`1|1.76\`, \`3|3.01\`). Velocity ranges (\`v86-94\`) are always safe.
+- **End sustains half a beat early** -- a note lasting exactly to the loop end retriggers with an audible dip. Note-off at the final bar's |4.5 and let release + sends bridge the seam. Same trick at section scale: trim ALL parts to |4.5 before a drop for a half-beat of true silence, then the drop slams.
 - **v0 won't delete humanized notes** -- use transform \`PITCH: velocity = 0\` to delete all notes of a pitch regardless of timing.
 
 ### Velocity Reference (all genres)


### PR DESCRIPTION
### **User description**
## Summary

Captures validated facts from a full production session (indie dance track, Live 12.4.3, server v2.1.0) and promotes two genre-agnostic humanization rules into the served skills payload.

### Findings (docs/findings/)

- **dev/device/clip-envelope-survives-duplicate** — envelopes written on a session clip survive `adj-duplicate` to arrangement; documents the write → dup → clear-source workflow as the only path to arrangement automation (envelope API is session-clip-only). User-verified in Live UI; API read-back can't verify.
- **workflow/portal-restart-exposes-new-tools** — MCP tool list is fixed at connect time; `adj-automate` (present in server v2.1.0 per adj-connect) stayed invisible until an MCP reconnect.

### Skills (src/skills/electronic-music.ts)

Two new Production Workflow bullets, both validated in-session after user flagged the symptoms ("starts and ends weird", "ends too abruptly"):

- Humanize must respect loop boundaries — no random jitter on bar-1 downbeats or final-bar tails; bake positions instead
- End sustains at the final bar's |4.5 so release+sends bridge the loop seam; same trim at section scale = pause-before-drop

## Test plan

- [x] prettier clean on touched files
- [x] eslint clean on src/skills/electronic-music.ts
- [x] tsc --project src/tsconfig.json clean
- Skills payload is a template-string content change — no logic touched; dist rebuild handled by CI


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Enhance electronic music skills with new humanization rules.

- Document clip envelope transfer to arrangement via duplication.

- Document MCP client's tool list refresh behavior.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>electronic-music.ts</strong><dd><code>Add loop-boundary humanization and sustain seam-trim rules</code></dd></summary>
<hr>

src/skills/electronic-music.ts

<ul><li>Added a rule to ensure humanization respects loop boundaries, <br>preventing jitter on bar-1 downbeats or final-bar tails.<br> <li> Introduced a rule to end sustains half a beat early at loop ends or <br>before drops for smoother transitions.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/263/files#diff-d0b7d6423c7d7d5877f8f03cc2faf078f168a75f186ed80677031eda5f1a05cd">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>INDEX.md</strong><dd><code>Update findings index with new documentation links</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/INDEX.md

<ul><li>Added a link to the new <code>clip-envelope-survives-duplicate.md</code> finding.<br> <li> Added a link to the new <code>portal-restart-exposes-new-tools.md</code> finding.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/263/files#diff-979fccfe801351786b9cff5fb897af3ff04082c758a89f3c81ac6903e5592f98">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>clip-envelope-survives-duplicate.md</strong><dd><code>Document clip envelope duplication behavior for arrangement automation</code></dd></summary>
<hr>

docs/findings/dev/device/clip-envelope-survives-duplicate.md

<ul><li>New document detailing that clip envelopes written on session clips <br>survive <code>adj-duplicate</code> to the arrangement.<br> <li> Explains this as the only path for arrangement automation given the <br>session-clip-only envelope API.<br> <li> Provides evidence and context for applying this finding in automation <br>workflows.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/263/files#diff-724930d3cfde1fdf5c99280c827553445067e21ec58a02787440f6bab0c246ef">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>portal-restart-exposes-new-tools.md</strong><dd><code>Document MCP client's tool list refresh behavior on server updates</code></dd></summary>
<hr>

docs/findings/workflow/portal-restart-exposes-new-tools.md

<ul><li>New document explaining that the MCP client's tool list is fixed at <br>connection time.<br> <li> States that new tools added by a server update require an MCP <br>reconnect to appear.<br> <li> Provides evidence and context for debugging missing tools after server <br>updates.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/263/files#diff-e8ea27edc0a563c52377711ea657f9af033578966007bde682cd8cabe08b7161">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

