### PR TITLE
docs: correct the param-write finding after #271

### DIFF
--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -81,9 +81,10 @@ subdirs (see `HOW-TO-WRITE.md`).
   [src/tools/device/**, src/tools/track/**] — Live blocks 2nd instrument per
   track with vague error; delete first
 - [param-write-silently-ignored](dev/device/param-write-silently-ignored.md)
-  [src/tools/device/update/**] — adj-update-device returns success even when the
-  value is rejected; params with normalized or degenerate min/max ignore
-  display-unit writes
+  [src/tools/device/update/**,
+  src/tools/shared/device/helpers/device-display-helpers.ts] — Live ignores
+  out-of-range param sets rather than clamping; adj-update-device clamps + warns
+  since #271, and params with unparseable labels can't be set by display value
 
 ### build
 

--- a/docs/findings/dev/device/param-write-silently-ignored.md
+++ b/docs/findings/dev/device/param-write-silently-ignored.md
@@ -3,29 +3,35 @@ title: param-write-silently-ignored
 domain: dev
 validated: 2026-08-04
 evidence:
-  "adj-update-device Ratio=5 / 2 Q A=1.1 both returned success, values unchanged
-  on read"
+  "PR #271 — Live ignores out-of-range sets; adj-update-device now clamps and
+  warns"
 ---
 
 ## Fact
 
-`adj-update-device` returns success even when a parameter write is rejected.
-Parameters whose reported range is normalized (`min:0, max:1`) or degenerate
-(`min:1, max:1`) silently ignore values expressed in the unit Live displays.
+Live **ignores** a parameter set whose value falls outside the parameter's raw
+range — it does not clamp. Before PR #271 `adj-update-device` passed such values
+straight through, so the call reported success while the parameter kept its old
+value. It now clamps into range and warns.
+
+Params whose min/max labels are unparseable still cannot be set by display value
+at all: the display-to-raw mapping can't be derived, so the input is treated as
+raw and clamped.
 
 ## Evidence
 
 ```
-Compressor Ratio   → {value:4,    min:1, max:1}   ; "Ratio=5"   → still 4
-EQ Eight  "2 Q A"  → {value:0.71, min:0, max:1}   ; "2 Q A=1.1" → still 0.71
+Compressor Ratio: raw range 0-1, max label "inf:1" (unparseable)
+  "Ratio=5"   → set raw 5 → ignored by Live, value unchanged   (pre-#271)
+              → clamped to 1 + warning                          (post-#271)
+EQ Eight "2 Q A": raw range 0-1
+  "2 Q A=1.1" → set raw 1.1 → ignored by Live                   (pre-#271)
+              → clamped to 1 + warning                          (post-#271)
 ```
-
-Both calls returned `{id:"..."}` with no warning. Contrast with a genuinely
-unknown name, which does warn:
-`WARNING: updateDevice: param "DecayTime" not found on device`.
 
 ## Apply when
 
-Any `adj-update-device` call. Read the parameter back and compare before relying
-on the write — a success response only proves the parameter name resolved, not
-that the value was accepted. </content>
+Setting a device parameter to a value near or beyond its bounds, or on a
+parameter whose displayed unit differs from raw (ratios, Q). A clamp warning
+means the requested value was unreachable — read the parameter back rather than
+assuming the intent landed. </content>


### PR DESCRIPTION
### **User description**
Follow-up to #267, which merged while #271 was landing.

## Problem

#267 captured `dev/device/param-write-silently-ignored.md` describing behaviour that #271 then fixed. As merged on main, the finding says:

> `adj-update-device` returns success even when a parameter write is rejected.

That is no longer true — it clamps and warns.

## Fix

Restated as the durable invariant rather than the (now former) symptom:

- **Live ignores out-of-range parameter sets rather than clamping** — this is the underlying fact and it hasn't changed
- `adj-update-device` clamps into range and warns since #271
- Params whose min/max labels are unparseable (Compressor `Ratio`, max label `inf:1`) still cannot be set by display value, because the display-to-raw mapping can't be derived

Evidence block now shows pre-#271 and post-#271 behaviour side by side, and the "Apply when" tells the reader what a clamp warning means.

INDEX summary and globs updated to match.

Docs-only, `npm run format:check` clean.


___

### **PR Type**
Documentation


___

### **Description**
- Correct `param-write-silently-ignored` documentation.

- Reflect `adj-update-device` now clamps and warns.

- Clarify Live's out-of-range parameter set behavior.

- Update `INDEX.md` with accurate finding summary.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>INDEX.md</strong><dd><code>Update `INDEX.md` for parameter write finding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/INDEX.md

<ul><li>Updated the summary for the <code>param-write-silently-ignored</code> finding.<br> <li> Added <code>src/tools/shared/device/helpers/device-display-helpers.ts</code> to <br>relevant source paths.<br> <li> Reflected the new clamping and warning behavior of <code>adj-update-device</code>.<br> <li> Clarified handling of unparseable parameter labels.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/273/files#diff-979fccfe801351786b9cff5fb897af3ff04082c758a89f3c81ac6903e5592f98">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>param-write-silently-ignored.md</strong><dd><code>Update `param-write-silently-ignored` finding details</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/dev/device/param-write-silently-ignored.md

<ul><li>Rewrote the "Fact" section to reflect Live's parameter handling.<br> <li> Updated the "Evidence" section to show pre and post-#271 behavior.<br> <li> Clarified that <code>adj-update-device</code> now clamps and warns.<br> <li> Provided guidance on applying the finding and interpreting warnings.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/273/files#diff-3659132f5c71b637b965c067009b67b38c271b718dad439a22cea4383bb6d08d">+20/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

