### PR TITLE
fix: warn and clamp instead of silently dropping out-of-range param writes

### DIFF
--- a/src/tools/device/update/tests/update-device-param-setters.test.ts
+++ b/src/tools/device/update/tests/update-device-param-setters.test.ts
@@ -431,4 +431,90 @@ describe("updateDevice - param value conversion", () => {
       );
     });
   });
+
+  describe("out-of-range numeric values", () => {
+    let param: RegisteredMockObject;
+
+    beforeEach(() => {
+      registerMockObject("dev1", {
+        path: livePath.track(0).device(0),
+        type: "Device",
+        properties: { parameters: children("q-param") },
+      });
+      // Mirrors EQ Eight "2 Q A": raw range 0-1, display labels match raw
+      param = registerMockObject("q-param", {
+        properties: {
+          name: "2 Q A",
+          original_name: "2 Q A",
+          is_quantized: 0,
+          value: 0.71,
+          min: 0,
+          max: 1,
+        },
+        methods: {
+          str_for_value: (v: unknown) => `${Number(v)}`,
+        },
+      });
+    });
+
+    it("should clamp a value above max instead of letting Live drop it", () => {
+      updateDevice({ ids: "dev1", params: "2 Q A = 1.1" });
+
+      expect(param.set).toHaveBeenCalledWith("value", 1);
+    });
+
+    it("should warn when a value is clamped", () => {
+      updateDevice({ ids: "dev1", params: "2 Q A = 1.1" });
+
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("outside the parameter range 0-1"),
+      );
+    });
+
+    it("should clamp a value below min", () => {
+      updateDevice({ ids: "dev1", params: "2 Q A = -3" });
+
+      expect(param.set).toHaveBeenCalledWith("value", 0);
+    });
+
+    it("should not warn for an in-range value", () => {
+      updateDevice({ ids: "dev1", params: "2 Q A = 0.4" });
+
+      expect(param.set).toHaveBeenCalledWith("value", 0.4);
+      expect(outlet).not.toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("outside the parameter range"),
+      );
+    });
+
+    it("should clamp when the display mapping is unknown", () => {
+      // Mirrors Compressor Ratio: max label "inf:1" is unparseable, so the
+      // display-to-raw mapping fails and the input is treated as raw
+      registerMockObject("dev2", {
+        path: livePath.track(0).device(1),
+        type: "Device",
+        properties: { parameters: children("ratio-param") },
+      });
+
+      const ratio = registerMockObject("ratio-param", {
+        properties: {
+          name: "Ratio",
+          original_name: "Ratio",
+          is_quantized: 0,
+          value: 0.3,
+          min: 0,
+          max: 1,
+        },
+        methods: {
+          str_for_value: (v: unknown) =>
+            Number(v) >= 1 ? "inf:1" : `${(1 + Number(v) * 9).toFixed(2)}:1`,
+        },
+      });
+
+      updateDevice({ ids: "dev2", params: "Ratio = 5" });
+
+      expect(ratio.set).toHaveBeenCalledWith("value", 1);
+    });
+  });
 });

--- a/src/tools/device/update/update-device-param-setters.ts
+++ b/src/tools/device/update/update-device-param-setters.ts
@@ -174,14 +174,47 @@ function setParamValue(param: LiveAPI, inputValue: string | number): void {
       rawMax,
       minLabel,
     );
+    const paramName = param.getProperty("name") as string;
 
-    param.set("value", rawValue ?? inputValue);
+    param.set(
+      "value",
+      clampToRawRange(rawValue ?? inputValue, rawMin, rawMax, paramName),
+    );
 
     return;
   }
 
   // 6. String fallback
   param.set("value", inputValue);
