### PR TITLE
docs: fix stale dev-tool commands and create-device path example

### DIFF
--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -181,7 +181,8 @@ Read device parameters and chain structure.
 Load a device onto a track by name, or by browser URI (via the bridge).
 
 - `deviceName` — Ableton native device name (see `src/tools/constants.ts`)
-- `path` — `"trackIndex/deviceIndex"` where to insert
+- `path` — insertion path, e.g. `"t0"`, `"t0/d1"`, `"t0/d0/c0"` (`t`=track,
+  `d`=device, `c`=chain — bare `"trackIndex/deviceIndex"` is rejected)
 - `browserUri` — load the exact item from `adj-browse` (e.g., a specific preset
   or User Library file). Pair with `deviceName: "Drum Rack"` to insert a rack
   and load a kit into it in one call. Requires the Live Browser Bridge — install

--- a/docs/contributing/Development-Tools.md
+++ b/docs/contributing/Development-Tools.md
@@ -44,7 +44,10 @@ update state in Ableton Live.
 
 ## Raw Live API Tool
 
-Available only in debug builds (`npm run build:debug` or `npm run dev:debug`).
+Available only when built with the raw API flag enabled:
+`ENABLE_RAW_LIVE_API=true npm run build` (there is no `build:debug` /
+`dev:debug` script — the flag is a build-time env var read by
+`config/rollup.config.mjs`).
 
 ### Purpose
 
