### PR TITLE
fix: skip source clip in arrangement-clip overlap clearing

### DIFF
--- a/src/tools/shared/arrangement/arrangement-tiling-workaround.ts
+++ b/src/tools/shared/arrangement/arrangement-tiling-workaround.ts
@@ -52,7 +52,8 @@ export function clearClipAtDuplicateTarget(
 ): void {
   if (!arrangementDuplicateCrashWorkaround) return;
 
-  const sourceClip = LiveAPI.from(toLiveApiId(sourceClipId));
+  const normalizedSourceId = toLiveApiId(sourceClipId);
+  const sourceClip = LiveAPI.from(normalizedSourceId);
 
   if (sourceClip.getProperty("is_arrangement_clip") !== 1) return;
 
@@ -66,6 +67,12 @@ export function clearClipAtDuplicateTarget(
   const clipIds = track.getChildIds("arrangement_clips");
 
   for (const clipId of clipIds) {
+    // The source clip is still at its old position and hasn't moved yet, so a
+    // short move (new target overlapping the old position) makes it match its
+    // own overlap check. Skip it or this workaround destroys the very clip
+    // duplicate_clip_to_arrangement is about to move (see #264).
+    if (clipId === normalizedSourceId) continue;
+
     const clip = LiveAPI.from(clipId);
     const clipStart = clip.getProperty("start_time") as number;
     const clipEnd = clip.getProperty("end_time") as number;

--- a/src/tools/shared/arrangement/tests/arrangement-duplicate-workaround.test.ts
+++ b/src/tools/shared/arrangement/tests/arrangement-duplicate-workaround.test.ts
@@ -323,6 +323,87 @@ describe("clearClipAtDuplicateTarget", () => {
     );
   });
 
+  it("does not clear the source clip itself when a small move overlaps its own old position (#264)", () => {
+    // Source: 1.906 beats long (start_time=8, end_time=9.906), moved a
+    // short distance to target position=8.5. Target range [8.5, 10.406)
+    // overlaps the source's own current position [8, 9.906) — the source
+    // clip is still present in arrangement_clips (hasn't moved yet), so
+    // without self-exclusion it gets trimmed to a sliver by this workaround
+    // before duplicate_clip_to_arrangement ever runs.
+    setupClip("100", {
+      properties: {
+        is_arrangement_clip: 1,
+        start_time: 8,
+        end_time: 9.906,
+      },
+    });
+
+    const trackMock = setupTrack(0, {
+      properties: {
+        arrangement_clips: ["id", "100"],
+      },
+    });
+
+    clearClipAtDuplicateTarget(
+      LiveAPI.from(trackMock.path),
+      "100",
+      8.5,
+      false,
+      mockContext,
+    );
+
+    expect(trackMock.call).not.toHaveBeenCalled();
+  });
+
+  it("still clears a genuine overlapping neighbor when the source is also in the list (#264)", () => {
+    // Source at 8-9.906 moves to target 8.5 (range 8.5-10.406). A separate
+    // neighbor clip at 9-11 genuinely overlaps and must still be cleared;
+    // only the source clip itself should be skipped.
+    setupClip("100", {
+      properties: {
+        is_arrangement_clip: 1,
+        start_time: 8,
+        end_time: 9.906,
+      },
+    });
+
+    const neighbor = setupArrangementClip("201", 0, {
+      start_time: 9,
+      end_time: 11,
+    });
+
+    const trackMock = setupTrack(0, {
+      properties: {
+        arrangement_clips: ["id", "100", "id", neighbor.id],
+      },
+      methods: {
+        duplicate_clip_to_arrangement: () => ["id", "400"],
+        create_midi_clip: () => ["id", "300"],
+        delete_clip: () => null,
+      },
+    });
+
+    clearClipAtDuplicateTarget(
+      LiveAPI.from(trackMock.path),
+      "100",
+      8.5,
+      true,
+      mockContext,
+    );
+
+    // Neighbor [9,11] genuinely overlaps and end_time 11 > targetEnd 10.406,
+    // so it must still go through the holding-clip workaround (proves the
+    // fix only skips the source, not overlap detection generally).
+    expect(trackMock.call).toHaveBeenCalledWith("delete_clip", "id 201");
+    // The source clip 100 must never be treated as an obstacle.
+    expect(trackMock.call).not.toHaveBeenCalledWith("delete_clip", "id 100");
+    expect(trackMock.call).not.toHaveBeenCalledWith(
+      "duplicate_clip_to_arrangement",
+      "id 100",
+      expect.anything(),
+    );
+  });
+
   it("checks multiple arrangement clips for overlap", () => {
     // Source: 4 beats long, target position=16
     // Target range: 16 to 20. Clip1 at 0-4 doesn't overlap, clip2 at 16-20 does.


### PR DESCRIPTION
### **User description**
## Summary

Fixes #264. Root cause: `clearClipAtDuplicateTarget` (the workaround for
Ableton's crash-on-overlap bug in `duplicate_clip_to_arrangement`) scans
a track's arrangement clips for anything overlapping the move target so
it can be cleared first. The scan never excluded the clip being moved
itself.

For any short-distance move — quantizing a clip a few beats, snapping to
a grid — the source clip's own *current* position trivially overlaps its
own target (it hasn't moved yet), so the workaround treated it as an
obstacle and right/left-trimmed or deleted it before
`duplicate_clip_to_arrangement` ever ran. This matches all three repro
attempts in #264: single moves and batched moves both corrupted clips
because every move (batched or not) hits this self-overlap case whenever
the move distance is shorter than the clip's own length.

Fix: skip the source clip's own ID when scanning for overlapping clips
to clear.

Out of scope: #264 also reports `adj-create-clip` defaulting a new
looping clip's arrangement footprint to the full loop region and
silently swallowing neighboring clips on overlap. That's a separate code
path (create, not update) and isn't touched here — worth its own follow-up
if still relevant.

## Test plan

- [x] New regression test: source clip present in `arrangement_clips`
      with a short move overlapping its own old position — asserts no
      track calls happen (previously would have trimmed itself)
- [x] New regression test: same scenario but with a genuine overlapping
      neighbor also present — asserts the neighbor is still cleared
      normally, proving the fix only skips the source, not overlap
      detection in general
- [x] `npm test` — 225 files, 3918 passed
- [x] lint, typecheck (src/scripts/e2e), prettier — clean


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixes arrangement clip corruption during moves.

- Excludes source clip from overlap clearing logic.

- Prevents accidental trimming or deletion of clips.

- Adds regression tests for self-overlap scenarios.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["clearClipAtDuplicateTarget"] --> B{Iterate Arrangement Clips};
  B -- For each clip --> C{Is Current Clip == Source Clip?};
  C -- Yes --> D[Skip Current Clip];
  C -- No --> E{Does Current Clip Overlap Target?};
  E -- Yes --> F[Clear Overlapping Clip];
  E -- No --> B;
  D --> B;
  F --> B;
  B -- All clips processed --> G[End];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>arrangement-tiling-workaround.ts</strong><dd><code>Exclude source clip from overlap clearing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/shared/arrangement/arrangement-tiling-workaround.ts

<ul><li>Normalized the <code>sourceClipId</code> for consistent comparison.<br> <li> Added a check to skip the source clip itself during overlap detection.<br> <li> Prevents accidental trimming or deletion of the clip being moved.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/280/files#diff-8194f651e4a46afffeb72832c12ec824b587ad47d1934fae1c69ee1302ec6747">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>arrangement-duplicate-workaround.test.ts</strong><dd><code>Add regression tests for source clip self-overlap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/shared/arrangement/tests/arrangement-duplicate-workaround.test.ts

<ul><li>Added a test case to confirm the source clip is not cleared when its <br>target overlaps its original position.<br> <li> Included a test to verify that genuine overlapping neighbor clips are <br>still cleared as expected.<br> <li> Ensures the fix correctly distinguishes between the source clip and <br>other overlapping clips.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/280/files#diff-4708491451b0b4c16b33cc4398ba97ab37c3e462b7064d9901b523d9f9006ae0">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