+}
+
+/**
+ * Clamp a raw value into the parameter's raw range, warning when it was outside.
+ * Live silently ignores out-of-range sets, so an unclamped write looks like a
+ * success while leaving the parameter untouched.
+ * @param rawValue - Candidate raw value
+ * @param rawMin - Raw minimum value
+ * @param rawMax - Raw maximum value
+ * @param paramName - Parameter name, for the warning
+ * @returns Raw value guaranteed to be within range
+ */
+function clampToRawRange(
+  rawValue: number,
+  rawMin: number,
+  rawMax: number,
+  paramName: string,
+): number {
+  const lo = Math.min(rawMin, rawMax);
+  const hi = Math.max(rawMin, rawMax);
+  const clamped = Math.min(Math.max(rawValue, lo), hi);
+
+  if (clamped !== rawValue) {
+    console.warn(
+      `updateDevice: "${paramName}" value ${rawValue} is outside the parameter range ${lo}-${hi}; clamped to ${clamped}`,
+    );
+  }
+
+  return clamped;
 }
 
 /**

--- a/src/tools/shared/device/helpers/device-display-helpers.ts
+++ b/src/tools/shared/device/helpers/device-display-helpers.ts
@@ -307,13 +307,18 @@ export function readParameter(paramApi: LiveAPI): Record<string, unknown> {
     return result;
   }
 
+  // min/max must share a unit. Mixing a parsed display bound with a raw bound
+  // reports a nonsensical range (e.g. Compressor Ratio, whose max label "inf:1"
+  // is unparseable, reported min:1 from the label and max:1 from the raw value).
+  const boundsParseable =
+    typeof minParsed.value === "number" && typeof maxParsed.value === "number";
   const result: Record<string, unknown> = {
     id: paramApi.id,
     name,
     value:
       valueParsed.value ?? paramApi.getProperty("display_value") ?? rawValue,
-    min: minParsed.value ?? rawMin,
-    max: maxParsed.value ?? rawMax,
+    min: boundsParseable ? minParsed.value : rawMin,
+    max: boundsParseable ? maxParsed.value : rawMax,
   };
 
   if (unit) result.unit = unit;

--- a/src/tools/shared/device/helpers/tests/device-display-helpers.test.ts
+++ b/src/tools/shared/device/helpers/tests/device-display-helpers.test.ts
@@ -569,6 +569,29 @@ describe("device-display-helpers", () => {
       expect(result.value).toBe("Repitch");
     });
 
+    it("reports raw bounds for both min and max when one label is unparseable", () => {
+      // Compressor Ratio: min label "1.00:1" parses to 1, max label "inf:1"
+      // does not. Reporting the parsed min alongside the raw max produced a
+      // nonsensical min:1 max:1 range.
+      setupParamMock({ name: "Ratio", value: 0.3, min: 0, max: 1 });
+      setupValueLabels({ 0.3: "4.00:1", 0: "1.00:1", 1: "inf:1" });
+
+      const result = readParameter(createMockParamApi("param_ratio"));
+
+      expect(result.min).toBe(0);
+      expect(result.max).toBe(1);
+    });
+
+    it("keeps parsed display bounds when both labels are parseable", () => {
+      setupParamMock({ name: "Freq", value: 0.5, min: 0, max: 1 });
+      setupValueLabels({ 0.5: "1000 Hz", 0: "20 Hz", 1: "20000 Hz" });
+
+      const result = readParameter(createMockParamApi("param_freq"));
+
+      expect(result.min).toBe(20);
+      expect(result.max).toBe(20000);
+    });
+
     it("handles division param detected via minLabel", () => {
       // Edge case: current value is "1" (not a fraction) but min is "1/64"
       setupParamMock({ name: "Division", value: 0, min: -2, max: 0 });


### PR DESCRIPTION
### **User description**
Fixes #269.

## Root cause

Two independent bugs, both surfaced by the same session.

### 1. Out-of-range writes were silently dropped

`setParamValue` computed a raw value and set it without range checking:

```ts
param.set("value", rawValue ?? inputValue);
```

Live **ignores** a set whose value falls outside the parameter's raw range — it does not clamp. So `adj-update-device` returned `{id}` (success) while the parameter kept its old value.

Two ways to land out of range:

- **Direct**: a linear param with raw range 0-1 given `1.1` (EQ Eight `Q`)
- **Via failed mapping**: `findRawValueForDisplay` returns `null` when a display label is unparseable, and the fallback `?? inputValue` treats the *display* number as a *raw* value. Compressor `Ratio = 5` set raw `5` on a 0-1 range.

**Fix**: clamp into `[rawMin, rawMax]` before setting, and warn when clamping occurred. A caller now either gets the value or a warning explaining why not.

### 2. Read path mixed units in min/max

```ts
min: minParsed.value ?? rawMin,
max: maxParsed.value ?? rawMax,
```

Each bound independently falls back to raw. Compressor Ratio's min label `"1.00:1"` parses to `1`; its max label `"inf:1"` does not, so max fell through to the raw `1`. Result: `min:1, max:1` — a display bound and a raw bound in one range, coincidentally equal, reading as a degenerate parameter.

**Fix**: bounds are all-or-nothing. If either label fails to parse, report raw for both.

## Tests

7 new, all in existing files:

- clamps above max / below min, warns on clamp, stays silent in range
- clamps when the display mapping is unknown (Compressor Ratio shape, `inf:1` max label)
- read reports raw bounds for both when one label is unparseable
- read keeps parsed display bounds when both parse

`npm run check` passes — 3916 tests (+7), coverage 98.28% statements.

## Note

This does not make every write succeed — a value genuinely outside a parameter's range still cannot be set. It makes the failure **visible**, which is what the issue asked for. #268 (sidechain routing) remains separate.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Clamp out-of-range parameter values.

- Warn when parameter values are clamped.

- Report consistent min/max bounds for parameters.

- Prevent silent rejection of invalid parameter writes.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["updateDevice"] --> B{"`clampToRawRange`"};
  B -- "Clamped Value" --> C["LiveAPI.set('value')"];
  B -- "Warns if clamped" --> D["console.warn"];
  E["readParameter"] --> F{"`Determine Bounds Parseability`"};
  F -- "Reports" --> G["Consistent min/max Bounds"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update-device-param-setters.test.ts</strong><dd><code>Add tests for out-of-range parameter value clamping and warnings</code></dd></summary>
<hr>

src/tools/device/update/tests/update-device-param-setters.test.ts

<ul><li>Added new test suite for "out-of-range numeric values".<br> <li> Verified that values above max are clamped and a warning is issued.<br> <li> Confirmed that values below min are clamped.<br> <li> Ensured no warning is issued for in-range values.<br> <li> Tested clamping behavior when display mapping is unknown (e.g., <br>Compressor Ratio).</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/271/files#diff-c0584f3ff2205a8ee61ad7f7b812e1648824a131c26c0eb7e8fa79b1c37954c7">+86/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>device-display-helpers.test.ts</strong><dd><code>Add tests for consistent parameter min/max bound reporting</code></dd></summary>
<hr>

src/tools/shared/device/helpers/tests/device-display-helpers.test.ts

<ul><li>Added a test to verify raw bounds are reported when one display label <br>is unparseable (e.g., Compressor Ratio).<br> <li> Added a test to confirm parsed display bounds are kept when both <br>labels are parseable (e.g., Freq).</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/271/files#diff-85ed7d32d91de300ac0e27562750d2e012fd7917e9dbe0aeeb76bb5860fd65df">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update-device-param-setters.ts</strong><dd><code>Implement clamping and warning for out-of-range parameter writes</code></dd></summary>
<hr>

src/tools/device/update/update-device-param-setters.ts

<ul><li>Modified <code>setParamValue</code> to use a new <code>clampToRawRange</code> function.<br> <li> Implemented <code>clampToRawRange</code> to ensure parameter values are within <br><code>rawMin</code> and <code>rawMax</code>.<br> <li> Added a <code>console.warn</code> message when a value is clamped, informing the <br>user.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/271/files#diff-25fb5a1fb5d0fbcd65b7f43fb653ed3e3ae9ded7ee23968ff53da641d37f9920">+34/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>device-display-helpers.ts</strong><dd><code>Ensure consistent unit reporting for parameter min/max bounds</code></dd></summary>
<hr>

src/tools/shared/device/helpers/device-display-helpers.ts

<ul><li>Modified <code>readParameter</code> to ensure <code>min</code> and <code>max</code> bounds share a consistent <br>unit.<br> <li> Introduced <code>boundsParseable</code> check to determine if both display labels <br>can be parsed to numbers.<br> <li> If not fully parseable, <code>min</code> and <code>max</code> now fall back to raw values for <br>consistency.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/271/files#diff-d33816709b5663b7bd7fa87e3ea68abcc9e3f39240436eb02e2f5394e4729c5e">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

