### PR TITLE
fix: await updateClip in duplicate's arrangementLength tiling path

### DIFF
--- a/src/tools/operations/duplicate/duplicate.ts
+++ b/src/tools/operations/duplicate/duplicate.ts
@@ -80,7 +80,7 @@ interface DuplicateParams {
  * @param context - Context object
  * @returns Result object(s)
  */
-export function duplicate(
+export async function duplicate(
   {
     type,
     id,
@@ -98,7 +98,7 @@ export function duplicate(
     toPath,
   }: DuplicateArgs,
   context: Partial<ToolContext> = {},
-): object | object[] {
+): Promise<object | object[]> {
   // Validate basic inputs
   validateBasicInputs(type, id, count);
 
@@ -136,7 +136,7 @@ export function duplicate(
   // For clips, use position-based iteration; for tracks/scenes, use count-based
   const createdObjects =
     type === "clip"
-      ? duplicateClipWithPositions(
+      ? await duplicateClipWithPositions(
           destination,
           object,
           id,
@@ -148,7 +148,7 @@ export function duplicate(
           arrangementLength,
           context,
         )
-      : duplicateTrackOrSceneWithCount(
+      : await duplicateTrackOrSceneWithCount(
           type,
           destination,
           object,
@@ -221,7 +221,7 @@ function duplicateDeviceWithPaths(
  * @param context - Context object with holdingAreaStartBeats
  * @returns Array of result objects
  */
-function duplicateTrackOrSceneWithCount(
+async function duplicateTrackOrSceneWithCount(
   type: string,
   destination: string | undefined,
   object: LiveAPI,
@@ -231,10 +231,10 @@ function duplicateTrackOrSceneWithCount(
   color: string | undefined,
   params: DuplicateParams,
   context: Partial<ToolContext>,
-): object[] {
+): Promise<object[]> {
   // Scene to arrangement: use position-based iteration (supports multi-value locators)
   if (type === "scene" && destination === "arrangement") {
-    return duplicateSceneToArrangementAtPositions(
+    return await duplicateSceneToArrangementAtPositions(
       object,
       id,
       count,
@@ -285,14 +285,14 @@ function duplicateTrackOrSceneWithCount(
  * @param context - Context object
  * @returns Array of result objects
  */
-function duplicateSceneToArrangementAtPositions(
+async function duplicateSceneToArrangementAtPositions(
   object: LiveAPI,
   id: string,
   count: number,
   name: string | undefined,
   params: DuplicateParams,
   context: Partial<ToolContext>,
-): object[] {
+): Promise<object[]> {
   const { arrangementStart, locator, arrangementLength } = params;
   const withoutClips = params.withoutClips;
 
@@ -338,7 +338,7 @@ function duplicateSceneToArrangementAtPositions(
   warnExtraNames(parsedNames, allPositions.length, "duplicate");
 
   for (let i = 0; i < allPositions.length; i++) {
-    const result = duplicateSceneToArrangement(
+    const result = await duplicateSceneToArrangement(
       id,
       allPositions[i] as number, // bounded by loop
       getNameForIndex(name, i, parsedNames),

--- a/src/tools/operations/duplicate/helpers/duplicate-clip-position-helpers.ts
+++ b/src/tools/operations/duplicate/helpers/duplicate-clip-position-helpers.ts
@@ -37,7 +37,7 @@ import {
  * @param context - Context object with holdingAreaStartBeats
  * @returns Array of result objects
  */
-export function duplicateClipWithPositions(
+export async function duplicateClipWithPositions(
   destination: string | undefined,
   object: LiveAPI,
   id: string,
@@ -48,7 +48,7 @@ export function duplicateClipWithPositions(
   locator: string | undefined,
   arrangementLength: string | undefined,
   context: Partial<ToolContext>,
-): object[] {
+): Promise<object[]> {
   const createdObjects: object[] = [];
 
   if (destination === "session") {
@@ -109,7 +109,7 @@ export function duplicateClipWithPositions(
     warnExtraNames(parsedNames, positionsInBeats.length, "duplicate");
 
     for (let i = 0; i < positionsInBeats.length; i++) {
-      const result = duplicateClipToArrangement(
+      const result = await duplicateClipToArrangement(
         id,
         positionsInBeats[i] as number,
         getNameForIndex(name, i, parsedNames),

--- a/src/tools/operations/duplicate/helpers/duplicate-helpers.ts
+++ b/src/tools/operations/duplicate/helpers/duplicate-helpers.ts
@@ -150,7 +150,7 @@ export function getMinimalClipInfo(
  * @param color - Optional color for the clips
  * @returns Array of minimal clip info objects
  */
-export function createClipsForLength(
+export async function createClipsForLength(
   sourceClip: LiveAPI,
   track: LiveAPI,
   arrangementStartBeats: number,
@@ -159,7 +159,7 @@ export function createClipsForLength(
   omitFields: string[] = [],
   context: Partial<ToolContext & TilingContext> = {},
   color?: string,
-): MinimalClipInfo[] {
+): Promise<MinimalClipInfo[]> {
   const sourceClipLength = sourceClip.getProperty("length") as number;
   const isMidiClip = sourceClip.getProperty("is_midi_clip") === 1;
   const duplicatedClips: MinimalClipInfo[] = [];
@@ -208,7 +208,7 @@ export function createClipsForLength(
     const newClipId = newClip.id;
 
     if (arrangementLengthBeats > sourceClipLength) {
-      lengthenClipAndCollectInfo(
+      await lengthenClipAndCollectInfo(
         sourceClip,
         track,
         newClipId,
@@ -238,7 +238,7 @@ export function createClipsForLength(
  * @param context - Context object
  * @param duplicatedClips - Array to push results to
  */
-function lengthenClipAndCollectInfo(
+async function lengthenClipAndCollectInfo(
   sourceClip: LiveAPI,
   track: LiveAPI,
   newClipId: string,
@@ -247,7 +247,7 @@ function lengthenClipAndCollectInfo(
   omitFields: string[],
   context: Partial<ToolContext & TilingContext>,
   duplicatedClips: MinimalClipInfo[],
-): void {
+): Promise<void> {
   // Convert beats to bar:beat format using clip's time signature
   const timeSigNum = sourceClip.getProperty("signature_numerator") as number;
   const timeSigDenom = sourceClip.getProperty(
@@ -258,7 +258,7 @@ function lengthenClipAndCollectInfo(
   const remainingBeats = targetBeats - bars * beatsPerBar;
   const arrangementLengthBarBeat = `${bars}:${remainingBeats.toFixed(3)}`;
 
-  const updateResult = updateClip(
+  const updateResult = await updateClip(
     { ids: newClipId, arrangementLength: arrangementLengthBarBeat, name },
     context,
   );
@@ -352,7 +352,7 @@ export function duplicateClipSlot(
  * @param context - Context object with holdingAreaStartBeats and silenceWavPath
  * @returns Clip info or object with trackIndex and clips array
  */
-export function duplicateClipToArrangement(
+export async function duplicateClipToArrangement(
   clipId: string,
   arrangementStartBeats: number,
   name?: string,
@@ -361,7 +361,7 @@ export function duplicateClipToArrangement(
   _songTimeSigNumerator = 4,
   _songTimeSigDenominator = 4,
   context: Partial<ToolContext & TilingContext> = {},
-): MinimalClipInfo | { trackIndex: number; clips: MinimalClipInfo[] } {
+): Promise<MinimalClipInfo | { trackIndex: number; clips: MinimalClipInfo[] }> {
   // Support "id {id}" (such as returned by childIds()) and id values directly
   const clip = LiveAPI.from(clipId);
 
@@ -394,7 +394,7 @@ export function duplicateClipToArrangement(
       clipTimeSigDenominator,
     );
     // When creating multiple clips, omit trackIndex since they all share the same track
-    const clipsCreated = createClipsForLength(
+    const clipsCreated = await createClipsForLength(
       clip,
       track,
       arrangementStartBeats,

--- a/src/tools/operations/duplicate/helpers/duplicate-track-scene-helpers.ts
+++ b/src/tools/operations/duplicate/helpers/duplicate-track-scene-helpers.ts
@@ -25,7 +25,8 @@ type ClipInSceneCallback = (
 ) => void;
 
 /**
- * Iterate over all clips in a scene and call a callback for each
+ * Iterate over all clips in a scene and call a callback for each.
+ * Synchronous only — see forEachClipInSceneAsync for the awaited variant.
  * @param sceneIndex - Scene index
  * @param trackIds - Array of track IDs
  * @param callback - Callback to call for each clip
@@ -45,6 +46,38 @@ function forEachClipInScene(
 
       if (clip.exists()) {
         callback(clip, clipSlot, trackIndex);
+      }
+    }
+  }
+}
+
+/**
+ * Async variant of forEachClipInScene. Awaits each callback sequentially,
+ * since callbacks mutate shared track state (e.g. arrangement clip
+ * positions) that later iterations depend on.
+ * @param sceneIndex - Scene index
+ * @param trackIds - Array of track IDs
+ * @param callback - Async callback to call for each clip
+ */
+async function forEachClipInSceneAsync(
+  sceneIndex: number,
+  trackIds: string[],
+  callback: (
+    clip: LiveAPI,
+    clipSlot: LiveAPI,
+    trackIndex: number,
+  ) => Promise<void>,
+): Promise<void> {
+  for (let trackIndex = 0; trackIndex < trackIds.length; trackIndex++) {
+    const clipSlot = LiveAPI.from(
+      livePath.track(trackIndex).clipSlot(sceneIndex),
+    );
+
+    if (clipSlot.exists() && clipSlot.getProperty("has_clip")) {
+      const clip = LiveAPI.from(`${clipSlot.path} clip`);
+
+      if (clip.exists()) {
+        await callback(clip, clipSlot, trackIndex);
       }
     }
   }
@@ -343,7 +376,7 @@ function assignNamesToClips(clips: MinimalClipInfo[], name: string): void {
  * @param context - Context object with holdingAreaStartBeats and silenceWavPath
  * @returns Object with arrangementStart and clips array
  */
-export function duplicateSceneToArrangement(
+export async function duplicateSceneToArrangement(
   sceneId: string,
   arrangementStartBeats: number,
   name?: string,
@@ -352,7 +385,7 @@ export function duplicateSceneToArrangement(
   songTimeSigNumerator = 4,
   songTimeSigDenominator = 4,
   context: Partial<ToolContext & TilingContext> = {},
-): { arrangementStart: string; clips: MinimalClipInfo[] } {
+): Promise<{ arrangementStart: string; clips: MinimalClipInfo[] }> {
   const scene = LiveAPI.from(sceneId);
 
   if (!scene.exists()) {
@@ -391,28 +424,32 @@ export function duplicateSceneToArrangement(
 
     // Only duplicate clips if withoutClips is not explicitly true
     // Find all clips in this scene and duplicate them to arrangement
-    forEachClipInScene(sceneIndex, trackIds, (clip, _clipSlot, trackIndex) => {
-      const track = LiveAPI.from(livePath.track(trackIndex));
+    await forEachClipInSceneAsync(
+      sceneIndex,
+      trackIds,
+      async (clip, _clipSlot, trackIndex) => {
+        const track = LiveAPI.from(livePath.track(trackIndex));
 
-      // Use the new length-aware clip creation logic
-      // Omit arrangementStart since all clips share the same start time
-      const clipsForTrack = createClipsForLength(
-        clip,
-        track,
-        arrangementStartBeats,
-        arrangementLengthBeats,
-        name,
-        ["arrangementStart"],
-        context,
-      );
+        // Use the new length-aware clip creation logic
+        // Omit arrangementStart since all clips share the same start time
+        const clipsForTrack = await createClipsForLength(
+          clip,
+          track,
+          arrangementStartBeats,
+          arrangementLengthBeats,
+          name,
+          ["arrangementStart"],
+          context,
+        );
 
-      // Add the scene name to each clip result if provided
-      if (name != null) {
-        assignNamesToClips(clipsForTrack, name);
-      }
+        // Add the scene name to each clip result if provided
+        if (name != null) {
+          assignNamesToClips(clipsForTrack, name);
+        }
 
-      duplicatedClips.push(...clipsForTrack);
-    });
+        duplicatedClips.push(...clipsForTrack);
+      },
+    );
   }
 
   return {

--- a/src/tools/operations/duplicate/helpers/tests/duplicate-helpers.test.ts
+++ b/src/tools/operations/duplicate/helpers/tests/duplicate-helpers.test.ts
@@ -435,23 +435,25 @@ describe("duplicate-helpers", () => {
       vi.clearAllMocks();
     });
 
-    it("throws error when clip does not exist", () => {
+    it("throws error when clip does not exist", async () => {
       (global as Record<string, unknown>).LiveAPI =
         createArrangementMockLiveAPI({ clipExists: false });
 
-      expect(() => duplicateClipToArrangement("nonexistent", 0)).toThrow(
+      await expect(
+        duplicateClipToArrangement("nonexistent", 0),
+      ).rejects.toThrow(
         'duplicate failed: no clip exists for clipId "nonexistent"',
       );
     });
 
-    it("throws error when clip has no track index", () => {
+    it("throws error when clip has no track index", async () => {
       (global as Record<string, unknown>).LiveAPI =
         createArrangementMockLiveAPI({
           clipExists: true,
           trackIndex: null,
         });
 
-      expect(() => duplicateClipToArrangement("clip1", 0)).toThrow(
+      await expect(duplicateClipToArrangement("clip1", 0)).rejects.toThrow(
         'duplicate failed: no track index for clipId "clip1"',
       );
     });

--- a/src/tools/operations/duplicate/helpers/tests/duplicate-track-scene-helpers.test.ts
+++ b/src/tools/operations/duplicate/helpers/tests/duplicate-track-scene-helpers.test.ts
@@ -19,10 +19,12 @@ import {
   duplicateTrack,
 } from "../duplicate-track-scene-helpers.ts";
 
-// Mock updateClip to avoid complex internal logic
+// Mock updateClip to avoid complex internal logic. Async to match the real
+// signature — a synchronous mock hid a bug where the caller never awaited
+// the real call (#279).
 // @ts-expect-error Vitest mock types are overly strict for partial mocks
 vi.mock(import("#src/tools/clip/update/update-clip.ts"), () => ({
-  updateClip: vi.fn(({ ids }: { ids: string }) => {
+  updateClip: vi.fn(async ({ ids }: { ids: string }) => {
     return [{ id: ids }];
   }),
 }));
@@ -560,10 +562,10 @@ describe("duplicate-track-scene-helpers", () => {
   }
 
   describe("duplicateSceneToArrangement", () => {
-    it("should throw error when scene does not exist", () => {
+    it("should throw error when scene does not exist", async () => {
       mockNonExistentObjects();
 
-      expect(() =>
+      await expect(
         duplicateSceneToArrangement(
           "scene123",
           16,
@@ -573,13 +575,15 @@ describe("duplicate-track-scene-helpers", () => {
           4,
           4,
         ),
-      ).toThrow('duplicate failed: scene with id "scene123" does not exist');
+      ).rejects.toThrow(
+        'duplicate failed: scene with id "scene123" does not exist',
+      );
     });
 
-    it("should throw error when scene has no sceneIndex", () => {
+    it("should throw error when scene has no sceneIndex", async () => {
       registerMockObject("scene123", { path: "some/invalid/path" });
 
-      expect(() =>
+      await expect(
         duplicateSceneToArrangement(
           "scene123",
           16,
@@ -589,17 +593,17 @@ describe("duplicate-track-scene-helpers", () => {
           4,
           4,
         ),
-      ).toThrow('duplicate failed: no scene index for id "scene123"');
+      ).rejects.toThrow('duplicate failed: no scene index for id "scene123"');
     });
 
-    it("should return empty clips when withoutClips is true", () => {
+    it("should return empty clips when withoutClips is true", async () => {
       setupSceneToArrangementBaseMocks();
       registerClipSlot(0, 0, true);
       registerMockObject("live_set/tracks/0/clip_slots/0/clip", {
         path: livePath.track(0).clipSlot(0).clip(),
       });
 
-      const result = duplicateSceneToArrangement(
+      const result = await duplicateSceneToArrangement(
         "scene1",
         16,
         undefined,
@@ -634,7 +638,7 @@ describe("duplicate-track-scene-helpers", () => {
       },
     ])(
       "$desc",
-      ({
+      async ({
         clipLength,
         liveSetExtra,
         sceneName,
@@ -650,6 +654,10 @@ describe("duplicate-track-scene-helpers", () => {
         });
         registerMockObject("live_set/tracks/0", {
           path: livePath.track(0),
+          properties: {
+            // The lengthening path (updateClip) looks the new clip up here.
+            arrangement_clips: children(livePath.track(0).arrangementClip(0)),
+          },
           methods: {
             duplicate_clip_to_arrangement: () => [
               "id",
@@ -662,7 +670,7 @@ describe("duplicate-track-scene-helpers", () => {
           properties: { is_arrangement_clip: 1, start_time: 16 },
         });
 
-        const result = duplicateSceneToArrangement(
+        const result = await duplicateSceneToArrangement(
           "scene1",
           16,
           sceneName,

--- a/src/tools/operations/duplicate/tests/duplicate-advanced-features.test.ts
+++ b/src/tools/operations/duplicate/tests/duplicate-advanced-features.test.ts
@@ -21,7 +21,7 @@ vi.mock(import("#src/tools/control/select.ts"), () => ({
 }));
 
 describe("duplicate - routeToSource with duplicate track names", () => {
-  it("should handle duplicate track names without crashing", () => {
+  it("should handle duplicate track names without crashing", async () => {
     registerSourceTrackWithRouting("track2", livePath.track(1), "Synth");
 
     registerMockObject("live_set", {
@@ -50,7 +50,7 @@ describe("duplicate - routeToSource with duplicate track names", () => {
     });
 
     // Test that the function doesn't crash with duplicate names
-    const result = duplicate({
+    const result = await duplicate({
       type: "track",
       id: "track2", // Duplicate second "Synth" track
       routeToSource: true,
@@ -59,7 +59,7 @@ describe("duplicate - routeToSource with duplicate track names", () => {
     expectTrackResult(result);
   });
 
-  it("should handle unique track names without crashing (backward compatibility)", () => {
+  it("should handle unique track names without crashing (backward compatibility)", async () => {
     registerSourceTrackWithRouting("track1", livePath.track(0), "UniqueTrack");
     registerMockObject("live_set", { path: livePath.liveSet });
 
@@ -70,7 +70,7 @@ describe("duplicate - routeToSource with duplicate track names", () => {
       ],
     });
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "track",
       id: "track1",
       routeToSource: true,
@@ -79,7 +79,7 @@ describe("duplicate - routeToSource with duplicate track names", () => {
     expectTrackResult(result);
   });
 
-  it("should warn when track is not found in routing options", () => {
+  it("should warn when track is not found in routing options", async () => {
     registerSourceTrackWithRouting(
       "track1",
       livePath.track(0),
@@ -94,7 +94,7 @@ describe("duplicate - routeToSource with duplicate track names", () => {
       ],
     });
 
-    duplicate({
+    await duplicate({
       type: "track",
       id: "track1",
       routeToSource: true,
@@ -119,7 +119,7 @@ describe("duplicate - routeToSource with duplicate track names", () => {
 describe("duplicate - focus functionality", () => {
   const selectMock = setupSelectMock();
 
-  it("should select clip and show clip detail when duplicating to arrangement", () => {
+  it("should select clip and show clip detail when duplicating to arrangement", async () => {
     registerMockObject("clip1", {
       path: livePath.track(0).clipSlot(0).clip(),
       properties: { length: 4 },
@@ -128,7 +128,7 @@ describe("duplicate - focus functionality", () => {
     registerTrackWithArrangementDup(0);
     registerArrangementClip(0, 0, 0);
 
-    duplicate({
+    await duplicate({
       type: "clip",
       id: "clip1",
       arrangementStart: "1|1",
@@ -141,12 +141,12 @@ describe("duplicate - focus functionality", () => {
     });
   });
 
-  it("should select clip and show clip detail when duplicating to session", () => {
+  it("should select clip and show clip detail when duplicating to session", async () => {
     registerSessionClipDuplication({
       destClipProperties: { is_arrangement_clip: 0 },
     });
 
-    duplicate({
+    await duplicate({
       type: "clip",
       id: "clip1",
       focus: true,
@@ -159,10 +159,10 @@ describe("duplicate - focus functionality", () => {
     });
   });
 
-  it("should not call select when duplicating tracks", () => {
+  it("should not call select when duplicating tracks", async () => {
     setupTrackForFocus();
 
-    duplicate({
+    await duplicate({
       type: "track",
       id: "track1",
       focus: true,
@@ -171,7 +171,7 @@ describe("duplicate - focus functionality", () => {
     expect(selectMock.get()).not.toHaveBeenCalled();
   });
 
-  it("should select scene in session view when duplicating scenes", () => {
+  it("should select scene in session view when duplicating scenes", async () => {
     registerMockObject("scene1", { path: livePath.scene(0) });
     registerMockObject("live_set", {
       path: livePath.liveSet,
@@ -183,7 +183,7 @@ describe("duplicate - focus functionality", () => {
     });
     registerMockObject("live_set/scenes/1", { path: livePath.scene(1) });
 
-    duplicate({
+    await duplicate({
       type: "scene",
       id: "scene1",
       focus: true,
@@ -195,10 +195,10 @@ describe("duplicate - focus functionality", () => {
     });
   });
 
-  it("should not call select when focus=false", () => {
+  it("should not call select when focus=false", async () => {
     setupTrackForFocus();
 
-    duplicate({
+    await duplicate({
       type: "track",
       id: "track1",
       focus: false,
@@ -207,7 +207,7 @@ describe("duplicate - focus functionality", () => {
     expect(selectMock.get()).not.toHaveBeenCalled();
   });
 
-  it("should not call select for multiple track duplicates when focus=true", () => {
+  it("should not call select for multiple track duplicates when focus=true", async () => {
     setupTrackForFocus();
     // Register second new track for count=2
     registerMockObject("live_set/tracks/2", {
@@ -215,7 +215,7 @@ describe("duplicate - focus functionality", () => {
       properties: { devices: [], clip_slots: [], arrangement_clips: [] },
     });
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "track",
       id: "track1",
       count: 2,
@@ -241,10 +241,10 @@ describe("duplicate - comma-separated names", () => {
     return { newTrack1, newTrack2 };
   }
 
-  it("should assign different names to each track when comma-separated", () => {
+  it("should assign different names to each track when comma-separated", async () => {
     const { newTrack1, newTrack2 } = setupTwoNewTracks();
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "track",
       id: "track1",
       count: 2,
@@ -256,10 +256,10 @@ describe("duplicate - comma-separated names", () => {
     expect(result).toHaveLength(2);
   });
 
-  it("should not set name for extras beyond the comma-separated list", () => {
+  it("should not set name for extras beyond the comma-separated list", async () => {
     const { newTrack1, newTrack2 } = setupTwoNewTracks();
 
-    duplicate({
+    await duplicate({
       type: "track",
       id: "track1",
       count: 2,

--- a/src/tools/operations/duplicate/tests/duplicate-arrangement-length.test.ts
+++ b/src/tools/operations/duplicate/tests/duplicate-arrangement-length.test.ts
@@ -29,7 +29,7 @@ function setupLengthMocks(): LengthMocks {
 }
 
 describe("duplicate - arrangementLength functionality", () => {
-  it("should duplicate a clip to arrangement with shorter length", () => {
+  it("should duplicate a clip to arrangement with shorter length", async () => {
     registerMockObject("clip1", {
       path: livePath.track(0).clipSlot(0).clip(),
       properties: {
@@ -51,7 +51,7 @@ describe("duplicate - arrangementLength functionality", () => {
 
     registerMockObject("live_set", { path: livePath.liveSet });
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "clip",
       id: "clip1",
 
@@ -69,7 +69,7 @@ describe("duplicate - arrangementLength functionality", () => {
     // Just verify the result is correct - the holding area operations are tested in arrangement-tiling.test.js
   });
 
-  it("should duplicate a looping clip with lengthening via updateClip", () => {
+  it("should duplicate a looping clip with lengthening via updateClip", async () => {
     registerMockObject("clip1", {
       path: livePath.track(0).clipSlot(0).clip(),
       properties: {
@@ -87,7 +87,7 @@ describe("duplicate - arrangementLength functionality", () => {
 
     const { track0 } = setupLengthMocks();
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "clip",
       id: "clip1",
 
@@ -110,7 +110,7 @@ describe("duplicate - arrangementLength functionality", () => {
     expect(result).toHaveProperty("id", livePath.track(0).arrangementClip(0));
   });
 
-  it("should duplicate a non-looping clip at original length when requested length is longer", () => {
+  it("should duplicate a non-looping clip at original length when requested length is longer", async () => {
     registerMockObject("clip1", {
       path: livePath.track(0).clipSlot(0).clip(),
       properties: {
@@ -124,7 +124,7 @@ describe("duplicate - arrangementLength functionality", () => {
 
     const { track0 } = setupLengthMocks();
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "clip",
       id: "clip1",
 
@@ -151,7 +151,7 @@ describe("duplicate - arrangementLength functionality", () => {
     ["2/2", 2, 2, 8],
   ] as const)(
     "should correctly handle %s time signature duration conversion",
-    (label, numerator, denominator, clipLength) => {
+    async (label, numerator, denominator, clipLength) => {
       registerMockObject("clip1", {
         path: livePath.track(0).clipSlot(0).clip(),
         properties: {
@@ -181,7 +181,7 @@ describe("duplicate - arrangementLength functionality", () => {
 
       registerArrangementClip(0, 0, 0);
 
-      const result = duplicate({
+      const result = await duplicate({
         type: "clip",
         id: "clip1",
 
@@ -196,7 +196,7 @@ describe("duplicate - arrangementLength functionality", () => {
     },
   );
 
-  it("should error when arrangementLength is zero or negative", () => {
+  it("should error when arrangementLength is zero or negative", async () => {
     registerMockObject("clip1", {
       path: livePath.track(0).clipSlot(0).clip(),
       properties: { length: 4, looping: 1 },
@@ -204,7 +204,7 @@ describe("duplicate - arrangementLength functionality", () => {
 
     registerMockObject("live_set", { path: livePath.liveSet });
 
-    expect(() =>
+    await expect(
       duplicate({
         type: "clip",
         id: "clip1",
@@ -212,12 +212,12 @@ describe("duplicate - arrangementLength functionality", () => {
         arrangementStart: "5|1",
         arrangementLength: "0:0", // 0 bars + 0 beats = 0 total
       }),
-    ).toThrow(
+    ).rejects.toThrow(
       'duplicate failed: arrangementLength must be positive, got "0:0"',
     );
   });
 
-  it("should work normally without arrangementLength (backward compatibility)", () => {
+  it("should work normally without arrangementLength (backward compatibility)", async () => {
     registerMockObject("clip1", {
       path: livePath.track(0).clipSlot(0).clip(),
       properties: { length: 8, looping: 0 },
@@ -228,7 +228,7 @@ describe("duplicate - arrangementLength functionality", () => {
 
     registerMockObject("live_set", { path: livePath.liveSet });
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "clip",
       id: "clip1",
 

--- a/src/tools/operations/duplicate/tests/duplicate-clip.test.ts
+++ b/src/tools/operations/duplicate/tests/duplicate-clip.test.ts
@@ -14,22 +14,22 @@ import {
 } from "#src/tools/operations/duplicate/helpers/duplicate-test-helpers.ts";
 
 describe("duplicate - clip duplication", () => {
-  it("should throw an error when clip has no position params", () => {
+  it("should throw an error when clip has no position params", async () => {
     registerMockObject("clip1", {
       path: livePath.track(0).clipSlot(0).clip(),
     });
-    expect(() => duplicate({ type: "clip", id: "clip1" })).toThrow(
+    await expect(duplicate({ type: "clip", id: "clip1" })).rejects.toThrow(
       "duplicate failed: clip requires toSlot (for session) or arrangementStart/locator (for arrangement)",
     );
   });
 
   describe("session destination", () => {
-    it("should duplicate a single clip to the session view", () => {
+    it("should duplicate a single clip to the session view", async () => {
       const { sourceClipSlot } = registerSessionClipDuplication({
         destClipProperties: {},
       });
 
-      const result = duplicate({
+      const result = await duplicate({
         type: "clip",
         id: "clip1",
 
@@ -47,7 +47,7 @@ describe("duplicate - clip duplication", () => {
       });
     });
 
-    it("should duplicate multiple clips to session view with comma-separated toSceneIndex", () => {
+    it("should duplicate multiple clips to session view with comma-separated toSceneIndex", async () => {
       const { sourceClipSlot } = registerSessionClipDuplication();
 
       registerMockObject("live_set/tracks/0/clip_slots/2", {
@@ -69,7 +69,7 @@ describe("duplicate - clip duplication", () => {
         },
       );
 
-      const result = duplicate({
+      const result = await duplicate({
         type: "clip",
         id: "clip1",
 
@@ -101,26 +101,26 @@ describe("duplicate - clip duplication", () => {
       expect(destClip2.set).toHaveBeenCalledWith("name", "Custom Clip");
     });
 
-    it("should throw an error when trying to duplicate an arrangement clip to session", () => {
+    it("should throw an error when trying to duplicate an arrangement clip to session", async () => {
       registerMockObject("arrangementClip1", {
         path: livePath.track(0).arrangementClip(0),
       });
 
-      expect(() =>
+      await expect(
         duplicate({
           type: "clip",
           id: "arrangementClip1",
 
           toSlot: "1/2",
         }),
-      ).toThrow(
+      ).rejects.toThrow(
         'unsupported duplicate operation: cannot duplicate arrangement clips to the session (source clip id="arrangementClip1" path="live_set tracks 0 arrangement_clips 0") ',
       );
     });
   });
 
   describe("arrangement destination", () => {
-    it("should duplicate a single clip to the arrangement view", () => {
+    it("should duplicate a single clip to the arrangement view", async () => {
       registerMockObject("clip1", {
         path: livePath.track(0).clipSlot(0).clip(),
       });
@@ -129,7 +129,7 @@ describe("duplicate - clip duplication", () => {
 
       registerArrangementClip(0, 0, 8);
 
-      const result = duplicate({
+      const result = await duplicate({
         type: "clip",
         id: "clip1",
 
@@ -149,7 +149,7 @@ describe("duplicate - clip duplication", () => {
       });
     });
 
-    it("should duplicate multiple clips to arrangement view with comma-separated positions", () => {
+    it("should duplicate multiple clips to arrangement view with comma-separated positions", async () => {
       registerMockObject("clip1", {
         path: livePath.track(0).clipSlot(0).clip(),
       });
@@ -160,7 +160,7 @@ describe("duplicate - clip duplication", () => {
       registerArrangementClip(0, 1, 12);
       registerArrangementClip(0, 2, 16);
 
-      const result = duplicate({
+      const result = await duplicate({
         type: "clip",
         id: "clip1",
 

--- a/src/tools/operations/duplicate/tests/duplicate-device.test.ts
+++ b/src/tools/operations/duplicate/tests/duplicate-device.test.ts
@@ -35,7 +35,7 @@ describe("duplicate - device duplication", () => {
     vi.clearAllMocks();
   });
 
-  it("should duplicate a device to position after original (no toPath)", () => {
+  it("should duplicate a device to position after original (no toPath)", async () => {
     registerMockObject("device1", {
       path: livePath.track(0).device(2),
       type: "PluginDevice",
@@ -49,7 +49,7 @@ describe("duplicate - device duplication", () => {
       path: livePath.track(1).device(2),
     });
 
-    const result = duplicate({ type: "device", id: "device1" });
+    const result = await duplicate({ type: "device", id: "device1" });
 
     expect(result).toStrictEqual({
       id: "live_set/tracks/1/devices/2",
@@ -70,10 +70,10 @@ describe("duplicate - device duplication", () => {
     expect(liveSet.call).toHaveBeenCalledWith("delete_track", 1);
   });
 
-  it("should duplicate a device with toPath to different track", () => {
+  it("should duplicate a device with toPath to different track", async () => {
     setupDeviceDuplicationMocks(1);
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "device",
       id: "device1",
       toPath: "t2/d0",
@@ -92,7 +92,7 @@ describe("duplicate - device duplication", () => {
     );
   });
 
-  it("should duplicate a device in a rack chain", () => {
+  it("should duplicate a device in a rack chain", async () => {
     registerMockObject("rack_device1", {
       path: livePath.track(1).device(0).chain(0).device(1),
       type: "PluginDevice",
@@ -106,7 +106,7 @@ describe("duplicate - device duplication", () => {
       path: livePath.track(2).device(0).chain(0).device(1),
     });
 
-    const result = duplicate({ type: "device", id: "rack_device1" });
+    const result = await duplicate({ type: "device", id: "rack_device1" });
 
     expect(result).toStrictEqual({
       id: "live_set/tracks/2/devices/0/chains/0/devices/1",
@@ -127,39 +127,39 @@ describe("duplicate - device duplication", () => {
     expect(liveSet.call).toHaveBeenCalledWith("delete_track", 2);
   });
 
-  it("should emit warning when count > 1", () => {
+  it("should emit warning when count > 1", async () => {
     setupDeviceDuplicationMocks();
 
-    duplicate({ type: "device", id: "device1", count: 3 });
+    await duplicate({ type: "device", id: "device1", count: 3 });
 
     expect(consoleMock.warn).toHaveBeenCalledWith(
       "count parameter ignored for device duplication (only single copy supported)",
     );
   });
 
-  it("should throw error for device on return track", () => {
+  it("should throw error for device on return track", async () => {
     registerMockObject("return_device1", {
       path: livePath.returnTrack(0).device(0),
       type: "PluginDevice",
     });
 
-    expect(() => duplicate({ type: "device", id: "return_device1" })).toThrow(
-      "cannot duplicate devices on return/master tracks",
-    );
+    await expect(
+      duplicate({ type: "device", id: "return_device1" }),
+    ).rejects.toThrow("cannot duplicate devices on return/master tracks");
   });
 
-  it("should throw error for device on master track", () => {
+  it("should throw error for device on master track", async () => {
     registerMockObject("master_device1", {
       path: livePath.masterTrack().device(0),
       type: "PluginDevice",
     });
 
-    expect(() => duplicate({ type: "device", id: "master_device1" })).toThrow(
-      "cannot duplicate devices on return/master tracks",
-    );
+    await expect(
+      duplicate({ type: "device", id: "master_device1" }),
+    ).rejects.toThrow("cannot duplicate devices on return/master tracks");
   });
 
-  it("should set custom name on duplicated device", () => {
+  it("should set custom name on duplicated device", async () => {
     registerMockObject("device1", {
       path: livePath.track(0).device(0),
       type: "PluginDevice",
@@ -169,13 +169,13 @@ describe("duplicate - device duplication", () => {
       path: livePath.track(1).device(0),
     });
 
-    duplicate({ type: "device", id: "device1", name: "My Effect" });
+    await duplicate({ type: "device", id: "device1", name: "My Effect" });
 
     // Check that set was called with name
     expect(tempDevice.set).toHaveBeenCalledWith("name", "My Effect");
   });
 
-  it("should not adjust destination for tracks before source", () => {
+  it("should not adjust destination for tracks before source", async () => {
     registerMockObject("device1", {
       path: livePath.track(5).device(0),
       type: "PluginDevice",
@@ -185,7 +185,7 @@ describe("duplicate - device duplication", () => {
       path: livePath.track(6).device(0),
     });
 
-    duplicate({ type: "device", id: "device1", toPath: "t2/d0" });
+    await duplicate({ type: "device", id: "device1", toPath: "t2/d0" });
 
     // Destination t2 is before source t5, should not be adjusted
     expect(moveDeviceToPathMock).toHaveBeenCalledWith(
@@ -194,7 +194,7 @@ describe("duplicate - device duplication", () => {
     );
   });
 
-  it("should throw and cleanup if device not found in duplicated track", () => {
+  it("should throw and cleanup if device not found in duplicated track", async () => {
     registerMockObject("device1", {
       path: livePath.track(0).device(0),
       type: "PluginDevice",
@@ -207,7 +207,7 @@ describe("duplicate - device duplication", () => {
     // Do NOT register "live_set tracks 1 devices 0" — this makes it non-existent
     mockNonExistentObjects();
 
-    expect(() => duplicate({ type: "device", id: "device1" })).toThrow(
+    await expect(duplicate({ type: "device", id: "device1" })).rejects.toThrow(
       "device not found in duplicated track",
     );
 
@@ -215,11 +215,11 @@ describe("duplicate - device duplication", () => {
     expect(liveSet.call).toHaveBeenCalledWith("delete_track", 1);
   });
 
-  it("should not adjust non-track destination path (return/master)", () => {
+  it("should not adjust non-track destination path (return/master)", async () => {
     setupDeviceDuplicationMocks();
 
     // Using a path that doesn't start with "t" should not be adjusted
-    duplicate({ type: "device", id: "device1", toPath: "r0/d0" });
+    await duplicate({ type: "device", id: "device1", toPath: "r0/d0" });
 
     // Should pass the path through unchanged (return track)
     expect(moveDeviceToPathMock).toHaveBeenCalledWith(
@@ -228,22 +228,22 @@ describe("duplicate - device duplication", () => {
     );
   });
 
-  it("should throw error for invalid device path without device segment", () => {
+  it("should throw error for invalid device path without device segment", async () => {
     // Path with track but no device segment - triggers extractDevicePathWithinTrack error
     registerMockObject("device1", {
       path: livePath.track(0),
       type: "PluginDevice",
     });
 
-    expect(() => duplicate({ type: "device", id: "device1" })).toThrow(
+    await expect(duplicate({ type: "device", id: "device1" })).rejects.toThrow(
       "cannot extract device path",
     );
   });
 
-  it("should duplicate a device to multiple toPath destinations", () => {
+  it("should duplicate a device to multiple toPath destinations", async () => {
     setupDeviceDuplicationMocks(1);
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "device",
       id: "device1",
       toPath: "t2/d0, t3/d0",
@@ -254,7 +254,7 @@ describe("duplicate - device duplication", () => {
     expect(result).toHaveLength(2);
   });
 
-  it("should handle device path ending with chain segment (not device)", () => {
+  it("should handle device path ending with chain segment (not device)", async () => {
     // When extractDevicePath returns a path that ends with a chain (not device),
     // it should use the fallback of returning the simplified path as-is
     // This tests the "return simplifiedPath" fallback in calculateDefaultDestination
@@ -267,7 +267,7 @@ describe("duplicate - device duplication", () => {
       path: livePath.track(1).device(0).chain(0),
     });
 
-    const result = duplicate({ type: "device", id: "device1" });
+    const result = await duplicate({ type: "device", id: "device1" });
 
     expect(result).toBeDefined();
     // When last segment is "c0" (not "d"), use the simplified path as destination

--- a/src/tools/operations/duplicate/tests/duplicate-locator.test.ts
+++ b/src/tools/operations/duplicate/tests/duplicate-locator.test.ts
@@ -125,10 +125,10 @@ const standardCuePoints: CuePointConfig[] = [
 
 describe("duplicate - locator-based arrangement positioning", () => {
   describe("parameter validation", () => {
-    it("should throw error when arrangementStart and locator are both provided", () => {
+    it("should throw error when arrangementStart and locator are both provided", async () => {
       registerMockObject("scene1", { path: livePath.scene(0) });
 
-      expect(() =>
+      await expect(
         duplicate({
           type: "scene",
           id: "scene1",
@@ -136,15 +136,15 @@ describe("duplicate - locator-based arrangement positioning", () => {
           arrangementStart: "5|1",
           locator: "locator-0",
         }),
-      ).toThrow(
+      ).rejects.toThrow(
         "duplicate failed: arrangementStart and locator are mutually exclusive",
       );
     });
 
-    it("should throw error when arrangementStart and locator name are both provided", () => {
+    it("should throw error when arrangementStart and locator name are both provided", async () => {
       registerMockObject("scene1", { path: livePath.scene(0) });
 
-      expect(() =>
+      await expect(
         duplicate({
           type: "scene",
           id: "scene1",
@@ -152,20 +152,20 @@ describe("duplicate - locator-based arrangement positioning", () => {
           arrangementStart: "5|1",
           locator: "Verse",
         }),
-      ).toThrow(
+      ).rejects.toThrow(
         "duplicate failed: arrangementStart and locator are mutually exclusive",
       );
     });
   });
 
   describe("scene duplication with locator", () => {
-    it("should duplicate a scene to arrangement at locator ID position", () => {
+    it("should duplicate a scene to arrangement at locator ID position", async () => {
       const track0 = setupSceneWithLocators([
         { time: 0, name: "Intro" },
         { time: 16, name: "Verse" },
       ]);
 
-      const result = duplicate({
+      const result = await duplicate({
         type: "scene",
         id: "scene1",
         locator: "locator-1",
@@ -175,14 +175,14 @@ describe("duplicate - locator-based arrangement positioning", () => {
       expect(result).toHaveProperty("arrangementStart", "5|1");
     });
 
-    it("should duplicate a scene to arrangement at locator name position", () => {
+    it("should duplicate a scene to arrangement at locator name position", async () => {
       const track0 = setupSceneWithLocators([
         { time: 0, name: "Intro" },
         { time: 16, name: "Verse" },
         { time: 32, name: "Chorus" },
       ]);
 
-      const result = duplicate({
+      const result = await duplicate({
         type: "scene",
         id: "scene1",
         locator: "Chorus",
@@ -194,10 +194,10 @@ describe("duplicate - locator-based arrangement positioning", () => {
   });
 
   describe("clip duplication with locator", () => {
-    it("should duplicate a clip to arrangement at locator ID position", () => {
+    it("should duplicate a clip to arrangement at locator ID position", async () => {
       const track0 = setupClipWithLocators(standardCuePoints);
 
-      const result = duplicate({
+      const result = await duplicate({
         type: "clip",
         id: "clip1",
         locator: "locator-1",
@@ -207,10 +207,14 @@ describe("duplicate - locator-based arrangement positioning", () => {
       expect(result).toHaveProperty("arrangementStart", "3|1");
     });
 
-    it("should duplicate a clip to arrangement at locator name position", () => {
+    it("should duplicate a clip to arrangement at locator name position", async () => {
       const track0 = setupClipWithLocators(standardCuePoints);
 
-      const result = duplicate({ type: "clip", id: "clip1", locator: "Drop" });
+      const result = await duplicate({
+        type: "clip",
+        id: "clip1",
+        locator: "Drop",
+      });
 
       expectDuplicatedAt(track0, "id clip1", 8);
       expect(result).toHaveProperty("arrangementStart", "3|1");
@@ -224,9 +228,9 @@ describe("duplicate - locator-based arrangement positioning", () => {
       { time: 16, name: "Chorus" },
     ];
 
-    it("should duplicate a clip to multiple locator ID positions", () => {
+    it("should duplicate a clip to multiple locator ID positions", async () => {
       const track0 = setupClipWithLocators(multiCuePoints);
-      const result = duplicate({
+      const result = await duplicate({
         type: "clip",
         id: "clip1",
         locator: "locator-1, locator-2",
@@ -236,9 +240,9 @@ describe("duplicate - locator-based arrangement positioning", () => {
       expect(result).toHaveLength(2);
     });
 
-    it("should duplicate a clip to multiple locator name positions", () => {
+    it("should duplicate a clip to multiple locator name positions", async () => {
       const track0 = setupClipWithLocators(multiCuePoints);
-      const result = duplicate({
+      const result = await duplicate({
         type: "clip",
         id: "clip1",
         locator: "Verse, Chorus",
@@ -248,9 +252,9 @@ describe("duplicate - locator-based arrangement positioning", () => {
       expect(result).toHaveLength(2);
     });
 
-    it("should duplicate a clip to mixed locator ID and name positions", () => {
+    it("should duplicate a clip to mixed locator ID and name positions", async () => {
       const track0 = setupClipWithLocators(multiCuePoints);
-      const result = duplicate({
+      const result = await duplicate({
         type: "clip",
         id: "clip1",
         locator: "locator-1, Chorus",
@@ -260,14 +264,14 @@ describe("duplicate - locator-based arrangement positioning", () => {
       expect(result).toHaveLength(2);
     });
 
-    it("should duplicate a scene to multiple locator ID positions", () => {
+    it("should duplicate a scene to multiple locator ID positions", async () => {
       const track0 = setupSceneWithLocators([
         { time: 0, name: "Intro" },
         { time: 16, name: "Verse" },
         { time: 32, name: "Chorus" },
       ]);
 
-      const result = duplicate({
+      const result = await duplicate({
         type: "scene",
         id: "scene1",
         locator: "locator-1, locator-2",
@@ -302,30 +306,32 @@ describe("duplicate - locator-based arrangement positioning", () => {
       registerMockObject("cue0", { properties: { time: 0, name: "Intro" } });
     }
 
-    it("should throw error for non-existent locator ID", () => {
+    it("should throw error for non-existent locator ID", async () => {
       setupErrorHandlingMocks();
 
-      expect(() =>
+      await expect(
         duplicate({
           type: "scene",
           id: "scene1",
 
           locator: "locator-5",
         }),
-      ).toThrow("duplicate failed: locator not found: locator-5");
+      ).rejects.toThrow("duplicate failed: locator not found: locator-5");
     });
 
-    it("should throw error for non-existent locator name", () => {
+    it("should throw error for non-existent locator name", async () => {
       setupErrorHandlingMocks();
 
-      expect(() =>
+      await expect(
         duplicate({
           type: "scene",
           id: "scene1",
 
           locator: "NonExistent",
         }),
-      ).toThrow('duplicate failed: no locator found with name "NonExistent"');
+      ).rejects.toThrow(
+        'duplicate failed: no locator found with name "NonExistent"',
+      );
     });
   });
 });

--- a/src/tools/operations/duplicate/tests/duplicate-scene.test.ts
+++ b/src/tools/operations/duplicate/tests/duplicate-scene.test.ts
@@ -7,6 +7,7 @@ import "./duplicate-mocks-test-helpers.ts";
 import { duplicate } from "#src/tools/operations/duplicate/duplicate.ts";
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import {
+  children,
   createStandardMidiClipMock,
   registerArrangementClip,
   registerClipMocks,
@@ -32,13 +33,13 @@ interface DuplicateSceneResult {
 }
 
 describe("duplicate - scene duplication", () => {
-  it("should duplicate a single scene to session view (default behavior)", () => {
+  it("should duplicate a single scene to session view (default behavior)", async () => {
     const liveSet = setupSessionSceneMocks();
 
-    const result = duplicate({
+    const result = (await duplicate({
       type: "scene",
       id: "scene1",
-    }) as DuplicateSceneResult;
+    })) as DuplicateSceneResult;
 
     expect(result).toStrictEqual({
       id: "live_set/scenes/1",
@@ -58,7 +59,7 @@ describe("duplicate - scene duplication", () => {
     expect(liveSet.call).toHaveBeenCalledWith("duplicate_scene", 0);
   });
 
-  it("should duplicate multiple scenes with same name", () => {
+  it("should duplicate multiple scenes with same name", async () => {
     const liveSet = setupSessionSceneMocks({ registerNewScene: false });
 
     // Register additional clip slots and mocks for second duplicated scene
@@ -73,12 +74,12 @@ describe("duplicate - scene duplication", () => {
       path: livePath.scene(2),
     });
 
-    const result = duplicate({
+    const result = (await duplicate({
       type: "scene",
       id: "scene1",
       count: 2,
       name: "Custom Scene",
-    }) as DuplicateSceneResult[];
+    })) as DuplicateSceneResult[];
 
     expect(result).toStrictEqual([
       {
@@ -118,7 +119,7 @@ describe("duplicate - scene duplication", () => {
     expect(scene2.set).toHaveBeenCalledWith("name", "Custom Scene");
   });
 
-  it("should duplicate a scene without clips when withoutClips is true", () => {
+  it("should duplicate a scene without clips when withoutClips is true", async () => {
     const liveSet = setupArrangementSceneMocks();
 
     const slot0 = registerClipSlot(0, 1, true);
@@ -128,11 +129,11 @@ describe("duplicate - scene duplication", () => {
     registerClipMocks(2, 1);
     registerMockObject("live_set/scenes/1", { path: livePath.scene(1) });
 
-    const result = duplicate({
+    const result = (await duplicate({
       type: "scene",
       id: "scene1",
       withoutClips: true,
-    }) as DuplicateSceneResult;
+    })) as DuplicateSceneResult;
 
     expect(result).toStrictEqual({
       id: "live_set/scenes/1",
@@ -157,7 +158,7 @@ describe("duplicate - scene duplication", () => {
   });
 
   describe("arrangement destination", () => {
-    it("should duplicate a scene to arrangement view", () => {
+    it("should duplicate a scene to arrangement view, including clips lengthened via updateClip (#279)", async () => {
       setupArrangementSceneMocks();
 
       registerClipSlot(
@@ -182,9 +183,14 @@ describe("duplicate - scene duplication", () => {
         is_midi_clip: 1,
       });
 
-      // Register tracks with duplicate_clip_to_arrangement method
+      // Register tracks with duplicate_clip_to_arrangement method.
+      // arrangement_clips must include the created clip's id — the
+      // lengthening path (updateClip) looks the new clip up by id here.
       const track0 = registerMockObject("live_set/tracks/0", {
         path: livePath.track(0),
+        properties: {
+          arrangement_clips: children(livePath.track(0).arrangementClip(0)),
+        },
         methods: {
           duplicate_clip_to_arrangement: (clipId: unknown) => {
             const trackMatch = (clipId as string).match(/tracks\/(\d+)/);
@@ -214,12 +220,12 @@ describe("duplicate - scene duplication", () => {
       registerArrangementClip(0, 0, 16);
       registerArrangementClip(2, 0, 16);
 
-      const result = duplicate({
+      const result = (await duplicate({
         type: "scene",
         id: "scene1",
 
         arrangementStart: "5|1",
-      }) as DuplicateSceneResult;
+      })) as DuplicateSceneResult;
 
       // Both clips now use duplicate_clip_to_arrangement
       // Track 0 clip (4 beats -> 8 beats) - lengthened via updateClip
@@ -239,14 +245,20 @@ describe("duplicate - scene duplication", () => {
       expect(result).toHaveProperty("arrangementStart", "5|1");
       expect(result).toHaveProperty("clips");
       expect(Array.isArray(result.clips)).toBe(true);
-      // At least the exact-match clip (track 2) should appear
-      // Track 0's lengthening via updateClip is tested in updateClip's own tests
+      // Exact-match clip (track 2) appears
       expect(
         result.clips.some((c: DuplicateClipResult) => c.trackIndex === 2),
       ).toBe(true);
+      // Regression for #279: the lengthened clip (track 0) went through
+      // updateClip (async) and must also appear in the returned array, not
+      // just land correctly in Live while the report comes back empty.
+      expect(
+        result.clips.some((c: DuplicateClipResult) => c.trackIndex === 0),
+      ).toBe(true);
+      expect(result.clips).toHaveLength(2);
     });
 
-    it("should duplicate multiple scenes to arrangement view at sequential positions", () => {
+    it("should duplicate multiple scenes to arrangement view at sequential positions", async () => {
       setupArrangementSceneMocks(1);
 
       // Mock scene with one clip of length 8 beats
@@ -259,14 +271,14 @@ describe("duplicate - scene duplication", () => {
       registerArrangementClip(0, 1, 24);
       registerArrangementClip(0, 2, 32);
 
-      const result = duplicate({
+      const result = (await duplicate({
         type: "scene",
         id: "scene1",
 
         arrangementStart: "5|1",
         count: 3,
         name: "Scene Copy",
-      }) as DuplicateSceneResult[];
+      })) as DuplicateSceneResult[];
 
       // Scenes should be placed at sequential positions based on scene length (8 beats)
       // All use duplicate_clip_to_arrangement (exact match, no lengthening needed)
@@ -320,18 +332,18 @@ describe("duplicate - scene duplication", () => {
       ]);
     });
 
-    it("should handle empty scenes gracefully", () => {
+    it("should handle empty scenes gracefully", async () => {
       setupArrangementSceneMocks(2);
 
       registerClipSlot(0, 0, false);
       registerClipSlot(1, 0, false);
 
-      const result = duplicate({
+      const result = (await duplicate({
         type: "scene",
         id: "scene1",
 
         arrangementStart: "5|1",
-      }) as DuplicateSceneResult;
+      })) as DuplicateSceneResult;
 
       expect(result).toStrictEqual({
         arrangementStart: "5|1",
@@ -339,7 +351,7 @@ describe("duplicate - scene duplication", () => {
       });
     });
 
-    it("should duplicate a scene to arrangement without clips when withoutClips is true", () => {
+    it("should duplicate a scene to arrangement without clips when withoutClips is true", async () => {
       setupArrangementSceneMocks();
 
       registerClipSlot(0, 0, true, { length: 4 });
@@ -357,13 +369,13 @@ describe("duplicate - scene duplication", () => {
         path: livePath.track(2),
       });
 
-      const result = duplicate({
+      const result = (await duplicate({
         type: "scene",
         id: "scene1",
 
         arrangementStart: "5|1",
         withoutClips: true,
-      }) as DuplicateSceneResult;
+      })) as DuplicateSceneResult;
 
       // Verify that duplicate_clip_to_arrangement was NOT called on any track
       expect(track0.call).not.toHaveBeenCalledWith(
@@ -389,7 +401,7 @@ describe("duplicate - scene duplication", () => {
     });
   });
 
-  it("should apply color when duplicating a scene", () => {
+  it("should apply color when duplicating a scene", async () => {
     registerMockObject("scene1", { path: livePath.scene(0) });
 
     const liveSet = registerMockObject("live_set", {
@@ -401,11 +413,11 @@ describe("duplicate - scene duplication", () => {
       path: livePath.scene(1),
     });
 
-    const result = duplicate({
+    const result = (await duplicate({
       type: "scene",
       id: "scene1",
       color: "#00ff00",
-    }) as DuplicateSceneResult;
+    })) as DuplicateSceneResult;
 
     expect(liveSet.call).toHaveBeenCalledWith("duplicate_scene", 0);
     expect(newScene.set).toHaveBeenCalledWith("color", 0x00ff00);

--- a/src/tools/operations/duplicate/tests/duplicate-track.test.ts
+++ b/src/tools/operations/duplicate/tests/duplicate-track.test.ts
@@ -17,7 +17,7 @@ import {
 } from "#src/tools/operations/duplicate/helpers/duplicate-test-helpers.ts";
 
 describe("duplicate - track duplication", () => {
-  it("should duplicate a single track (default count)", () => {
+  it("should duplicate a single track (default count)", async () => {
     registerMockObject("track1", { path: livePath.track(0) });
     const liveSet = registerMockObject("live_set", {
       path: livePath.liveSet,
@@ -28,13 +28,13 @@ describe("duplicate - track duplication", () => {
       properties: { devices: [], clip_slots: [], arrangement_clips: [] },
     });
 
-    const result = duplicate({ type: "track", id: "track1" });
+    const result = await duplicate({ type: "track", id: "track1" });
 
     expect(result).toStrictEqual(createTrackResult(1));
     expect(liveSet.call).toHaveBeenCalledWith("duplicate_track", 0);
   });
 
-  it("should duplicate multiple tracks with same name", () => {
+  it("should duplicate multiple tracks with same name", async () => {
     registerMockObject("track1", { path: livePath.track(0) });
     const liveSet = registerMockObject("live_set", {
       path: livePath.liveSet,
@@ -52,7 +52,7 @@ describe("duplicate - track duplication", () => {
       properties: { devices: [], clip_slots: [], arrangement_clips: [] },
     });
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "track",
       id: "track1",
       count: 3,
@@ -70,7 +70,7 @@ describe("duplicate - track duplication", () => {
     expect(track3.set).toHaveBeenCalledWith("name", "Custom Track");
   });
 
-  it("should duplicate a track without clips when withoutClips is true", () => {
+  it("should duplicate a track without clips when withoutClips is true", async () => {
     registerMockObject("track1", { path: livePath.track(0) });
     registerMockObject("live_set", { path: livePath.liveSet });
     const newTrack = registerMockObject("live_set/tracks/1", {
@@ -97,7 +97,7 @@ describe("duplicate - track duplication", () => {
       properties: { has_clip: 1 },
     });
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "track",
       id: "track1",
       withoutClips: true,
@@ -120,10 +120,10 @@ describe("duplicate - track duplication", () => {
     );
   });
 
-  it("should duplicate a track without devices when withoutDevices is true", () => {
+  it("should duplicate a track without devices when withoutDevices is true", async () => {
     const { liveSet, newTrack } = setupMcpDeviceMocks();
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "track",
       id: "track1",
       withoutDevices: true,
@@ -139,7 +139,7 @@ describe("duplicate - track duplication", () => {
     ["withoutDevices is false", false],
   ] as const)(
     "should duplicate a track with devices when %s",
-    (_desc: string, withoutDevices: boolean | undefined) => {
+    async (_desc: string, withoutDevices: boolean | undefined) => {
       registerMockObject("track1", { path: livePath.track(0) });
       const liveSet = registerMockObject("live_set", {
         path: livePath.liveSet,
@@ -153,7 +153,7 @@ describe("duplicate - track duplication", () => {
         },
       });
 
-      const result = duplicate({
+      const result = await duplicate({
         type: "track",
         id: "track1",
         ...(withoutDevices !== undefined && { withoutDevices }),
@@ -170,10 +170,10 @@ describe("duplicate - track duplication", () => {
     },
   );
 
-  it("should remove Ableton DJ MCP device when duplicating host track", () => {
+  it("should remove Ableton DJ MCP device when duplicating host track", async () => {
     const { liveSet, newTrack } = setupMcpDeviceMocks();
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "track",
       id: "track1",
     });
@@ -188,10 +188,10 @@ describe("duplicate - track duplication", () => {
     );
   });
 
-  it("should not remove Ableton DJ MCP device when withoutDevices is true", () => {
+  it("should not remove Ableton DJ MCP device when withoutDevices is true", async () => {
     const { newTrack } = setupMcpDeviceMocks();
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "track",
       id: "track1",
       withoutDevices: true,
@@ -209,21 +209,21 @@ describe("duplicate - track duplication", () => {
   });
 
   describe("routeToSource functionality", () => {
-    it("should throw an error when routeToSource is used with non-track type", () => {
-      expect(() =>
+    it("should throw an error when routeToSource is used with non-track type", async () => {
+      await expect(
         duplicate({ type: "scene", id: "scene1", routeToSource: true }),
-      ).toThrow(
+      ).rejects.toThrow(
         "duplicate failed: routeToSource is only supported for type 'track'",
       );
     });
 
-    it("should configure routing when routeToSource is true", () => {
+    it("should configure routing when routeToSource is true", async () => {
       setupRoutingMocks({
         monitoringState: 1,
         inputRoutingName: "Audio In",
       });
 
-      const result = duplicate({
+      const result = await duplicate({
         type: "track",
         id: "track1",
         routeToSource: true,
@@ -232,10 +232,10 @@ describe("duplicate - track duplication", () => {
       expect(result).toStrictEqual(createTrackResult(1));
     });
 
-    it("should not change source track monitoring if already set to In", () => {
+    it("should not change source track monitoring if already set to In", async () => {
       const { sourceTrack } = setupRoutingMocks();
 
-      duplicate({
+      await duplicate({
         type: "track",
         id: "track1",
         routeToSource: true,
@@ -248,10 +248,10 @@ describe("duplicate - track duplication", () => {
       );
     });
 
-    it("should not change source track input routing if already set to No Input", () => {
+    it("should not change source track input routing if already set to No Input", async () => {
       const { sourceTrack } = setupRoutingMocks();
 
-      duplicate({
+      await duplicate({
         type: "track",
         id: "track1",
         routeToSource: true,
@@ -264,10 +264,10 @@ describe("duplicate - track duplication", () => {
       );
     });
 
-    it("should override withoutClips to true when routeToSource is true", () => {
+    it("should override withoutClips to true when routeToSource is true", async () => {
       setupRoutingMocks();
 
-      const result = duplicate({
+      const result = await duplicate({
         type: "track",
         id: "track1",
         routeToSource: true,
@@ -281,10 +281,10 @@ describe("duplicate - track duplication", () => {
       });
     });
 
-    it("should override withoutDevices to true when routeToSource is true", () => {
+    it("should override withoutDevices to true when routeToSource is true", async () => {
       setupRoutingMocks();
 
-      const result = duplicate({
+      const result = await duplicate({
         type: "track",
         id: "track1",
         routeToSource: true,
@@ -298,12 +298,12 @@ describe("duplicate - track duplication", () => {
       });
     });
 
-    it("should arm the source track when routeToSource is true", () => {
+    it("should arm the source track when routeToSource is true", async () => {
       const { sourceTrack } = setupRoutingMocks({
         inputRoutingName: "Audio In",
       });
 
-      duplicate({
+      await duplicate({
         type: "track",
         id: "track1",
         routeToSource: true,
@@ -313,7 +313,7 @@ describe("duplicate - track duplication", () => {
       expect(sourceTrack.set).toHaveBeenCalledWith("arm", 1);
     });
 
-    it("should not emit arm warning when source track is already armed", () => {
+    it("should not emit arm warning when source track is already armed", async () => {
       const { sourceTrack } = setupRoutingMocks({
         inputRoutingName: "Audio In",
         arm: 1,
@@ -321,7 +321,7 @@ describe("duplicate - track duplication", () => {
 
       vi.mocked(outlet).mockClear();
 
-      duplicate({
+      await duplicate({
         type: "track",
         id: "track1",
         routeToSource: true,
@@ -338,7 +338,7 @@ describe("duplicate - track duplication", () => {
     });
   });
 
-  it("should apply color when duplicating a track", () => {
+  it("should apply color when duplicating a track", async () => {
     registerMockObject("track1", { path: livePath.track(0) });
     registerMockObject("live_set", { path: livePath.liveSet });
     const newTrack = registerMockObject("live_set/tracks/1", {
@@ -346,7 +346,7 @@ describe("duplicate - track duplication", () => {
       properties: { devices: [], clip_slots: [], arrangement_clips: [] },
     });
 
-    const result = duplicate({
+    const result = await duplicate({
       type: "track",
       id: "track1",
       color: "#ff0000",

--- a/src/tools/operations/duplicate/tests/duplicate-validation.test.ts
+++ b/src/tools/operations/duplicate/tests/duplicate-validation.test.ts
@@ -10,75 +10,79 @@ import { registerMockObject } from "#src/tools/operations/duplicate/helpers/dupl
 import { mockNonExistentObjects } from "#src/test/mocks/mock-registry.ts";
 
 describe("duplicate - input validation", () => {
-  it("should throw an error when type is missing", () => {
-    expect(() =>
+  it("should throw an error when type is missing", async () => {
+    await expect(
       duplicate({ id: "some-id" } as { type: string; id: string }),
-    ).toThrow("duplicate failed: type is required");
+    ).rejects.toThrow("duplicate failed: type is required");
   });
 
-  it("should throw an error when id is missing", () => {
-    expect(() =>
+  it("should throw an error when id is missing", async () => {
+    await expect(
       duplicate({ type: "track" } as { type: string; id: string }),
-    ).toThrow("duplicate failed: id is required");
+    ).rejects.toThrow("duplicate failed: id is required");
   });
 
-  it("should throw an error when type is invalid", () => {
-    expect(() => duplicate({ type: "invalid", id: "some-id" })).toThrow(
+  it("should throw an error when type is invalid", async () => {
+    await expect(duplicate({ type: "invalid", id: "some-id" })).rejects.toThrow(
       "duplicate failed: type must be one of track, scene, clip",
     );
   });
 
-  it("should throw an error when count is less than 1", () => {
-    expect(() => duplicate({ type: "track", id: "some-id", count: 0 })).toThrow(
-      "duplicate failed: count must be at least 1",
-    );
+  it("should throw an error when count is less than 1", async () => {
+    await expect(
+      duplicate({ type: "track", id: "some-id", count: 0 }),
+    ).rejects.toThrow("duplicate failed: count must be at least 1");
   });
 
-  it("should throw an error when the object doesn't exist", () => {
+  it("should throw an error when the object doesn't exist", async () => {
     mockNonExistentObjects();
-    expect(() => duplicate({ type: "track", id: "nonexistent" })).toThrow(
-      'duplicate failed: id "nonexistent" does not exist',
-    );
+    await expect(
+      duplicate({ type: "track", id: "nonexistent" }),
+    ).rejects.toThrow('duplicate failed: id "nonexistent" does not exist');
   });
 
-  it("should throw an error when track has arrangement params", () => {
+  it("should throw an error when track has arrangement params", async () => {
     registerMockObject("track1", { path: livePath.track(0) });
-    expect(() =>
+    await expect(
       duplicate({
         type: "track",
         id: "track1",
         arrangementStart: "1|1|1",
       }),
-    ).toThrow("duplicate failed: tracks cannot be duplicated to arrangement");
+    ).rejects.toThrow(
+      "duplicate failed: tracks cannot be duplicated to arrangement",
+    );
   });
 
-  it("should allow type 'track' without arrangement params", () => {
+  it("should allow type 'track' without arrangement params", async () => {
     registerMockObject("track1", { path: livePath.track(0) });
-    expect(() => duplicate({ type: "track", id: "track1" })).not.toThrow();
+    await expect(
+      duplicate({ type: "track", id: "track1" }),
+    ).resolves.toBeDefined();
   });
 });
 
 describe("duplicate - clip session validation", () => {
-  it("should throw an error when toSlot is empty for session clip", () => {
+  it("should throw an error when toSlot is empty for session clip", async () => {
     registerMockObject("clip1", {
       path: livePath.track(0).clipSlot(0).clip(),
     });
 
-    expect(() =>
+    await expect(
       duplicate({
         type: "clip",
         id: "clip1",
         toSlot: "  ",
       }),
-    ).toThrow("duplicate failed: toSlot is required for session clips");
+    ).rejects.toThrow("duplicate failed: toSlot is required for session clips");
   });
 });
 
 describe("duplicate - return format", () => {
-  it("should return single object format when count=1", () => {
+  it("should return single object format when count=1", async () => {
     registerMockObject("track1", { path: livePath.track(0) });
 
-    const result = duplicate({ type: "track", id: "track1", count: 1 });
+    const result = await duplicate({ type: "track", id: "track1", count: 1 });
 
     expect(result).toStrictEqual({
       id: expect.any(String),
@@ -87,10 +91,10 @@ describe("duplicate - return format", () => {
     });
   });
 
-  it("should return objects array format when count>1", () => {
+  it("should return objects array format when count>1", async () => {
     registerMockObject("track1", { path: livePath.track(0) });
 
-    const result = duplicate({ type: "track", id: "track1", count: 2 });
+    const result = await duplicate({ type: "track", id: "track1", count: 2 });
 
     expect(result).toMatchObject([
       expect.objectContaining({ trackIndex: expect.any(Number) }),
@@ -100,13 +104,13 @@ describe("duplicate - return format", () => {
 });
 
 describe("duplicate - track/scene index validation", () => {
-  it("should throw when track index cannot be determined", () => {
+  it("should throw when track index cannot be determined", async () => {
     registerMockObject("track1", {
       path: "live_set some_other_path",
       type: "Track",
     });
 
-    expect(() => duplicate({ type: "track", id: "track1" })).toThrow(
+    await expect(duplicate({ type: "track", id: "track1" })).rejects.toThrow(
       'duplicate failed: no track index for id "track1"',
     );
   });
@@ -119,20 +123,20 @@ describe("duplicate - track/scene index validation", () => {
       });
     });
 
-    it("should throw for session duplication", () => {
-      expect(() => duplicate({ type: "scene", id: "scene1" })).toThrow(
+    it("should throw for session duplication", async () => {
+      await expect(duplicate({ type: "scene", id: "scene1" })).rejects.toThrow(
         'duplicate failed: no scene index for id "scene1"',
       );
     });
 
-    it("should throw for arrangement duplication", () => {
-      expect(() =>
+    it("should throw for arrangement duplication", async () => {
+      await expect(
         duplicate({
           type: "scene",
           id: "scene1",
           arrangementStart: "1|1",
         }),
-      ).toThrow('duplicate failed: no scene index for id "scene1"');
+      ).rejects.toThrow('duplicate failed: no scene index for id "scene1"');
     });
   });
 });

--- a/src/tools/operations/duplicate/tests/setup.ts
+++ b/src/tools/operations/duplicate/tests/setup.ts
@@ -12,8 +12,10 @@ interface MockTrack {
 
 /**
  * Mock implementation for updateClip that returns tiled clip array format.
+ * Async to match the real updateClip signature — a synchronous mock here
+ * previously hid a bug where the caller never awaited the real call (#279).
  */
-export const updateClipMock = vi.fn(({ ids }: { ids: string }) => [
+export const updateClipMock = vi.fn(async ({ ids }: { ids: string }) => [
   { id: ids },
 ]);
 


### PR DESCRIPTION
### **User description**
## Summary

Fixes #279. `adj-duplicate` returned `clips: []` whenever `arrangementLength` was longer than the source clip and the tool had to auto-tile/lengthen via `updateClip` — even though the tiles landed correctly in Live.

`updateClip` is `async`. The caller (`lengthenClipAndCollectInfo` in `duplicate-helpers.ts`) called it without `await`. An async function's body runs synchronously up to its first `await`, which is why Live ended up correct while the report came back empty — but the return value was a `Promise`, not an array: `Array.isArray(promise)` is `false`, so it got wrapped as `[promise]`, `clipObj.id` was `undefined`, and the id lookup against the track's arrangement clips never matched anything.

## Fix

Threaded `async`/`await` through the full call chain to `duplicate()`'s top level, for both affected paths (per the issue):
- clip-to-arrangement lengthening: `createClipsForLength` -> `lengthenClipAndCollectInfo` -> `updateClip`
- scene-to-arrangement lengthening: `duplicateSceneToArrangement`, same `createClipsForLength` call

No changes needed outside the `duplicate` module — `live-api-adapter.ts`'s tool dispatcher already does `await callTool(...)` generically for every tool, sync or async.

`forEachClipInScene` stays synchronous for its two unrelated callers (`duplicateScene`, `calculateSceneLength`): forcing it async would have broken them silently, since `await`ing even a non-promise value still defers a microtask, and neither of those callers awaits the outer call. Added `forEachClipInSceneAsync` for the one call site that actually needs to await per-clip work, rather than touching the two callers that don't.

## Why tests missed it

Per the issue: the shared `updateClip` mock in `tests/setup.ts`, and a second local mock in `duplicate-track-scene-helpers.test.ts`, both returned an array synchronously instead of a promise — so `Array.isArray(mockResult)` succeeded in tests where the real call failed. Both are now async to match the real signature.

## Test plan

- [x] `tests/setup.ts` and the local mock in `duplicate-track-scene-helpers.test.ts` are now async
- [x] New regression assertion in `duplicate-scene.test.ts` on the *returned* `clips` array for a scene clip lengthened via `updateClip` (previously only asserted on the exact-match clip, not the lengthened one — exactly the gap that hid this bug)
- [x] All 11 test files under `duplicate/` updated to `await duplicate(...)` and `.rejects.toThrow(...)` for the now-async top-level function; 146 tests pass
- [x] `npm run check` — full suite (3918 tests), lint, typecheck, format, duplication all clean


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Correctly await `updateClip` in `adj-duplicate`'s tiling paths.

- Ensure `adj-duplicate` returns all created clip IDs, even when auto-tiling.

- Refactor `forEachClipInScene` into synchronous and asynchronous variants.

- Update `updateClip` test mocks to be asynchronous, matching real behavior.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["duplicate()"] --> B["createClipsForLength()"];
  B --> C["lengthenClipAndCollectInfo()"];
  C -- "now awaits" --> D["updateClip()"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>duplicate.ts</strong><dd><code>Made main `duplicate` function and its dispatchers asynchronous</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-8210461e116477dcfe2b27c1868fc513a6b2eb64ca28c50d31017043df039b7f">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>duplicate-clip-position-helpers.ts</strong><dd><code>Made <code>duplicateClipWithPositions</code> asynchronous to await internal calls</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-c4c01d01ee1e7e5787a304ba64992e480df78caf07109d7e85a1aca0317094db">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>duplicate-track-scene-helpers.ts</strong><dd><code>Introduced <code>forEachClipInSceneAsync</code> and updated <br><code>duplicateSceneToArrangement</code> to use it</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-4652d280c7940b417850a992a9c540d42aa8dcd2260a2f31ce0a8947fdc9e437">+60/-23</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>duplicate-helpers.ts</strong><dd><code>Implemented core fix by awaiting <code>updateClip</code> and making related <br>functions asynchronous</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-ada4415f31727232f97658b51c4ad4b257fda7fbf2824599c1f2540d4f981006">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>duplicate-helpers.test.ts</strong><dd><code>Updated <code>duplicateClipToArrangement</code> tests to use <code>async</code>/<code>await</code> for error <br>handling</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-6a1365500d2080e4e9cef87b000494cc630597750299b9fe63eb7698edb97096">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>duplicate-track-scene-helpers.test.ts</strong><dd><code>Made <code>updateClip</code> mock asynchronous and added regression test for <br>returned clips</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-c9e589faa2b1df5d6fff0348bb8b1b8437c5cb440db254cbed17c3661af871b7">+20/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>duplicate-advanced-features.test.ts</strong><dd><code>Updated tests to use `async`/`await` for `duplicate` calls</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-6efc751552f7da98a07c48d51cf52815cee6f2b2b3f2113af82c7671f0016b69">+22/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>duplicate-arrangement-length.test.ts</strong><dd><code>Updated tests to use `async`/`await` for `duplicate` calls</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-7a31dba629332042bfe359ab43f30242ea4b666a479af0a9ed85d06d56a49a6e">+13/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>duplicate-clip.test.ts</strong><dd><code>Updated tests to use `async`/`await` for `duplicate` calls</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-475f0fb99d282ad60cdba01c8372c320d5b12e93abfaf46fe4bcdf98f35e28b5">+13/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>duplicate-device.test.ts</strong><dd><code>Updated tests to use `async`/`await` for `duplicate` calls</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-1d2c190e55a901a32c49ffd4a87c747c4716497435be2e60a7e53d38047b16c9">+30/-30</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>duplicate-locator.test.ts</strong><dd><code>Updated tests to use `async`/`await` for `duplicate` calls</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-f3f1ecb6bb229e976fc566b69ae4dc1e104d872438ce774289dd069fc980354b">+34/-28</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>duplicate-scene.test.ts</strong><dd><code>Updated tests to use <code>async</code>/<code>await</code> for <code>duplicate</code> calls and added <br>regression assertion</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-9fb9e45c258cd70d83527f12131e21c720769bfaf94ecf9098591b2b1d71c3cf">+39/-27</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>duplicate-track.test.ts</strong><dd><code>Updated tests to use `async`/`await` for `duplicate` calls</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-f4c1d53df625982297bf14ace5921fb0433210081d68ce31e2925f9b7d9bbf79">+33/-33</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>duplicate-validation.test.ts</strong><dd><code>Updated validation tests to use `async`/`await` for `duplicate` calls</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-06bfe7ba37045e5695e94c66e4880dda844c202c1c8fe2ab829eda80c2030889">+39/-35</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>setup.ts</strong><dd><code>Made <code>updateClipMock</code> asynchronous to accurately reflect real <code>updateClip</code> <br>behavior</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/287/files#diff-919a3d15708e51be29c1900c06852e59d47affa5492e25ad720edb63976169de">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

