### PR TITLE
docs: capture five MCP tool findings from a music session

### DIFF
--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -17,6 +17,10 @@ subdirs (see `HOW-TO-WRITE.md`).
   [src/tools/track/update/**] — no LOM hook to trigger freeze/flatten on a
   track, only read-only can_be_frozen/is_frozen; feature removed, don't re-add
   without a real API path
+- [track-index-not-stable](dev/track-index-not-stable.md) [src/tools/track/**,
+  src/tools/live-set/**, src/tools/clip/duplicate/**] — trackIndex is
+  positional, not identity; deleting tracks in Live renumbers everything after
+  them, re-read before batch ops
 - [v8-task-needs-persistent-ref](dev/v8-task-needs-persistent-ref.md)
   [src/shared/v8-sleep.ts, src/live-api-adapter/**] — inline
   `new Task(cb).schedule(ms)` risks GC before firing; keep a persistent
@@ -27,6 +31,9 @@ subdirs (see `HOW-TO-WRITE.md`).
 - [barbeat-notation-order](dev/notation/barbeat-notation-order.md)
   [src/notation/barbeat/**, src/tools/generative/**, *_/notes-formatter_] —
   pitch must precede time pos in barbeat or first note drops + warning
+- [transform-time-filter-needs-range](dev/notation/transform-time-filter-needs-range.md)
+  [src/notation/transforms/**, src/tools/clip/update/**] — transform time
+  selectors must be ranges; a single `4|1` fails to parse, use `4|1-4|1`
 
 ### browser
 
@@ -46,6 +53,14 @@ subdirs (see `HOW-TO-WRITE.md`).
 
 ### device
 
+- [arrangement-clip-is-snapshot](dev/device/arrangement-clip-is-snapshot.md)
+  [src/tools/operations/duplicate/**, src/tools/clip/update/**,
+  src/tools/clip/automate/**] — adj-duplicate copies by value; editing the
+  session source after tiling requires deleting and re-duplicating every tile
+- [automate-normalized-log-scale](dev/device/automate-normalized-log-scale.md)
+  [src/tools/clip/automate/**, live_browser_bridge/**] — adj-automate 0..1 maps
+  logarithmically on frequency params; 0.34 = 224 Hz on a 20-20k filter, verify
+  in Hz by reading back
 - [clip-envelope-api-python-only](dev/device/clip-envelope-api-python-only.md)
   [src/tools/clip/automate/**, live_browser_bridge/**] — clip envelope
   write/read is Python-remote-script-only (LOM whitelist gap); route through the
@@ -61,6 +76,10 @@ subdirs (see `HOW-TO-WRITE.md`).
 - [live-instrument-limit](dev/device/live-instrument-limit.md)
   [src/tools/device/**, src/tools/track/**] — Live blocks 2nd instrument per
   track with vague error; delete first
+- [param-write-silently-ignored](dev/device/param-write-silently-ignored.md)
+  [src/tools/device/update/**] — adj-update-device returns success even when the
+  value is rejected; params with normalized or degenerate min/max ignore
+  display-unit writes
 
 ### build
 

--- a/docs/findings/dev/device/arrangement-clip-is-snapshot.md
+++ b/docs/findings/dev/device/arrangement-clip-is-snapshot.md
@@ -1,0 +1,33 @@
+---
+title: arrangement-clip-is-snapshot
+domain: dev
+validated: 2026-08-04
+evidence:
+  "session clip 147 rewritten; arrangement tiles duplicated from it still read
+  the old notes"
+---
+
+## Fact
+
+`adj-duplicate` copies clip content by value. Arrangement tiles are snapshots —
+later edits to the session source do not propagate, and there is no re-sync
+operation. Editing a source after tiling means deleting and re-duplicating every
+tile.
+
+## Evidence
+
+```
+adj-update-clip 147 noteUpdateMode=replace  (rewrote the session clip)
+adj-read-track trackIndex 2 → tiles still named/holding the previous version
+adj-delete clip 2745,2746,...  → adj-duplicate 147 → correct content
+```
+
+Same trap applies to the clip-envelope workaround: write envelope on session
+clip → duplicate → clear source. Reordering those steps produces tiles with no
+envelope.
+
+## Apply when
+
+Any workflow that edits a session clip and tiles it. Finalise the source before
+the first duplicate, and re-place tiles after any source change — including
+transform-only edits, which also do not propagate. </content>

--- a/docs/findings/dev/device/automate-normalized-log-scale.md
+++ b/docs/findings/dev/device/automate-normalized-log-scale.md
@@ -1,0 +1,31 @@
+---
+title: automate-normalized-log-scale
+domain: dev
+validated: 2026-08-04
+evidence: "adj-automate write 0.34 → adj-read-device reports 224 Hz"
+---
+
+## Fact
+
+`adj-automate` normalized 0..1 values map **logarithmically** onto frequency
+parameters, not linearly. On an Auto Filter Frequency (min 20, max 20000),
+`0.34` resolves to **224 Hz**, not the ~6800 Hz a linear reading implies.
+Approximate mapping: `hz = min * (max / min) ** value`.
+
+## Evidence
+
+```
+adj-automate  devicePath t7/d2  paramName Frequency  points "1|1:0.34"
+adj-read-device 3563 → {name:"Frequency", value:224, min:20, max:20000, unit:"Hz"}
+```
+
+Half the 0..1 range sits below 630 Hz. Values under ~0.5 on a full-range filter
+are far darker than they look: 0.34 = 224 Hz, 0.53 = 780 Hz, 0.80 = 5 kHz, 0.98
+= 17 kHz.
+
+## Apply when
+
+Writing envelopes for any frequency-domain parameter (filter cutoff, EQ
+frequency, delay time). Compute the target in Hz first, invert the formula, then
+read the device back to confirm before duplicating the clip to the arrangement.
+</content>

--- a/docs/findings/dev/device/param-write-silently-ignored.md
+++ b/docs/findings/dev/device/param-write-silently-ignored.md
@@ -1,0 +1,31 @@
+---
+title: param-write-silently-ignored
+domain: dev
+validated: 2026-08-04
+evidence:
+  "adj-update-device Ratio=5 / 2 Q A=1.1 both returned success, values unchanged
+  on read"
+---
+
+## Fact
+
+`adj-update-device` returns success even when a parameter write is rejected.
+Parameters whose reported range is normalized (`min:0, max:1`) or degenerate
+(`min:1, max:1`) silently ignore values expressed in the unit Live displays.
+
+## Evidence
+
+```
+Compressor Ratio   → {value:4,    min:1, max:1}   ; "Ratio=5"   → still 4
+EQ Eight  "2 Q A"  → {value:0.71, min:0, max:1}   ; "2 Q A=1.1" → still 0.71
+```
+
+Both calls returned `{id:"..."}` with no warning. Contrast with a genuinely
+unknown name, which does warn:
+`WARNING: updateDevice: param "DecayTime" not found on device`.
+
+## Apply when
+
+Any `adj-update-device` call. Read the parameter back and compare before relying
+on the write — a success response only proves the parameter name resolved, not
+that the value was accepted. </content>

--- a/docs/findings/dev/notation/transform-time-filter-needs-range.md
+++ b/docs/findings/dev/notation/transform-time-filter-needs-range.md
@@ -1,0 +1,32 @@
+---
+title: transform-time-filter-needs-range
+domain: dev
+validated: 2026-08-04
+evidence:
+  "adj-update-clip transforms '4|1: duration = 3.5' → transform syntax error"
+---
+
+## Fact
+
+A transform time selector must be a **range** (`bar|beat-bar|beat`). A single
+`bar|beat` position fails to parse, and the error points at column 1 rather than
+naming the selector as the problem.
+
+## Evidence
+
+```
+transforms: "4|1: duration = 3.5"
+→ transform syntax error at position 0 (line 1, column 1):
+  Expected parameter assignment but "4" found
+
+transforms: "4|1-4|1: duration = 3.5"
+→ {id:"2333", noteCount:4, transformed:1}
+```
+
+`4|1-4|1` targets exactly the notes starting at that one position.
+
+## Apply when
+
+Writing `transforms` that target a single beat — trimming one sustained note,
+deleting one hit. Degenerate ranges (`N|B-N|B`) are the supported form.
+</content>

--- a/docs/findings/dev/track-index-not-stable.md
+++ b/docs/findings/dev/track-index-not-stable.md
@@ -1,0 +1,33 @@
+---
+title: track-index-not-stable
+domain: dev
+validated: 2026-08-04
+evidence:
+  "readTrack: trackIndex 13 does not exist — every track shifted down by 3
+  mid-session"
+---
+
+## Fact
+
+`trackIndex` is a positional address, not an identity. Removing tracks in the
+Live UI renumbers every track after them, so indices cached earlier in a session
+silently point at the wrong track or fail. Track `id` is stable; `trackIndex` is
+not.
+
+## Evidence
+
+Reads at indices 4-12 returned Drums/Bass/Sub. After three empty stock tracks
+were deleted in Live:
+
+```
+adj-read-track trackIndex 13 → Error: readTrack: trackIndex 13 does not exist
+adj-read-track trackIndex 4  → {id:"349", name:"Lead"}   # was "Drums"
+```
+
+Same `id` values throughout — only the indices moved.
+
+## Apply when
+
+Any multi-call sequence addressing tracks by index, especially batch
+duplicate/delete across several tracks. Re-read `adj-read-live-set` first, and
+prefer `trackId` over `trackIndex` when the tool accepts both. </content>


### PR DESCRIPTION
### **User description**
Findings captured from a long Ableton production session. All five caused real rework or an audible mistake during the session.

## New findings

| Finding | Why it matters |
|---|---|
| `dev/device/automate-normalized-log-scale` | `adj-automate` 0..1 values map **logarithmically** on frequency params. Wrote `0.34` expecting a mild filter, got **224 Hz** — low-passed the percussion out of 28 bars before the user caught it by ear. |
| `dev/device/param-write-silently-ignored` | `adj-update-device` returns `{id}` success even when the value is rejected. Compressor `Ratio` reports `min:1, max:1`; EQ Eight `Q` reports `min:0, max:1`. Display-unit writes are dropped with no warning. |
| `dev/notation/transform-time-filter-needs-range` | `4|1: duration = 3.5` fails to parse; needs `4|1-4|1`. The error points at column 1 rather than the selector. |
| `dev/track-index-not-stable` | Deleting tracks in the Live UI renumbers everything after them mid-session. Cached indices then silently address the wrong track. |
| `dev/device/arrangement-clip-is-snapshot` | `adj-duplicate` copies by value. Editing a session source after tiling requires deleting and re-duplicating every tile — hit three times in one session. |

Docs-only. `npm run check` passes (3909 tests, coverage unchanged).


___

### **PR Type**
Documentation


___

### **Description**
- Document five new findings from Ableton production sessions.

- Highlights issues with clip duplication, automation scaling, parameter writes.

- Details requirements for transform time selectors and track indexing.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>INDEX.md</strong><dd><code>Updated index with five new development findings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/INDEX.md

<ul><li>Added new entries for five development findings: <br><code>track-index-not-stable</code>, <code>transform-time-filter-needs-range</code>, <br><code>arrangement-clip-is-snapshot</code>, <code>automate-normalized-log-scale</code>, and <br><code>param-write-silently-ignored</code>.<br> <li> Each entry includes a link to the new finding document and relevant <br>source code paths.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/267/files#diff-979fccfe801351786b9cff5fb897af3ff04082c758a89f3c81ac6903e5592f98">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>arrangement-clip-is-snapshot.md</strong><dd><code>Document `adj-duplicate` copies clips by value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/dev/device/arrangement-clip-is-snapshot.md

<ul><li>Documents that <code>adj-duplicate</code> copies clip content by value, making <br>arrangement tiles snapshots.<br> <li> Explains that later edits to the session source do not propagate to <br>duplicated tiles.<br> <li> Provides evidence and guidance on when to apply this finding in <br>workflows.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/267/files#diff-df596bbc353ca9ce84a627865ee380cfbca7bb7c2bf1e7f83135683d567ecbb1">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>automate-normalized-log-scale.md</strong><dd><code>Document logarithmic scaling for frequency automation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/dev/device/automate-normalized-log-scale.md

<ul><li>Explains that <code>adj-automate</code> normalized 0..1 values map logarithmically <br>onto frequency parameters.<br> <li> Provides an approximate mapping formula and examples of non-linear <br>behavior (e.g., 0.34 = 224 Hz).<br> <li> Offers advice on computing target frequencies in Hz before automation.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/267/files#diff-d0ad468bdd45214fb72537e221e0975cbbc6fbf015d9af538d2df84af1cf46cf">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>param-write-silently-ignored.md</strong><dd><code>Document `adj-update-device` silently ignores invalid writes</code></dd></summary>
<hr>

docs/findings/dev/device/param-write-silently-ignored.md

<ul><li>Documents that <code>adj-update-device</code> returns success even when a parameter <br>write is rejected.<br> <li> Highlights that parameters with normalized or degenerate ranges <br>silently ignore display-unit writes.<br> <li> Recommends reading the parameter back to confirm the write was <br>accepted.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/267/files#diff-3659132f5c71b637b965c067009b67b38c271b718dad439a22cea4383bb6d08d">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>transform-time-filter-needs-range.md</strong><dd><code>Document transform time selectors require ranges</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/dev/notation/transform-time-filter-needs-range.md

<ul><li>States that a transform time selector must be a range (e.g., <br><code>bar|beat-bar|beat</code>).<br> <li> Explains that a single <code>bar|beat</code> position fails to parse, with a <br>misleading error message.<br> <li> Provides examples and clarifies the supported degenerate range form.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/267/files#diff-98403df863a8ab849d4422e779d4c5646075d82fb51f6f185c47050ae028d9dc">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>track-index-not-stable.md</strong><dd><code>Document `trackIndex` instability after track deletion</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/dev/track-index-not-stable.md

<ul><li>Documents that <code>trackIndex</code> is a positional address and is not stable.<br> <li> Explains that deleting tracks in the Live UI renumbers subsequent <br>tracks, invalidating cached indices.<br> <li> Recommends preferring <code>trackId</code> over <code>trackIndex</code> for stability in <br>multi-call sequences.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/267/files#diff-77e84a601c511b34bc84e438e054996e73397a5f500aa9534356a6bf56d8152b">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

