### PR TITLE
feat: expose Compressor sidechain input routing

### DIFF
--- a/src/tools/device/read/read-device.def.ts
+++ b/src/tools/device/read/read-device.def.ts
@@ -24,19 +24,21 @@ export const toolDefReadDevice = defineTool("adj-read-device", {
     include: z
       .array(
         z.enum([
+          "available-routings",
           "chains",
           "drum-map",
           "drum-pads",
           "params",
           "param-values",
           "return-chains",
+          "routings",
           "sample",
           "*",
         ]),
       )
       .default([])
       .describe(
-        'chains, return-chains, drum-pads = rack contents (use maxDepth). params, param-values = parameters. drum-map = note names. sample = Simpler file. "*" = all',
+        'chains, return-chains, drum-pads = rack contents (use maxDepth). params, param-values = parameters. drum-map = note names. sample = Simpler file. routings, available-routings = Compressor sidechain input source (Compressor only). "*" = all',
       ),
     maxDepth: z.coerce
       .number()
@@ -55,10 +57,12 @@ export const toolDefReadDevice = defineTool("adj-read-device", {
   },
 
   smallModelModeConfig: {
-    excludeEnumValues: { include: ["drum-pads", "return-chains", "*"] },
+    excludeEnumValues: {
+      include: ["available-routings", "drum-pads", "return-chains", "*"],
+    },
     descriptionOverrides: {
       include:
-        "chains = rack contents (use maxDepth). params, param-values = parameters. drum-map = note names. sample = Simpler file",
+        "chains = rack contents (use maxDepth). params, param-values = parameters. drum-map = note names. sample = Simpler file. routings = Compressor sidechain input source (Compressor only)",
       maxDepth:
         "Device tree depth for chains. 0=chains only with deviceCount, 1=direct devices, 2+=deeper",
     },

--- a/src/tools/device/read/read-device.ts
+++ b/src/tools/device/read/read-device.ts
@@ -35,6 +35,8 @@ interface ReadOptions {
   includeParams: boolean;
   includeParamValues: boolean;
   includeSample: boolean;
+  includeRoutings: boolean;
+  includeAvailableRoutings: boolean;
   maxDepth: number;
   paramSearch?: string;
 }
@@ -64,6 +66,9 @@ export function readDevice(
   const includeParamValues = includeAll || include.includes("param-values");
   const includeParams = includeParamValues || include.includes("params");
   const includeSample = includeAll || include.includes("sample");
+  const includeRoutings = includeAll || include.includes("routings");
+  const includeAvailableRoutings =
+    includeAll || include.includes("available-routings");
 
   // Force chain processing internally when drum-map is requested (needed for getDrumMap)
   const chainsForDrumMap = includeDrumMap && !includeChains;
@@ -76,6 +81,8 @@ export function readDevice(
     includeParams,
     includeParamValues,
     includeSample,
+    includeRoutings,
+    includeAvailableRoutings,
     // drum-map needs depth >= 1 to detect instruments in drum pad chains
     maxDepth: includeDrumMap ? Math.max(1, maxDepth) : maxDepth,
     paramSearch,

--- a/src/tools/device/read/tests/read-device-sidechain-routing.test.ts
+++ b/src/tools/device/read/tests/read-device-sidechain-routing.test.ts
@@ -1,0 +1,119 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearMockRegistry,
+  registerMockObject,
+} from "#src/test/mocks/mock-registry.ts";
+import { readDevice } from "../read-device.ts";
+
+describe("readDevice - sidechain routing (#268, #93)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearMockRegistry();
+  });
+
+  it("includes current sidechain routing for a Compressor with routings", () => {
+    registerMockObject("comp-1", {
+      path: "id comp-1",
+      type: "CompressorDevice",
+      properties: {
+        class_display_name: "Compressor",
+        type: 2, // LIVE_API_DEVICE_TYPE_AUDIO_EFFECT
+        can_have_chains: 0,
+        can_have_drum_pads: 0,
+        is_active: 1,
+        input_routing_type: [
+          '{"input_routing_type": {"display_name": "Drums", "identifier": 3}}',
+        ],
+        input_routing_channel: [
+          '{"input_routing_channel": {"display_name": "Post FX", "identifier": 1}}',
+        ],
+      },
+    });
+
+    const result = readDevice({ deviceId: "comp-1", include: ["routings"] });
+
+    expect(result).toMatchObject({
+      sidechainInputRoutingType: { name: "Drums", id: "3" },
+      sidechainInputRoutingChannel: { name: "Post FX", id: "1" },
+    });
+  });
+
+  it("includes available sidechain routing options for a Compressor", () => {
+    registerMockObject("comp-2", {
+      path: "id comp-2",
+      type: "CompressorDevice",
+      properties: {
+        class_display_name: "Compressor",
+        type: 2,
+        can_have_chains: 0,
+        can_have_drum_pads: 0,
+        is_active: 1,
+        available_input_routing_types: [
+          '{"available_input_routing_types": [{"display_name": "Drums", "identifier": 3}, {"display_name": "Bass", "identifier": 4}]}',
+        ],
+        available_input_routing_channels: [
+          '{"available_input_routing_channels": [{"display_name": "Post FX", "identifier": 1}]}',
+        ],
+      },
+    });
+
+    const result = readDevice({
+      deviceId: "comp-2",
+      include: ["available-routings"],
+    });
+
+    expect(result).toMatchObject({
+      availableSidechainInputRoutingTypes: [
+        { name: "Drums", id: "3" },
+        { name: "Bass", id: "4" },
+      ],
+      availableSidechainInputRoutingChannels: [{ name: "Post FX", id: "1" }],
+    });
+  });
+
+  it("omits sidechain routing fields for non-Compressor devices", () => {
+    registerMockObject("plugin-1", {
+      path: "id plugin-1",
+      type: "PluginDevice",
+      properties: {
+        class_display_name: "Operator",
+        type: 1, // LIVE_API_DEVICE_TYPE_INSTRUMENT
+        can_have_chains: 0,
+        can_have_drum_pads: 0,
+        is_active: 1,
+        input_routing_type: { display_name: "Drums", identifier: 3 },
+      },
+    });
+
+    const result = readDevice({
+      deviceId: "plugin-1",
+      include: ["routings", "available-routings"],
+    });
+
+    expect(result).not.toHaveProperty("sidechainInputRoutingType");
+    expect(result).not.toHaveProperty("availableSidechainInputRoutingTypes");
+  });
+
+  it("omits sidechain routing fields when not requested, even for a Compressor", () => {
+    registerMockObject("comp-3", {
+      path: "id comp-3",
+      type: "CompressorDevice",
+      properties: {
+        class_display_name: "Compressor",
+        type: 2,
+        can_have_chains: 0,
+        can_have_drum_pads: 0,
+        is_active: 1,
+        input_routing_type: { display_name: "Drums", identifier: 3 },
+      },
+    });
+
+    const result = readDevice({ deviceId: "comp-3" });
+
+    expect(result).not.toHaveProperty("sidechainInputRoutingType");
+  });
+});

--- a/src/tools/device/update/helpers/update-device-helpers.ts
+++ b/src/tools/device/update/helpers/update-device-helpers.ts
@@ -5,8 +5,50 @@
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import { noteNameToMidi } from "#src/shared/pitch.ts";
 import * as console from "#src/shared/v8-max-console.ts";
+import {
+  applySidechainRouting,
+  isSidechainRoutableDevice,
+} from "#src/tools/shared/device/helpers/device-routing-helpers.ts";
 import { resolveInsertionPath } from "#src/tools/shared/device/helpers/path/device-path-helpers.ts";
 import { toLiveApiId } from "#src/tools/shared/utils.ts";
+import { warnIfSet } from "./update-device-type-helpers.ts";
+
+/**
+ * Apply sidechain input routing if the target supports it (Compressor
+ * only), otherwise warn that the parameters don't apply. Safe to call
+ * unconditionally for any device, chain, or drum pad target.
+ * @param target - Target to update
+ * @param type - Target's Live object type
+ * @param sidechainInputRoutingTypeId - Sidechain source track identifier
+ * @param sidechainInputRoutingChannelId - Sidechain source channel identifier
+ */
+export function applyOrWarnSidechainRouting(
+  target: LiveAPI,
+  type: string,
+  sidechainInputRoutingTypeId: string | undefined,
+  sidechainInputRoutingChannelId: string | undefined,
+): void {
+  if (!isSidechainRoutableDevice(type)) {
+    warnIfSet("sidechainInputRoutingTypeId", sidechainInputRoutingTypeId, type);
+    warnIfSet(
+      "sidechainInputRoutingChannelId",
+      sidechainInputRoutingChannelId,
+      type,
+    );
+
+    return;
+  }
+
+  if (
+    sidechainInputRoutingTypeId != null ||
+    sidechainInputRoutingChannelId != null
+  ) {
+    applySidechainRouting(target, {
+      sidechainInputRoutingTypeId,
+      sidechainInputRoutingChannelId,
+    });
+  }
+}
 
 // ============================================================================
 // Device move helpers

--- a/src/tools/device/update/helpers/update-device-target-resolution-helpers.ts
+++ b/src/tools/device/update/helpers/update-device-target-resolution-helpers.ts
@@ -1,0 +1,98 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { errorMessage } from "#src/shared/error-utils.ts";
+import * as console from "#src/shared/v8-max-console.ts";
+import {
+  resolveDrumPadFromPath,
+  resolvePathToLiveApi,
+} from "#src/tools/shared/device/helpers/path/device-path-helpers.ts";
+
+export interface ResolvedTarget {
+  target: LiveAPI;
+  isDrumPadPath?: boolean;
+}
+
+/**
+ * Resolve an ID to a LiveAPI target
+ * @param id - Object ID
+ * @returns Resolved target or null if not found
+ */
+export function resolveIdToTarget(id: string): ResolvedTarget | null {
+  const target = LiveAPI.from(id);
+
+  return target.exists() ? { target } : null;
+}
+
+/**
+ * Safely resolve a path to a Live API target, catching errors
+ * @param path - Device/chain/drum-pad path
+ * @returns Resolved target or null if not found or invalid
+ */
+export function resolvePathToTargetSafe(path: string): ResolvedTarget | null {
+  try {
+    return resolvePathToTarget(path);
+  } catch (e) {
+    console.warn(`updateDevice: ${errorMessage(e)}`);
+
+    return null;
+  }
+}
+
+/**
+ * Resolve a path to a Live API target (device, chain, or drum pad)
+ * @param path - Device/chain/drum-pad path
+ * @returns Resolved target or null if not found
+ */
+function resolvePathToTarget(path: string): ResolvedTarget | null {
+  const resolved = resolvePathToLiveApi(path);
+
+  switch (resolved.targetType) {
+    case "device": // fallthrough
+    case "chain": // fallthrough
+
+    case "return-chain": {
+      const target = resolveTargetFromPath(resolved.liveApiPath);
+
+      return target ? { target } : null;
+    }
+
+    case "drum-pad": {
+      // drumPadNote is guaranteed for drum-pad targetType
+      const drumPadNote = resolved.drumPadNote as string;
+      const { remainingSegments } = resolved;
+      const drumPadResult = resolveDrumPadFromPath(
+        resolved.liveApiPath,
+        drumPadNote,
+        remainingSegments,
+      );
+
+      if (!drumPadResult.target) {
+        return null;
+      }
+
+      // Detect if this is a drum pad path (no explicit chain index) vs chain path
+      // pC1 = pad path, pC1/c0 = chain path
+      const hasExplicitChainIndex =
+        remainingSegments.length > 0 &&
+        (remainingSegments[0] as string).startsWith("c");
+
+      return {
+        target: drumPadResult.target,
+        isDrumPadPath: !hasExplicitChainIndex,
+      };
+    }
+  }
+}
+
+/**
+ * Resolve device or chain target from Live API path
+ * @param liveApiPath - Live API canonical path
+ * @returns LiveAPI object or null if not found
+ */
+function resolveTargetFromPath(liveApiPath: string): LiveAPI | null {
+  const target = LiveAPI.from(liveApiPath);
+
+  return target.exists() ? target : null;
+}

--- a/src/tools/device/update/tests/update-device.test.ts
+++ b/src/tools/device/update/tests/update-device.test.ts
@@ -625,3 +625,124 @@ describe("updateDevice", () => {
 
   // Drum chain move tests are in update-device-drum-chain-move.test.js
 });
+
+describe("updateDevice - sidechain routing (#268, #93)", () => {
+  let compressor: RegisteredMockObject;
+  let plugin: RegisteredMockObject;
+
+  beforeEach(() => {
+    compressor = registerMockObject("comp-1", {
+      path: livePath.track(0).device(0),
+      type: "CompressorDevice",
+    });
+
+    plugin = registerMockObject("plugin-1", {
+      path: livePath.track(0).device(1),
+      type: "PluginDevice",
+    });
+  });
+
+  it("sets sidechain input routing type on a Compressor", () => {
+    const result = updateDevice({
+      ids: "comp-1",
+      sidechainInputRoutingTypeId: "3",
+    });
+
+    // setProperty for routing properties JSON-encodes onto .set()
+    expect(compressor.set).toHaveBeenCalledWith(
+      "input_routing_type",
+      JSON.stringify({ input_routing_type: { identifier: 3 } }),
+    );
+    expect(result).toStrictEqual({ id: "comp-1" });
+  });
+
+  it("sets sidechain input routing channel on a Compressor", () => {
+    updateDevice({
+      ids: "comp-1",
+      sidechainInputRoutingChannelId: "1",
+    });
+
+    expect(compressor.set).toHaveBeenCalledWith(
+      "input_routing_channel",
+      JSON.stringify({ input_routing_channel: { identifier: 1 } }),
+    );
+  });
+
+  it("sets both type and channel in one call", () => {
+    const result = updateDevice({
+      ids: "comp-1",
+      sidechainInputRoutingTypeId: "3",
+      sidechainInputRoutingChannelId: "1",
+    });
+
+    expect(compressor.set).toHaveBeenCalledWith(
+      "input_routing_type",
+      JSON.stringify({ input_routing_type: { identifier: 3 } }),
+    );
+    expect(compressor.set).toHaveBeenCalledWith(
+      "input_routing_channel",
+      JSON.stringify({ input_routing_channel: { identifier: 1 } }),
+    );
+    expect(result).toStrictEqual({ id: "comp-1" });
+  });
+
+  it("warns and does not write when target is not a Compressor", () => {
+    const result = updateDevice({
+      ids: "plugin-1",
+      sidechainInputRoutingTypeId: "3",
+    });
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "updateDevice: 'sidechainInputRoutingTypeId' not applicable to PluginDevice",
+    );
+    expect(plugin.set).not.toHaveBeenCalledWith(
+      "input_routing_type",
+      expect.anything(),
+    );
+    expect(result).toStrictEqual({ id: "plugin-1" });
+  });
+
+  it("warns for sidechainInputRoutingChannelId on non-Compressor devices", () => {
+    updateDevice({
+      ids: "plugin-1",
+      sidechainInputRoutingChannelId: "1",
+    });
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "updateDevice: 'sidechainInputRoutingChannelId' not applicable to PluginDevice",
+    );
+  });
+
+  it("does nothing when neither sidechain param is set", () => {
+    const result = updateDevice({
+      ids: "comp-1",
+      name: "My Compressor",
+    });
+
+    expect(compressor.set).toHaveBeenCalledWith("name", "My Compressor");
+    expect(result).toStrictEqual({ id: "comp-1" });
+  });
+
+  it("warns on chains too (never applicable)", () => {
+    const chain = registerMockObject("chain-1", {
+      path: livePath.track(0).device(0).chain(0),
+      type: "Chain",
+    });
+
+    updateDevice({
+      ids: "chain-1",
+      sidechainInputRoutingTypeId: "3",
+    });
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "updateDevice: 'sidechainInputRoutingTypeId' not applicable to Chain",
+    );
+    expect(chain.set).not.toHaveBeenCalledWith(
+      "input_routing_type",
+      expect.anything(),
+    );
+  });
+});

