### PR TITLE
ci: block eslint 10 in dependabot until eslint-plugin-import supports it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,19 @@ updates:
       prefix: "deps"
     labels:
       - dependencies
+    ignore:
+      # eslint 10 breaks the build in three ways and CI cannot catch it,
+      # because npm ci fails before any job runs. See PR #274.
+      #   - eslint-plugin-import caps its eslint peer at ^9 (no v10 release yet)
+      #   - @eslint/js stops arriving transitively; eslint.config.js imports it
+      #   - eslint-plugin-unicorn >=72 requires eslint >=10.4, so the two
+      #     plugins cannot both be satisfied
+      # Unblock once eslint-plugin-import supports eslint 10, or once that
+      # plugin is replaced by eslint-import-resolver-typescript + tsc.
+      - dependency-name: eslint
+        versions: [">=10"]
+      - dependency-name: eslint-plugin-unicorn
+        versions: [">=66"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
### **User description**
Prevention follow-up to #274.

## Why

#274 reverted eslint 10.8.0 after it broke main in three ways. Nothing currently stops dependabot re-proposing the identical bump next Monday.

The failure mode is what makes this worth guarding: `npm ci` fails at install, so **every job fails in under 10 seconds with no usable signal**. It reads like the PR is broken rather than the dependency pairing, and the two downstream breakages (`@eslint/js`, removed unicorn rule) stay invisible until you get past the install error locally.

## What

Ignore in the npm ecosystem block:

- `eslint >= 10` — `eslint-plugin-import@2.32.0` (latest) caps its peer at `^9`
- `eslint-plugin-unicorn >= 66` — first version requiring eslint >=10.4, so allowing it forces the eslint 10 bump back in

Comment in the file records all three breakages and the unblock condition, so whoever removes this knows what to re-test.

## Unblock when

Either `eslint-plugin-import` ships eslint 10 support, or it's replaced by `eslint-import-resolver-typescript` + tsc. At that point delete both ignore entries and bump the pair together in one PR — they can't move independently.

Config parses as valid YAML with both rules present; `format:check` clean.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Prevent `eslint 10` and `eslint-plugin-unicorn` updates.

- Block problematic dependency bumps in Dependabot.

- Avoid recurrence of CI failures.

- Document reasons for dependency ignores.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Configure Dependabot to ignore problematic ESLint dependency updates</code></dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Added <code>ignore</code> rules to the <code>npm</code> package-ecosystem configuration.<br> <li> Prevented Dependabot from proposing updates for <code>eslint</code> versions <code>>=10</code>.<br> <li> Prevented Dependabot from proposing updates for <code>eslint-plugin-unicorn</code> <br>versions <code>>=66</code>.<br> <li> Documented the specific reasons for these ignores, referencing <br>previous CI failures.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/275/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

