### PR TITLE
fix: bound adj-browse reply size to fit one UDP datagram

### DIFF
--- a/docs/specs/Browser-Bridge-Spec.md
+++ b/docs/specs/Browser-Bridge-Spec.md
@@ -143,6 +143,12 @@ Result:
 }
 ```
 
+Without `search`, the bridge stops enumerating a folder as soon as it has
+`limit + 1` children rather than walking the whole folder first — a populated
+Library folder can hold thousands of entries, and there's no point paying to
+enumerate past what will be discarded anyway (issue #270). `search` still
+scans every child, since matches can appear anywhere in the folder.
+
 #### `load_item`
 
 Args:
@@ -309,7 +315,7 @@ Risk-gated — not in the first ship.
 | Bridge installed, Live not running               | Send timeouts                                                | error: "start Live first"                                      |
 | Bridge installed, Live running, prefs toggle off | Same as above                                                | error: "enable AbletonDjMcp in Live prefs"                     |
 | Bridge crashed mid-session                       | Subsequent ops timeout                                       | error: "bridge died, restart Live"                             |
-| Bridge slow / blocked on Live main thread        | Op exceeds timeout (10 s for `browse`, 30 s for `load_item`) | error: "bridge timeout, retry"                                 |
+| Bridge slow / blocked on Live main thread        | Op exceeds timeout (25 s for `browse`, 30 s for `load_item`) | error: "bridge timeout, retry"                                 |
 
 The Node side caches `ping` success for 30 s to avoid round-tripping every call.
 Cache invalidates on first failure.

--- a/docs/specs/Browser-Bridge-Spec.md
+++ b/docs/specs/Browser-Bridge-Spec.md
@@ -146,8 +146,17 @@ Result:
 Without `search`, the bridge stops enumerating a folder as soon as it has
 `limit + 1` children rather than walking the whole folder first — a populated
 Library folder can hold thousands of entries, and there's no point paying to
-enumerate past what will be discarded anyway (issue #270). `search` still
-scans every child, since matches can appear anywhere in the folder.
+enumerate past what will be discarded anyway. `search` still scans every
+child, since matches can appear anywhere in the folder.
+
+The reply is also trimmed to `MAX_REPLY_BYTES` (8192, see `browser_ops.py`)
+regardless of `limit`: macOS's default `net.inet.udp.maxdgram` is 9216 bytes,
+and `BrowserBridge._send()`'s `sendto()` fails with `EMSGSIZE` above that —
+caught and only logged, so an oversized reply was silently dropped and the
+caller just saw its own request time out (issue #270). A folder with
+~65-70 items of typical name length already crosses that limit, which is
+well under the tool's default `limit=100` — this was not a slow-enumeration
+problem, despite how it presented.
 
 #### `load_item`
 
@@ -315,7 +324,7 @@ Risk-gated — not in the first ship.
 | Bridge installed, Live not running               | Send timeouts                                                | error: "start Live first"                                      |
 | Bridge installed, Live running, prefs toggle off | Same as above                                                | error: "enable AbletonDjMcp in Live prefs"                     |
 | Bridge crashed mid-session                       | Subsequent ops timeout                                       | error: "bridge died, restart Live"                             |
-| Bridge slow / blocked on Live main thread        | Op exceeds timeout (25 s for `browse`, 30 s for `load_item`) | error: "bridge timeout, retry"                                 |
+| Bridge slow / blocked on Live main thread        | Op exceeds timeout (10 s for `browse`, 30 s for `load_item`) | error: "bridge timeout, retry"                                 |
 
 The Node side caches `ping` success for 30 s to avoid round-tripping every call.
 Cache invalidates on first failure.

--- a/docs/specs/Browser-Bridge-Spec.md
+++ b/docs/specs/Browser-Bridge-Spec.md
@@ -146,17 +146,17 @@ Result:
 Without `search`, the bridge stops enumerating a folder as soon as it has
 `limit + 1` children rather than walking the whole folder first — a populated
 Library folder can hold thousands of entries, and there's no point paying to
-enumerate past what will be discarded anyway. `search` still scans every
-child, since matches can appear anywhere in the folder.
+enumerate past what will be discarded anyway. `search` still scans every child,
+since matches can appear anywhere in the folder.
 
 The reply is also trimmed to `MAX_REPLY_BYTES` (8192, see `browser_ops.py`)
 regardless of `limit`: macOS's default `net.inet.udp.maxdgram` is 9216 bytes,
 and `BrowserBridge._send()`'s `sendto()` fails with `EMSGSIZE` above that —
 caught and only logged, so an oversized reply was silently dropped and the
-caller just saw its own request time out (issue #270). A folder with
-~65-70 items of typical name length already crosses that limit, which is
-well under the tool's default `limit=100` — this was not a slow-enumeration
-problem, despite how it presented.
+caller just saw its own request time out (issue #270). A folder with ~65-70
+items of typical name length already crosses that limit, which is well under the
+tool's default `limit=100` — this was not a slow-enumeration problem, despite
+how it presented.
 
 #### `load_item`
 

--- a/live_browser_bridge/browser_ops.py
+++ b/live_browser_bridge/browser_ops.py
@@ -12,6 +12,8 @@ The functions tolerate Live's mix of attribute/iterator-style children
 (``BrowserItem.children`` is a sequence in modern versions; older versions
 exposed ``iter_children``)."""
 
+import itertools
+
 CATEGORY_ATTRS = (
     "instruments",
     "audio_effects",
@@ -55,17 +57,25 @@ def get_category_root(browser, category):
     return root
 
 
-def children_of(item):
-    """Return a list of children for a BrowserItem, abstracting over Live versions."""
+def children_of(item, max_items=None):
+    """Return children for a BrowserItem, abstracting over Live versions.
+
+    ``max_items``, when given, stops enumeration after that many children via
+    ``itertools.islice`` instead of materializing the whole collection first.
+    A populated Library folder can hold thousands of entries; on a large,
+    unfiltered folder this avoids paying for entries the caller is going to
+    discard anyway (see issue #270)."""
     children = getattr(item, "children", None)
     if children is None:
         children = getattr(item, "iter_children", None)
         if callable(children):
-            children = list(children())
+            children = children()
         else:
             children = []
-    # children may be a Live "vector" — coerce to plain list
-    return list(children)
+    if max_items is None:
+        # children may be a Live "vector" — coerce to plain list
+        return list(children)
+    return list(itertools.islice(children, max_items))
 
 
 def serialize_item(item, depth=0, max_depth=1, include_children=True):
@@ -138,11 +148,19 @@ def browse(browser, category=None, path=None, search=None, depth=1, limit=100):
 
     root = get_category_root(browser, category)
     target = walk_path(root, path)
-    raw_items = children_of(target)
 
     if search:
+        # A search needs to scan every child to find matches, so there's no
+        # cheaper enumeration cap to apply here.
+        raw_items = children_of(target)
         needle = search.lower()
         raw_items = [it for it in raw_items if needle in (getattr(it, "name", "") or "").lower()]
+    else:
+        # No filter: stop enumerating as soon as we have one more than
+        # `limit` so truncation can still be detected, instead of walking
+        # (and paying for) the rest of a large folder just to discard it.
+        scan_cap = (limit + 1) if limit is not None else None
+        raw_items = children_of(target, max_items=scan_cap)
 
     truncated = False
     if limit is not None and len(raw_items) > limit:

--- a/live_browser_bridge/browser_ops.py
+++ b/live_browser_bridge/browser_ops.py
@@ -13,6 +13,16 @@ The functions tolerate Live's mix of attribute/iterator-style children
 exposed ``iter_children``)."""
 
 import itertools
+import json
+
+# macOS's default net.inet.udp.maxdgram is 9216 bytes; a sendto() over that
+# fails with EMSGSIZE. BrowserBridge._send() catches that and only logs it,
+# so an oversized reply is silently dropped and the caller just sees its own
+# request time out with no indication why (issue #270 — a folder with ~65+
+# items already blows this budget, including under the tool's default
+# limit=100). Stay well under the OS ceiling to leave room for UDP/IP framing
+# and the {id, ok, result} envelope BrowserBridge wraps this in.
+MAX_REPLY_BYTES = 8192
 
 CATEGORY_ATTRS = (
     "instruments",
@@ -64,7 +74,7 @@ def children_of(item, max_items=None):
     ``itertools.islice`` instead of materializing the whole collection first.
     A populated Library folder can hold thousands of entries; on a large,
     unfiltered folder this avoids paying for entries the caller is going to
-    discard anyway (see issue #270)."""
+    discard anyway."""
     children = getattr(item, "children", None)
     if children is None:
         children = getattr(item, "iter_children", None)
@@ -130,6 +140,12 @@ def walk_path(root, path):
     return current
 
 
+def _reply_bytes(category, path, items):
+    """Size of the JSON `browse` result payload, as sent over the wire."""
+    envelope = {"category": category, "path": path or "", "items": items, "truncated": True}
+    return len(json.dumps(envelope).encode("utf-8"))
+
+
 def browse(browser, category=None, path=None, search=None, depth=1, limit=100):
     """Return a serialized listing of the browser tree.
 
@@ -171,6 +187,13 @@ def browse(browser, category=None, path=None, search=None, depth=1, limit=100):
         serialize_item(it, depth=0, max_depth=max(depth - 1, 0), include_children=depth > 1)
         for it in raw_items
     ]
+
+    # Belt-and-suspenders: `limit` alone doesn't bound reply size (long
+    # names, depth>1 sub-trees), so trim further if the JSON still wouldn't
+    # fit in one UDP datagram.
+    while items and _reply_bytes(category, path, items) > MAX_REPLY_BYTES:
+        items.pop()
+        truncated = True
 
     return {
         "category": category,

--- a/live_browser_bridge/tests/test_browser_ops.py
+++ b/live_browser_bridge/tests/test_browser_ops.py
@@ -128,8 +128,10 @@ class BrowseTest(unittest.TestCase):
         self.assertTrue(result["truncated"])
 
     def test_large_unfiltered_folder_stops_enumeration_early(self):
-        # Regression test for issue #270: an unfiltered browse of a huge
-        # folder must not walk every child just to discard most of them.
+        # An unfiltered browse of a huge folder must not walk every child
+        # just to discard most of them. limit=50 keeps the reply well under
+        # MAX_REPLY_BYTES so this isolates the item-count cap from the
+        # separate byte-budget cap (see test_oversized_reply_is_trimmed_*).
         pulled = []
 
         def counting_children():
@@ -141,11 +143,31 @@ class BrowseTest(unittest.TestCase):
         huge_root.children = counting_children()
         browser = FakeBrowser(instruments=huge_root)
 
-        result = browser_ops.browse(browser, category="instruments", limit=150)
+        result = browser_ops.browse(browser, category="instruments", limit=50)
 
-        self.assertEqual(len(result["items"]), 150)
+        self.assertEqual(len(result["items"]), 50)
         self.assertTrue(result["truncated"])
-        self.assertEqual(len(pulled), 151)
+        self.assertEqual(len(pulled), 51)
+
+    def test_oversized_reply_is_trimmed_to_fit_one_datagram(self):
+        # Regression test for issue #270: the bridge silently drops a browse
+        # reply that doesn't fit in a single UDP datagram (macOS rejects the
+        # sendto() with EMSGSIZE), which surfaces to the caller as an
+        # unexplained timeout. A folder with ~100 items already blows the
+        # default limit=100 past MAX_REPLY_BYTES, well before `limit` kicks in.
+        children = [FakeItem(name="Item%d" % i, uri="query:Big#Item%d" % i)
+                    for i in range(100)]
+        root = FakeItem(name="Big", is_folder=True, children=children)
+        browser = FakeBrowser(instruments=root)
+
+        result = browser_ops.browse(browser, category="instruments", limit=100)
+
+        self.assertLess(len(result["items"]), 100)
+        self.assertTrue(result["truncated"])
+        self.assertLessEqual(
+            browser_ops._reply_bytes("instruments", "", result["items"]),
+            browser_ops.MAX_REPLY_BYTES,
+        )
 
     def test_small_unfiltered_folder_not_truncated(self):
         children = [FakeItem(name="Item%d" % i) for i in range(5)]

--- a/live_browser_bridge/tests/test_browser_ops.py
+++ b/live_browser_bridge/tests/test_browser_ops.py
@@ -78,6 +78,18 @@ class WalkPathTest(unittest.TestCase):
             browser_ops.walk_path(root, "Synths/Nope")
 
 
+class ChildrenOfTest(unittest.TestCase):
+    def test_max_items_caps_result(self):
+        item = FakeItem(children=[FakeItem(name="Item%d" % i) for i in range(10)])
+        result = browser_ops.children_of(item, max_items=3)
+        self.assertEqual([c.name for c in result], ["Item0", "Item1", "Item2"])
+
+    def test_max_items_none_returns_all(self):
+        item = FakeItem(children=[FakeItem(name="Item%d" % i) for i in range(10)])
+        result = browser_ops.children_of(item)
+        self.assertEqual(len(result), 10)
+
+
 class BrowseTest(unittest.TestCase):
     def test_no_category_lists_categories(self):
         result = browser_ops.browse(_build_browser())
@@ -114,6 +126,34 @@ class BrowseTest(unittest.TestCase):
         result = browser_ops.browse(browser, category="instruments", limit=3)
         self.assertEqual(len(result["items"]), 3)
         self.assertTrue(result["truncated"])
+
+    def test_large_unfiltered_folder_stops_enumeration_early(self):
+        # Regression test for issue #270: an unfiltered browse of a huge
+        # folder must not walk every child just to discard most of them.
+        pulled = []
+
+        def counting_children():
+            for i in range(100_000):
+                pulled.append(i)
+                yield FakeItem(name="Item%d" % i)
+
+        huge_root = FakeItem(name="Huge", is_folder=True)
+        huge_root.children = counting_children()
+        browser = FakeBrowser(instruments=huge_root)
+
+        result = browser_ops.browse(browser, category="instruments", limit=150)
+
+        self.assertEqual(len(result["items"]), 150)
+        self.assertTrue(result["truncated"])
+        self.assertEqual(len(pulled), 151)
+
+    def test_small_unfiltered_folder_not_truncated(self):
+        children = [FakeItem(name="Item%d" % i) for i in range(5)]
+        root = FakeItem(name="Small", is_folder=True, children=children)
+        browser = FakeBrowser(instruments=root)
+        result = browser_ops.browse(browser, category="instruments", limit=150)
+        self.assertEqual(len(result["items"]), 5)
+        self.assertFalse(result["truncated"])
 
     def test_depth_recurses(self):
         result = browser_ops.browse(_build_browser(), category="instruments",

--- a/src/mcp-server/browser-bridge-client.ts
+++ b/src/mcp-server/browser-bridge-client.ts
@@ -19,9 +19,7 @@ import {
 
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 11_077;
-// A large, unfiltered Library folder can take the bridge several seconds to
-// enumerate on Live's main thread (see issue #270).
-const DEFAULT_BROWSE_TIMEOUT_MS = 25_000;
+const DEFAULT_BROWSE_TIMEOUT_MS = 10_000;
 const DEFAULT_LOAD_TIMEOUT_MS = 30_000;
 const DEFAULT_AUTOMATION_WRITE_TIMEOUT_MS = 15_000;
 const DEFAULT_AUTOMATION_TIMEOUT_MS = 10_000;

--- a/src/mcp-server/browser-bridge-client.ts
+++ b/src/mcp-server/browser-bridge-client.ts
@@ -19,7 +19,9 @@ import {
 
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 11_077;
-const DEFAULT_BROWSE_TIMEOUT_MS = 10_000;
+// A large, unfiltered Library folder can take the bridge several seconds to
+// enumerate on Live's main thread (see issue #270).
+const DEFAULT_BROWSE_TIMEOUT_MS = 25_000;
 const DEFAULT_LOAD_TIMEOUT_MS = 30_000;
 const DEFAULT_AUTOMATION_WRITE_TIMEOUT_MS = 15_000;
 const DEFAULT_AUTOMATION_TIMEOUT_MS = 10_000;


### PR DESCRIPTION
## Summary

Live verification caught that my first pass at this (enumeration cap) didn't actually fix the reported timeout — it just moved where the failure happened. Root cause, found by checking Live's own log during a repro:

```
[adj-bridge] udp send failed: [Errno 40] Message too long
```

macOS rejects any `sendto()` over `net.inet.udp.maxdgram` (9216 bytes) with `EMSGSIZE`. `BrowserBridge._send()` catches that and only logs it, so an oversized `browse` reply is silently dropped — the caller just sees its own request time out with zero indication why. A folder with ~65-70 items of typical name length already crosses that budget, which is *under the tool's own default* `limit=100`. This was never a slow-enumeration problem, despite how it presented.

Fix:
- `browse()` now trims `items` until the serialized JSON reply fits under `MAX_REPLY_BYTES` (8192, leaving headroom for the `{id, ok, result}` envelope `BrowserBridge` wraps it in), on top of the `limit + 1` enumeration cap from the previous commit (still a valid, independent optimization — avoids walking a huge folder just to discard most of it).
- Reverted the client-side timeout bump (10s → 25s) from the first commit — it never addressed the actual failure and only made a doomed request wait longer for nothing.

Verified against the exact repro from #270 (`category=sounds path="Bass" limit=150`) on a real Live 12.4.3 instance: previously timed out every time, now returns instantly with `truncated: true`.

Fixes #270.

## Test plan

- [x] `python3 -m unittest discover -s live_browser_bridge/tests` — 51 tests pass, including a new regression test (`test_oversized_reply_is_trimmed_to_fit_one_datagram`) proving a 100-item folder gets trimmed to fit `MAX_REPLY_BYTES`
- [x] `npm test` — full suite passes
- [x] `npm run typecheck` — clean
- [x] `eslint` / `prettier` on touched files — clean
- [x] **Live verification**: rebuilt, deployed device + bridge script, restarted Ableton Live 12.4.3, and re-ran the exact issue repro (`adj-browse category=sounds path="Bass" limit=150`) against a real Core Library folder — confirmed broken before this commit, fixed after