--- a/src/tools/device/update/update-device.def.ts
+++ b/src/tools/device/update/update-device.def.ts
@@ -91,6 +91,18 @@ export const toolDefUpdateDevice = defineTool("adj-update-device", {
       .string()
       .optional()
       .describe("output MIDI note e.g. 'C3' (drum chains only)"),
+    sidechainInputRoutingTypeId: z.coerce
+      .string()
+      .optional()
+      .describe(
+        "sidechain input source track identifier, from adj-read-device include=available-routings (Compressor only)",
+      ),
+    sidechainInputRoutingChannelId: z.coerce
+      .string()
+      .optional()
+      .describe(
+        "sidechain input channel identifier, from adj-read-device include=available-routings (Compressor only)",
+      ),
     wrapInRack: z
       .boolean()
       .optional()
@@ -105,6 +117,8 @@ export const toolDefUpdateDevice = defineTool("adj-update-device", {
       "abCompare",
       "chokeGroup",
       "mappedPitch",
+      "sidechainInputRoutingTypeId",
+      "sidechainInputRoutingChannelId",
       "wrapInRack",
     ],
     descriptionOverrides: {

--- a/src/tools/device/update/update-device.ts
+++ b/src/tools/device/update/update-device.ts
@@ -2,14 +2,9 @@
 // Copyright (C) 2026 Gabriel Pulga
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { errorMessage } from "#src/shared/error-utils.ts";
 import { noteNameToMidi } from "#src/shared/pitch.ts";
 import * as console from "#src/shared/v8-max-console.ts";
 import { select } from "#src/tools/control/select.ts";
-import {
-  resolveDrumPadFromPath,
-  resolvePathToLiveApi,
-} from "#src/tools/shared/device/helpers/path/device-path-helpers.ts";
 import {
   parseCommaSeparatedIds,
   unwrapSingleResult,
@@ -24,6 +19,7 @@ import {
   parseNames,
 } from "#src/tools/shared/validation/name-utils.ts";
 import {
+  applyOrWarnSidechainRouting,
   moveDeviceToPath,
   moveDrumChainToPath,
   setParamValues,
@@ -32,6 +28,11 @@ import {
   updateMacroCount,
   updateMacroVariation,
 } from "./helpers/update-device-helpers.ts";
+import {
+  type ResolvedTarget,
+  resolveIdToTarget,
+  resolvePathToTargetSafe,
+} from "./helpers/update-device-target-resolution-helpers.ts";
 import {
   isChainType,
   isDeviceType,
@@ -55,6 +56,8 @@ interface UpdateProperties {
   color?: string;
   chokeGroup?: number;
   mappedPitch?: string;
+  sidechainInputRoutingTypeId?: string;
+  sidechainInputRoutingChannelId?: string;
 }
 
 interface UpdateDeviceArgs extends UpdateProperties {
@@ -65,11 +68,6 @@ interface UpdateDeviceArgs extends UpdateProperties {
 }
 
 interface UpdateOptions extends UpdateProperties {
-  isDrumPadPath?: boolean;
-}
-
-interface ResolvedTarget {
-  target: LiveAPI;
   isDrumPadPath?: boolean;
 }
 
@@ -90,6 +88,8 @@ interface ResolvedTarget {
  * @param args.color - Color #RRGGBB (chains only)
  * @param args.chokeGroup - Choke group 0-16 (drum chains only)
  * @param args.mappedPitch - Output MIDI note (drum chains only)
+ * @param args.sidechainInputRoutingTypeId - Sidechain input source track identifier (Compressor only)
+ * @param args.sidechainInputRoutingChannelId - Sidechain input channel identifier (Compressor only)
  * @param args.wrapInRack - Wrap device(s) in a new rack
  * @param args.focus - Select the device and show device detail view
  * @param _context - Internal context object (unused)
@@ -111,6 +111,8 @@ export function updateDevice(
     color,
     chokeGroup,
     mappedPitch,
+    sidechainInputRoutingTypeId,
+    sidechainInputRoutingChannelId,
     wrapInRack,
     focus,
   }: UpdateDeviceArgs,
@@ -143,6 +145,8 @@ export function updateDevice(
       color,
       chokeGroup,
       mappedPitch,
+      sidechainInputRoutingTypeId,
+      sidechainInputRoutingChannelId,
     };
 
     result = updateMultipleTargets(
@@ -212,89 +216,6 @@ function updateMultipleTargets(
   }
 
   return unwrapSingleResult(results);
-}
-
-/**
- * Resolve an ID to a LiveAPI target
- * @param id - Object ID
- * @returns Resolved target or null if not found
- */
-function resolveIdToTarget(id: string): ResolvedTarget | null {
-  const target = LiveAPI.from(id);
-
-  return target.exists() ? { target } : null;
-}
-
-/**
- * Safely resolve a path to a Live API target, catching errors
- * @param path - Device/chain/drum-pad path
- * @returns Resolved target or null if not found or invalid
- */
-function resolvePathToTargetSafe(path: string): ResolvedTarget | null {
-  try {
-    return resolvePathToTarget(path);
-  } catch (e) {
-    console.warn(`updateDevice: ${errorMessage(e)}`);
-
-    return null;
-  }
-}
-
-/**
- * Resolve a path to a Live API target (device, chain, or drum pad)
- * @param path - Device/chain/drum-pad path
- * @returns Resolved target or null if not found
- */
-function resolvePathToTarget(path: string): ResolvedTarget | null {
-  const resolved = resolvePathToLiveApi(path);
-
-  switch (resolved.targetType) {
-    case "device": // fallthrough
-    case "chain": // fallthrough
-
-    case "return-chain": {
-      const target = resolveTargetFromPath(resolved.liveApiPath);
-
-      return target ? { target } : null;
-    }
-
-    case "drum-pad": {
-      // drumPadNote is guaranteed for drum-pad targetType
-      const drumPadNote = resolved.drumPadNote as string;
-      const { remainingSegments } = resolved;
-      const drumPadResult = resolveDrumPadFromPath(
-        resolved.liveApiPath,
-        drumPadNote,
-        remainingSegments,
-      );
-
-      if (!drumPadResult.target) {
-        return null;
-      }
-
-      // Detect if this is a drum pad path (no explicit chain index) vs chain path
-      // pC1 = pad path, pC1/c0 = chain path
-      const hasExplicitChainIndex =
-        remainingSegments.length > 0 &&
-        (remainingSegments[0] as string).startsWith("c");
-
-      return {
-        target: drumPadResult.target,
-        isDrumPadPath: !hasExplicitChainIndex,
-      };
-    }
-  }
-}
-
-/**
- * Resolve device or chain target from Live API path
- * @param liveApiPath - Live API canonical path
- * @returns LiveAPI object or null if not found
- */
-function resolveTargetFromPath(liveApiPath: string): LiveAPI | null {
-  const target = LiveAPI.from(liveApiPath);
-
-  return target.exists() ? target : null;
 }
 
 /**
@@ -371,6 +292,8 @@ function updateDeviceProperties(
     color,
     chokeGroup,
     mappedPitch,
+    sidechainInputRoutingTypeId,
+    sidechainInputRoutingChannelId,
   } = options;
 
   // collapsed — kept for potential future use
@@ -401,6 +324,14 @@ function updateDeviceProperties(
     warnIfSet("macroCount", macroCount, type);
   }
 
+  // Compressor-only: sidechain input routing
+  applyOrWarnSidechainRouting(
+    target,
+    type,
+    sidechainInputRoutingTypeId,
+    sidechainInputRoutingChannelId,
+  );
+
   // Warn for non-device properties on devices
   warnIfSet("mute", mute, type);
   warnIfSet("solo", solo, type);
@@ -426,6 +357,13 @@ function updateNonDeviceProperties(
   warnIfSet("macroVariationIndex", options.macroVariationIndex, type);
   warnIfSet("macroCount", options.macroCount, type);
   warnIfSet("abCompare", options.abCompare, type);
+  // Never applicable here (Chain/DrumPad types), always warns
+  applyOrWarnSidechainRouting(
+    target,
+    type,
+    options.sidechainInputRoutingTypeId,
+    options.sidechainInputRoutingChannelId,
+  );
 
   // Mute/solo work on Chain, DrumChain, DrumPad
   if (options.mute != null) {

--- a/src/tools/shared/device/device-reader.ts
+++ b/src/tools/shared/device/device-reader.ts
@@ -19,6 +19,7 @@ import {
   readDeviceParameters,
   readMacroVariations,
 } from "./helpers/device-reader-helpers.ts";
+import { readSidechainRouting } from "./helpers/device-routing-helpers.ts";
 import { extractDevicePath } from "./helpers/path/device-path-helpers.ts";
 
 export interface ReadDeviceOptions {
@@ -28,6 +29,8 @@ export interface ReadDeviceOptions {
   includeParams?: boolean;
   includeParamValues?: boolean;
   includeSample?: boolean;
+  includeRoutings?: boolean;
+  includeAvailableRoutings?: boolean;
   paramSearch?: string;
   depth?: number;
   maxDepth?: number;
@@ -198,6 +201,8 @@ export function readDevice(
     includeParams = false,
     includeParamValues = false,
     includeSample = false,
+    includeRoutings = false,
+    includeAvailableRoutings = false,
     paramSearch,
     depth = 0,
     maxDepth = 4,
@@ -212,26 +217,9 @@ export function readDevice(
 
   const deviceType = getDeviceType(device);
   const className = device.getProperty("class_display_name") as string;
-  const userDisplayName = device.getProperty("name") as string;
-  const isRedundant = isRedundantDeviceClassName(deviceType, className);
   // Use parentPath if provided (for devices inside drum pads), otherwise extract from Live API path
   const path = parentPath ?? extractDevicePath(device.path);
-
-  const deviceInfo: Record<string, unknown> = {
-    id: device.id,
-    ...(path && { path }),
-    type: isRedundant ? deviceType : `${deviceType}: ${className}`,
-  };
-
-  if (userDisplayName !== className) {
-    deviceInfo.name = userDisplayName;
-  }
-
-  const isActive = (device.getProperty("is_active") as number) > 0;
-
-  if (!isActive) {
-    deviceInfo.deactivated = true;
-  }
+  const deviceInfo = buildBaseDeviceInfo(device, deviceType, className, path);
 
   // collapsed — kept for potential future use
   // const deviceView = LiveAPI.from(`${device.path} view`);
@@ -254,6 +242,16 @@ export function readDevice(
     Object.assign(deviceInfo, readSimplerSample(device, className));
   }
 
+  // Add Compressor sidechain routing (spreads empty object otherwise)
+  Object.assign(
+    deviceInfo,
+    readRequestedSidechainRouting(
+      device,
+      includeRoutings,
+      includeAvailableRoutings,
+    ),
+  );
+
   // Process chains for rack devices
   processDeviceChains(device, deviceInfo, deviceType, {
     includeChains,
@@ -273,6 +271,64 @@ export function readDevice(
   }
 
   return deviceInfo;
+}
+
+/**
+ * Build the core id/path/type/name/deactivated fields for a device info object.
+ * @param device - Live API device object
+ * @param deviceType - Combined device type string
+ * @param className - Device class display name
+ * @param path - Simplified device path, or undefined
+ * @returns Device info object with core fields populated
+ */
+function buildBaseDeviceInfo(
+  device: LiveAPI,
+  deviceType: string,
+  className: string,
+  path: string | null | undefined,
+): Record<string, unknown> {
+  const isRedundant = isRedundantDeviceClassName(deviceType, className);
+  const userDisplayName = device.getProperty("name") as string;
+
+  const deviceInfo: Record<string, unknown> = {
+    id: device.id,
+    ...(path && { path }),
+    type: isRedundant ? deviceType : `${deviceType}: ${className}`,
+  };
+
+  if (userDisplayName !== className) {
+    deviceInfo.name = userDisplayName;
+  }
+
+  const isActive = (device.getProperty("is_active") as number) > 0;
+
+  if (!isActive) {
+    deviceInfo.deactivated = true;
+  }
+
+  return deviceInfo;
+}
+
+/**
+ * Read Compressor sidechain routing if requested.
+ * @param device - Live API device object
+ * @param includeRoutings - Whether to include current routing selection
+ * @param includeAvailableRoutings - Whether to include available routing options
+ * @returns Sidechain routing fields, or an empty object if neither requested or not applicable
+ */
+function readRequestedSidechainRouting(
+  device: LiveAPI,
+  includeRoutings: boolean,
+  includeAvailableRoutings: boolean,
+): Record<string, unknown> {
+  if (!includeRoutings && !includeAvailableRoutings) {
+    return {};
+  }
+
+  return readSidechainRouting(device, {
+    includeCurrent: includeRoutings,
+    includeAvailable: includeAvailableRoutings,
+  });
 }
 
 /**

--- a/src/tools/shared/device/helpers/device-routing-helpers.ts
+++ b/src/tools/shared/device/helpers/device-routing-helpers.ts
@@ -1,0 +1,116 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+const COMPRESSOR_DEVICE_TYPE = "CompressorDevice";
+
+interface RoutingInfo {
+  display_name: string;
+  identifier: string | number;
+}
+
+interface RoutingRef {
+  name: string;
+  id: string;
+}
+
+export interface SidechainRoutingReadOptions {
+  includeCurrent: boolean;
+  includeAvailable: boolean;
+}
+
+export interface SidechainRoutingWriteParams {
+  sidechainInputRoutingTypeId?: string;
+  sidechainInputRoutingChannelId?: string;
+}
+
+/**
+ * Check if a device type supports sidechain input routing. Only the
+ * standard Compressor exposes this in the Live Object Model — Gate and
+ * Glue Compressor have no dedicated LOM subclass for it.
+ * @param type - Device type (LiveAPI's `.type` accessor, e.g. "CompressorDevice")
+ * @returns True if the device supports sidechain input routing
+ */
+export function isSidechainRoutableDevice(type: string): boolean {
+  return type === COMPRESSOR_DEVICE_TYPE;
+}
+
+/**
+ * Read a Compressor's sidechain input routing (current selection and/or
+ * available options). No-op for any other device type.
+ * @param device - Device to read
+ * @param options - Which parts to include
+ * @returns Sidechain routing fields, or an empty object if not applicable
+ */
+export function readSidechainRouting(
+  device: LiveAPI,
+  options: SidechainRoutingReadOptions,
+): Record<string, unknown> {
+  if (!isSidechainRoutableDevice(device.type)) return {};
+
+  const result: Record<string, unknown> = {};
+
+  if (options.includeCurrent) {
+    const type = device.getProperty("input_routing_type") as RoutingInfo | null;
+    const channel = device.getProperty(
+      "input_routing_channel",
+    ) as RoutingInfo | null;
+
+    result.sidechainInputRoutingType = toRoutingRef(type);
+    result.sidechainInputRoutingChannel = toRoutingRef(channel);
+  }
+
+  if (options.includeAvailable) {
+    const types = (device.getProperty("available_input_routing_types") ??
+      []) as RoutingInfo[];
+    const channels = (device.getProperty("available_input_routing_channels") ??
+      []) as RoutingInfo[];
+
+    result.availableSidechainInputRoutingTypes = types.map(toRoutingRefStrict);
+    result.availableSidechainInputRoutingChannels =
+      channels.map(toRoutingRefStrict);
+  }
+
+  return result;
+}
+
+/**
+ * Apply sidechain input routing to a Compressor device.
+ * @param device - Compressor device to update
+ * @param params - Routing identifiers (from readSidechainRouting's
+ *   available-routing lists)
+ */
+export function applySidechainRouting(
+  device: LiveAPI,
+  params: SidechainRoutingWriteParams,
+): void {
+  if (params.sidechainInputRoutingTypeId != null) {
+    device.setProperty("input_routing_type", {
+      identifier: Number(params.sidechainInputRoutingTypeId),
+    });
+  }
+
+  if (params.sidechainInputRoutingChannelId != null) {
+    device.setProperty("input_routing_channel", {
+      identifier: Number(params.sidechainInputRoutingChannelId),
+    });
+  }
+}
+
+/**
+ * Convert a raw Live API routing dict to a name/id ref, or null.
+ * @param routing - Raw routing property value
+ * @returns Simplified ref, or null when absent
+ */
+function toRoutingRef(routing: RoutingInfo | null): RoutingRef | null {
+  return routing ? toRoutingRefStrict(routing) : null;
+}
+
+/**
+ * Convert a raw Live API routing dict to a name/id ref.
+ * @param routing - Raw routing property value
+ * @returns Simplified ref
+ */
+function toRoutingRefStrict(routing: RoutingInfo): RoutingRef {
+  return { name: routing.display_name, id: String(routing.identifier) };
+}

--- a/src/tools/shared/device/helpers/tests/device-routing-helpers.test.ts
+++ b/src/tools/shared/device/helpers/tests/device-routing-helpers.test.ts
@@ -1,0 +1,186 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  applySidechainRouting,
+  isSidechainRoutableDevice,
+  readSidechainRouting,
+} from "../device-routing-helpers.ts";
+
+interface MockRoutingInfo {
+  display_name: string;
+  identifier: string | number;
+}
+
+/**
+ * Build a minimal mock device with a fixed type and property map.
+ * @param type - Device type (LiveAPI's `.type` accessor)
+ * @param properties - Property values returned by getProperty
+ * @returns Mock LiveAPI-shaped device
+ */
+function mockDevice(type: string, properties: Record<string, unknown> = {}) {
+  return {
+    type,
+    getProperty: vi.fn((prop: string) => properties[prop] ?? null),
+    setProperty: vi.fn(),
+  };
+}
+
+describe("isSidechainRoutableDevice", () => {
+  it("returns true for CompressorDevice", () => {
+    expect(isSidechainRoutableDevice("CompressorDevice")).toBe(true);
+  });
+
+  it("returns false for Gate-like or other device types", () => {
+    // Gate and Glue Compressor have no dedicated LOM subclass for sidechain
+    // routing, so they fall through as plain "PluginDevice" or similar —
+    // never "CompressorDevice" (see #268/#93).
+    expect(isSidechainRoutableDevice("PluginDevice")).toBe(false);
+    expect(isSidechainRoutableDevice("RackDevice")).toBe(false);
+    expect(isSidechainRoutableDevice("Chain")).toBe(false);
+    expect(isSidechainRoutableDevice("DrumPad")).toBe(false);
+  });
+});
+
+describe("readSidechainRouting", () => {
+  it("returns empty object for non-Compressor devices", () => {
+    const device = mockDevice("PluginDevice", {
+      input_routing_type: { display_name: "Drums", identifier: 3 },
+    });
+
+    const result = readSidechainRouting(device as unknown as LiveAPI, {
+      includeCurrent: true,
+      includeAvailable: true,
+    });
+
+    expect(result).toStrictEqual({});
+    expect(device.getProperty).not.toHaveBeenCalled();
+  });
+
+  it("reads current routing selection for a Compressor", () => {
+    const type: MockRoutingInfo = { display_name: "Drums", identifier: 3 };
+    const channel: MockRoutingInfo = { display_name: "Post FX", identifier: 1 };
+    const device = mockDevice("CompressorDevice", {
+      input_routing_type: type,
+      input_routing_channel: channel,
+    });
+
+    const result = readSidechainRouting(device as unknown as LiveAPI, {
+      includeCurrent: true,
+      includeAvailable: false,
+    });
+
+    expect(result).toStrictEqual({
+      sidechainInputRoutingType: { name: "Drums", id: "3" },
+      sidechainInputRoutingChannel: { name: "Post FX", id: "1" },
+    });
+  });
+
+  it("returns null current routing fields when unset", () => {
+    const device = mockDevice("CompressorDevice", {});
+
+    const result = readSidechainRouting(device as unknown as LiveAPI, {
+      includeCurrent: true,
+      includeAvailable: false,
+    });
+
+    expect(result).toStrictEqual({
+      sidechainInputRoutingType: null,
+      sidechainInputRoutingChannel: null,
+    });
+  });
+
+  it("reads available routing options for a Compressor", () => {
+    const device = mockDevice("CompressorDevice", {
+      available_input_routing_types: [
+        { display_name: "Drums", identifier: 3 },
+        { display_name: "Bass", identifier: 4 },
+      ],
+      available_input_routing_channels: [
+        { display_name: "Post FX", identifier: 1 },
+        { display_name: "Pre FX", identifier: 2 },
+      ],
+    });
+
+    const result = readSidechainRouting(device as unknown as LiveAPI, {
+      includeCurrent: false,
+      includeAvailable: true,
+    });
+
+    expect(result).toStrictEqual({
+      availableSidechainInputRoutingTypes: [
+        { name: "Drums", id: "3" },
+        { name: "Bass", id: "4" },
+      ],
+      availableSidechainInputRoutingChannels: [
+        { name: "Post FX", id: "1" },
+        { name: "Pre FX", id: "2" },
+      ],
+    });
+  });
+
+  it("defaults available routing lists to empty arrays when unset", () => {
+    const device = mockDevice("CompressorDevice", {});
+
+    const result = readSidechainRouting(device as unknown as LiveAPI, {
+      includeCurrent: false,
+      includeAvailable: true,
+    });
+
+    expect(result).toStrictEqual({
+      availableSidechainInputRoutingTypes: [],
+      availableSidechainInputRoutingChannels: [],
+    });
+  });
+});
+
+describe("applySidechainRouting", () => {
+  it("writes the type identifier as a number", () => {
+    const device = mockDevice("CompressorDevice");
+
+    applySidechainRouting(device as unknown as LiveAPI, {
+      sidechainInputRoutingTypeId: "3",
+    });
+
+    expect(device.setProperty).toHaveBeenCalledWith("input_routing_type", {
+      identifier: 3,
+    });
+    expect(device.setProperty).not.toHaveBeenCalledWith(
+      "input_routing_channel",
+      expect.anything(),
+    );
+  });
+
+  it("writes the channel identifier as a number", () => {
+    const device = mockDevice("CompressorDevice");
+
+    applySidechainRouting(device as unknown as LiveAPI, {
+      sidechainInputRoutingChannelId: "1",
+    });
+
+    expect(device.setProperty).toHaveBeenCalledWith("input_routing_channel", {
+      identifier: 1,
+    });
+  });
+
+  it("writes both when both are provided", () => {
+    const device = mockDevice("CompressorDevice");
+
+    applySidechainRouting(device as unknown as LiveAPI, {
+      sidechainInputRoutingTypeId: "3",
+      sidechainInputRoutingChannelId: "1",
+    });
+
+    expect(device.setProperty).toHaveBeenCalledTimes(2);
+  });
+
+  it("writes nothing when neither is provided", () => {
+    const device = mockDevice("CompressorDevice");
+
+    applySidechainRouting(device as unknown as LiveAPI, {});
+
+    expect(device.setProperty).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### **User description**
## Summary

Closes #268, closes #93 (duplicates — same feature request from two production sessions).

`adj-update-device` could configure every Compressor sidechain parameter (`S/C On`, threshold, ratio, EQ...) except the one thing that makes sidechain compression actually work: which track feeds the sidechain input. That routing lives outside the automatable parameter list (`adj-read-device --include param-values`), so the AI could build a fully-configured compressor that does nothing, and the user had to finish the job by hand in Live's UI.

## Investigation

#93 claimed `Device.available_input_routing_types` existed generically on Live's Device class. Checked the actual Cycling74 LOM docs before touching code:

- The generic `Device` class has **no** routing properties (confirmed by fetching `docs.cycling74.com/apiref/lom/device/` directly).
- There's a **dedicated `CompressorDevice` subclass** with exactly this: `input_routing_type`, `input_routing_channel` (read/write, `getsetobserve`) and `available_input_routing_types`, `available_input_routing_channels` (read-only) — same `{display_name, identifier}` shape this codebase's adapter already handles generically for Track routing.
- This is documented on the Max-facing docs tree (same place Track routing lives), not the Python-only surface that trips up things like clip automation envelopes.
- **No other device gets a dedicated LOM subclass for this** — Gate and Glue Compressor have no `GateDevice`/`GlueCompressorDevice` class, so this is Compressor-only. Verified live: a Gate device reports `.type === "Device"` (generic), not a specialized class.

## What

- `adj-read-device` gains `include=routings` (current selection) / `available-routings` (options list) — split the same way Track routing already is, since the available list is one entry per track in the project.
- `adj-update-device` gains `sidechainInputRoutingTypeId` / `sidechainInputRoutingChannelId` — ids sourced from the `available-routings` read, matching the existing `inputRoutingTypeId` pattern on `adj-update-track`.
- Applies only to devices where `.type === "CompressorDevice"`; every other device/chain/drum-pad type gets the existing `warnIfSet` "not applicable" warning instead of a silent no-op.

## Verification

Ran the full flow against a real Compressor in Ableton Live 12.4.3 (not just mocks):

```
adj-create-device deviceName="Compressor" path=t5
adj-read-device <id> include=available-routings
  -> real project tracks listed, e.g. {name:"TEMP-268-source", id:"2"}
adj-update-device <id> sidechainInputRoutingTypeId=2
adj-read-device <id> include=routings
  -> sidechainInputRoutingType: {name:"TEMP-268-source", id:"2"}   (write confirmed)

adj-create-device deviceName="Gate" path=t5
adj-update-device <gate-id> sidechainInputRoutingTypeId=2
  -> WARNING: updateDevice: 'sidechainInputRoutingTypeId' not applicable to Device
```

- [x] `npm run check` — 3940 tests, lint/typecheck/format/duplication clean
- [x] New unit tests: `device-routing-helpers.test.ts` (shared helper), `read-device-sidechain-routing.test.ts`, and a new describe block in `update-device.test.ts`
- [x] Verified live in Ableton Live 12.4.3 (see above)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Expose Compressor sidechain input routing via `adj-read-device`.

- Allow setting Compressor sidechain input routing via `adj-update-device`.

- Warn if sidechain routing parameters are used on non-Compressor devices.

- Refactor device target resolution into a dedicated helper module.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["adj-read-device"] -- "include=routings/available-routings" --> B{CompressorDevice};
  C["adj-update-device"] -- "sidechainInputRoutingTypeId/ChannelId" --> B;
  B -- "reads/writes sidechain routing" --> D[Ableton Live LOM];
  E[Other Devices/Chains] -- "warns if sidechain params used" --> C;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>read-device.def.ts</strong><dd><code>Extends `adj-read-device` schema to support sidechain routing.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/288/files#diff-846194a00b160395c2e4b8dfba7d3db14ce0a3f8801646882e781f553a90c936">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-device.def.ts</strong><dd><code>Extends `adj-update-device` schema for sidechain routing.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/288/files#diff-f203ed674b60234cb28994e6835256730fd9865805526c0498acbb4ca9ad9574">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>read-device.ts</strong><dd><code>Implements parsing for new sidechain routing `include` options.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/288/files#diff-1a794696b44d76c2c14ba276fd5c40fee0d5f21b3d19cac80e3df8d511ee8c0b">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-device-helpers.ts</strong><dd><code>Introduces helper for applying or warning about sidechain routing.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/288/files#diff-1ffb2b170a6f7184cbc59888c368c0f09ed920ea9d3480fb82a4bd9894c6455c">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>update-device.ts</strong><dd><code>Integrates sidechain routing parameters and refactored target </code><br><code>resolution.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/288/files#diff-fb2e647b8951b38ac8165c9e429509a73cc7e6fc0b06dd7e939a2a71699a409f">+31/-93</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>device-reader.ts</strong><dd><code>Integrates sidechain routing reading and refactors base device info.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/288/files#diff-67764a81d7e1cb93b6237886b80007dc6388f0449537498e0672c2bec67cc73d">+74/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>device-routing-helpers.ts</strong><dd><code>Adds helpers for reading, writing, and checking Compressor sidechain </code><br><code>routing.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/288/files#diff-ea4a0eecd15f0f6415914b6e76af65618a1cf84be0949b642b6cd78eb3d113d5">+116/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>read-device-sidechain-routing.test.ts</strong><dd><code>Adds unit tests for Compressor sidechain routing in <code>adj-read-device</code>.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/288/files#diff-1a9433e1819a728f5af78fab1b0a5efff51871cd4eda3f7364cd597fe373fd16">+119/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>update-device.test.ts</strong><dd><code>Adds unit tests for Compressor sidechain routing in <code>adj-update-device</code>.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/288/files#diff-887a7ec809391830073965c72ae141b0860c19dab9755e08cbb17175daeeab47">+121/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>device-routing-helpers.test.ts</strong><dd><code>Adds unit tests for sidechain routing helper functions.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/288/files#diff-f382c52d5a4e44f6177787a064934f4c939a2976baf8e192f5ee3a8a51ba20c7">+186/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>update-device-target-resolution-helpers.ts</strong><dd><code>Refactors device target resolution into a dedicated helper file.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/288/files#diff-43e7b4d389f01ca4ec110a70a85e4b3e4d3e6839682a499cbacd6904371404bf">+98/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