@@ -183,9 +186,9 @@ node scripts/adj-client.ts tools/call adj-read-live-set '{}'
 ### Full Validation
 
 ```bash
-# Clean build
-npm run clean
-npm run build:debug
+# Clean build (raw Live API tool enabled — there is no `npm run clean` script)
+rm -rf dist
+ENABLE_RAW_LIVE_API=true npm run build
 
 # Run all tests with coverage
 npm run test:coverage

--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -69,6 +69,10 @@ subdirs (see `HOW-TO-WRITE.md`).
   [src/tools/clip/automate/**, src/tools/operations/duplicate/**] — envelopes
   written on a session clip survive adj-duplicate to arrangement; only path to
   arrangement automation (write → dup → clear source)
+- [clip-groove-write-no-op](dev/device/clip-groove-write-no-op.md)
+  [src/tools/clip/update/**, live_browser_bridge/**] — Clip.groove is a child
+  object reference; generic set_property reports success but doesn't actually
+  assign it, check the Python bridge before building on this
 - [drum-kit-uri-loads-full-rack](dev/device/drum-kit-uri-loads-full-rack.md)
   [src/tools/device/create/**, src/mcp-server/bridge-dispatcher.ts,
   live_browser_bridge/BrowserBridge.py] — load_item on a kit URI creates a

--- a/docs/findings/dev/device/clip-groove-write-no-op.md
+++ b/docs/findings/dev/device/clip-groove-write-no-op.md
@@ -1,0 +1,31 @@
+---
+title: clip-groove-write-no-op
+domain: dev
+validated: 2026-08-08
+evidence:
+  adj-raw-live-api probe against Live 12.4.3, branch
+  gabriel/feat-268-compressor-sidechain-routing@651bdd48
+---
+
+## Fact
+
+`Clip.groove` is a `child` object reference in the LOM (`type Groove`), not a
+plain settable property. Generic `set_property("groove", <id>)` via the M4L JS
+`LiveAPI` binding reports success but does not actually assign the groove.
+
+## Evidence
+
+`adj-raw-live-api` on a real session clip:
+`{type:"set", property:"groove", value:57}` (57 = a real Groove's id from
+`live_set groove_pool grooves 0`) returned `result: 1`. Immediate readback
+`{type:"get", property:"groove"}` returned `["id", 20]` — id 20 was an unrelated
+device object elsewhere in the set, not the target Groove. No working assignment
+path found on the JS surface.
+
+## Apply when
+
+Building any feature that applies a GroovePool template to a clip. Don't rely on
+`set`/`set_property` on `groove` via M4L JS — check whether the Python
+remote-script bridge (`live_browser_bridge/`) supports real attribute assignment
+first, the same way it already does for clip automation envelopes
+(`docs/findings/dev/device/clip-envelope-api-python-only.md`).


### PR DESCRIPTION
### **User description**
## Summary

Three small doc bugs found while live-probing the Live Object Model for a capability reference:

- `Development-Tools.md` references `npm run build:debug`, `npm run dev:debug`, and `npm run clean` — none of these scripts exist in `package.json`. The real invocation for the raw Live API tool is `ENABLE_RAW_LIVE_API=true npm run build` (build-time env var, read by `config/rollup.config.mjs`).
- `Tools-Reference.md` documents `adj-create-device`'s `path` param as bare `"trackIndex/deviceIndex"` — the actual schema (`create-device.def.ts`) requires `t`/`d`-prefixed segments like `"t0/d1"`. Bare numeric paths error with `Invalid track segment: 1`.
- Logs a new finding: `Clip.groove` is a `child` object reference in the LOM, not a settable property. Generic `set_property("groove", <id>)` via the M4L JS `LiveAPI` reports success but doesn't actually assign it — readback resolves to an unrelated object. Relevant if anyone builds a per-clip groove-template feature later; check the Python bridge first.

No source code changed — docs and one new finding file only.

## Test plan

- [x] `npm run format` — clean
- [x] `eslint --config config/eslint.config.js` (direct, `npm run lint` had an unrelated local wrapper issue) — clean
- [x] Grepped `docs/` for other copies of the stale `trackIndex/deviceIndex` wording — none found


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Correct `adj-create-device` path parameter format.

- Update Raw Live API tool build commands.

- Document `Clip.groove` as non-settable property.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Tools-Reference.md</strong><dd><code>Clarify `adj-create-device` path parameter format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/Tools-Reference.md

<ul><li>Updated the <code>path</code> parameter description for <code>adj-create-device</code>.<br> <li> Clarified that <code>path</code> requires <code>t</code>/<code>d</code>/<code>c</code> prefixes (e.g., <code>"t0/d1"</code>).<br> <li> Noted that bare numeric paths like <code>"trackIndex/deviceIndex"</code> are <br>rejected.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/289/files#diff-1144a39ffd998b6c8832a8e6e38fae79a98231f8e64046307c61134a0b297194">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Development-Tools.md</strong><dd><code>Update Raw Live API tool build commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/contributing/Development-Tools.md

<ul><li>Corrected the command to enable the Raw Live API tool.<br> <li> Replaced non-existent <code>build:debug</code> and <code>dev:debug</code> scripts with <br><code>ENABLE_RAW_LIVE_API=true npm run build</code>.<br> <li> Replaced <code>npm run clean</code> with <code>rm -rf dist</code> for a clean build.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/289/files#diff-eabef4b17c2dbc7c7890c039841db84865b1df6ebfb7db6ea41352d559d50ff0">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>INDEX.md</strong><dd><code>Index new `clip-groove-write-no-op` finding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/INDEX.md

<ul><li>Added a new entry for <code>clip-groove-write-no-op.md</code> to the findings <br>index.<br> <li> Included a brief description of the finding.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/289/files#diff-979fccfe801351786b9cff5fb897af3ff04082c758a89f3c81ac6903e5592f98">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>clip-groove-write-no-op.md</strong><dd><code>Document `Clip.groove` as non-settable property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/dev/device/clip-groove-write-no-op.md

<ul><li>Documented that <code>Clip.groove</code> is a child object reference, not a <br>settable property.<br> <li> Explained that <code>set_property("groove", <id>)</code> via M4L JS <code>LiveAPI</code> reports <br>success but fails to assign.<br> <li> Provided evidence from <code>adj-raw-live-api</code> probe.<br> <li> Advised checking Python bridge for attribute assignment before <br>building features.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/289/files#diff-024a1853ccae17e9f7f17709e037683b8e8f41ab7313bcbbab030240d0a32d42">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

