### PR TITLE
fix: surface REPLY_TOO_LARGE/SEND_FAILED instead of silently dropping bridge replies

### DIFF
--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -45,6 +45,11 @@ subdirs (see `HOW-TO-WRITE.md`).
   [src/tools/browse/**, live_browser_bridge/browser_ops.py,
   src/mcp-server/bridge-dispatcher.ts] — adj-browse search filters only direct
   children; user Places not reachable via Live categories
+- [large-udp-reply-silently-dropped](dev/browser/large-udp-reply-silently-dropped.md)
+  [live_browser_bridge/browser_ops.py, live_browser_bridge/BrowserBridge.py,
+  src/mcp-server/browser-bridge-client.ts] — browse replies over 9216 bytes fail
+  sendto() with EMSGSIZE and are silently dropped, presenting as a timeout, not
+  a slow-enumeration bug
 - [m4l-no-browser-api](dev/browser/m4l-no-browser-api.md) [src/tools/browse/**,
   src/tools/device/create/**, live_browser_bridge/**,
   src/mcp-server/browser-bridge-client.ts, src/mcp-server/bridge-dispatcher.ts]
@@ -128,6 +133,9 @@ subdirs (see `HOW-TO-WRITE.md`).
 
 ## workflow
 
+- [browser-bridge-needs-live-restart](workflow/browser-bridge-needs-live-restart.md)
+  [live_browser_bridge/**, scripts/install-bridge.ts] — install:bridge alone
+  doesn't reload edited Python while Live is running; full Live restart required
 - [device-deploy-flow](workflow/device-deploy-flow.md) [max-for-live-device/**,
   dist/**, package.json] — build → copy bundles to max-for-live-device → restart
   Live to load new version

--- a/docs/findings/dev/browser/large-udp-reply-silently-dropped.md
+++ b/docs/findings/dev/browser/large-udp-reply-silently-dropped.md
@@ -1,0 +1,33 @@
+---
+title: large-udp-reply-silently-dropped
+domain: dev
+validated: 2026-08-08
+evidence: PR #290, live Ableton 12.4.3 session log
+---
+
+## Fact
+
+A `browse` reply over macOS's `net.inet.udp.maxdgram` (9216 bytes) fails
+`sendto()` with `EMSGSIZE`. `BrowserBridge._send()` catches that and only logs
+it, so the reply is silently dropped and the caller just sees its own request
+time out — with nothing indicating the real cause. A folder with ~65-70 items of
+typical name length already exceeds this, well under the tool's default
+`limit=100`.
+
+## Evidence
+
+Live console log during the exact failure:
+
+```
+[adj-bridge] udp send failed: [Errno 40] Message too long
+```
+
+Capping enumeration speed alone (`browser_ops.children_of` early-exit) did not
+fix the reported timeout on a real Live instance; only bounding the serialized
+reply to `MAX_REPLY_BYTES` (8192, see `browser_ops.browse`) did.
+
+## Apply when
+
+Adding fields to `browse`'s per-item payload, raising `depth`, or debugging any
+bridge op (`browse`, `automation_read`) that returns a variable-length list over
+UDP — check reply byte size before assuming a timeout means slow enumeration.

--- a/docs/findings/workflow/browser-bridge-needs-live-restart.md
+++ b/docs/findings/workflow/browser-bridge-needs-live-restart.md
@@ -1,0 +1,28 @@
+---
+title: browser-bridge-needs-live-restart
+domain: workflow
+validated: 2026-08-08
+evidence: PR #290 live verification session
+---
+
+## Fact
+
+`npm run install:bridge` copies `live_browser_bridge/` into Live's Remote
+Scripts folder, but Live loads the Python remote script once at startup.
+Re-running `install:bridge` (or rebuilding) while Live keeps running does not
+reload edited Python — a full Live restart is required, separate from the
+`.amxd`'s own V8/node.script reload path in
+[`device-deploy-flow`](device-deploy-flow.md).
+
+## Evidence
+
+Editing `live_browser_bridge/browser_ops.py`, rebuilding, and re-running
+`install:bridge` while Live stayed open left `adj-browse` failing with the
+pre-fix behavior on the next call; `adj-connect` still reported the same bridge
+as before. Only after the user restarted Live did the edited `browser_ops.py`
+take effect — reproduced twice in the same session, once per fix iteration.
+
+## Apply when
+
+Deploying any change under `live_browser_bridge/` for live verification —
+`install:bridge` alone is not enough, Live itself must restart.

--- a/docs/specs/Browser-Bridge-Spec.md
+++ b/docs/specs/Browser-Bridge-Spec.md
@@ -101,7 +101,8 @@ JSON, UTF-8.
   "error": {
     "code": "BRIDGE_NOT_FOUND" | "MAIN_THREAD_ERROR"
           | "BROWSER_API_FAILED" | "AUTOMATION_FAILED"
-          | "INVALID_ARGS" | "TIMEOUT_INTERNAL",
+          | "INVALID_ARGS" | "TIMEOUT_INTERNAL"
+          | "REPLY_TOO_LARGE" | "SEND_FAILED",
     "message": "<human-readable>"
   }
 }
@@ -151,12 +152,15 @@ since matches can appear anywhere in the folder.
 
 The reply is also trimmed to `MAX_REPLY_BYTES` (8192, see `browser_ops.py`)
 regardless of `limit`: macOS's default `net.inet.udp.maxdgram` is 9216 bytes,
-and `BrowserBridge._send()`'s `sendto()` fails with `EMSGSIZE` above that —
-caught and only logged, so an oversized reply was silently dropped and the
-caller just saw its own request time out (issue #270). A folder with ~65-70
-items of typical name length already crosses that limit, which is well under the
-tool's default `limit=100` — this was not a slow-enumeration problem, despite
-how it presented.
+and `BrowserBridge._send()`'s `sendto()` fails with `EMSGSIZE` above that (issue
+#270). A folder with ~65-70 items of typical name length already crosses that
+limit, which is well under the tool's default `limit=100` — this was not a
+slow-enumeration problem, despite how it presented. `MAX_REPLY_BYTES` should
+keep any `browse` reply under the OS ceiling going forward; as defense in depth,
+`_send()` also reports a `REPLY_TOO_LARGE` (`EMSGSIZE`) or `SEND_FAILED` (any
+other `sendto()` exception) error reply on send failure, in place of the
+original payload, so a future oversized-reply bug fails fast instead of
+presenting as an unexplained timeout (issue #290).
 
 #### `load_item`
 
@@ -318,13 +322,14 @@ Risk-gated — not in the first ship.
 
 ## Recovery and error handling
 
-| Scenario                                         | Bridge state                                                 | Node behavior                                                  |
-| ------------------------------------------------ | ------------------------------------------------------------ | -------------------------------------------------------------- |
-| Bridge not installed                             | UDP send fails with ECONNREFUSED-equivalent                  | tool returns error: "install:bridge then enable in Live prefs" |
-| Bridge installed, Live not running               | Send timeouts                                                | error: "start Live first"                                      |
-| Bridge installed, Live running, prefs toggle off | Same as above                                                | error: "enable AbletonDjMcp in Live prefs"                     |
-| Bridge crashed mid-session                       | Subsequent ops timeout                                       | error: "bridge died, restart Live"                             |
-| Bridge slow / blocked on Live main thread        | Op exceeds timeout (10 s for `browse`, 30 s for `load_item`) | error: "bridge timeout, retry"                                 |
+| Scenario                                         | Bridge state                                                                            | Node behavior                                                  |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Bridge not installed                             | UDP send fails with ECONNREFUSED-equivalent                                             | tool returns error: "install:bridge then enable in Live prefs" |
+| Bridge installed, Live not running               | Send timeouts                                                                           | error: "start Live first"                                      |
+| Bridge installed, Live running, prefs toggle off | Same as above                                                                           | error: "enable AbletonDjMcp in Live prefs"                     |
+| Bridge crashed mid-session                       | Subsequent ops timeout                                                                  | error: "bridge died, restart Live"                             |
+| Bridge slow / blocked on Live main thread        | Op exceeds timeout (10 s for `browse`, 30 s for `load_item`)                            | error: "bridge timeout, retry"                                 |
+| Reply too large to fit one UDP datagram          | `sendto()` fails `EMSGSIZE`; bridge sends a small `REPLY_TOO_LARGE` error reply instead | error surfaces immediately instead of timing out               |
 
 The Node side caches `ping` success for 30 s to avoid round-tripping every call.
 Cache invalidates on first failure.

--- a/live_browser_bridge/BrowserBridge.py
+++ b/live_browser_bridge/BrowserBridge.py
@@ -19,6 +19,7 @@ Threading:
       drain the request queue there and execute browser ops, then push results
       onto the response queue."""
 
+import errno
 import json
 import os
 import socket
@@ -145,6 +146,25 @@ class BrowserBridge(ControlSurface):
             self._socket.sendto(json.dumps(payload).encode("utf-8"), addr)
         except Exception as exc:
             self._log("udp send failed: %s" % exc)
+            self._send_fallback_error(addr, payload.get("id"), exc)
+
+    def _send_fallback_error(self, addr, req_id, exc):
+        # The original payload didn't fit on the wire (or otherwise failed
+        # to send); tell the caller so it fails fast with a clear reason
+        # instead of just timing out with no indication why (issue #290).
+        if self._socket is None or req_id is None:
+            return
+        code = (
+            "REPLY_TOO_LARGE"
+            if isinstance(exc, OSError) and exc.errno == errno.EMSGSIZE
+            else "SEND_FAILED"
+        )
+        fallback = self._error(req_id, code, str(exc))
+        try:
+            self._socket.sendto(json.dumps(fallback).encode("utf-8"), addr)
+        except Exception as fallback_exc:
+            # Truly nothing more we can do — the caller will time out.
+            self._log("udp fallback send also failed: %s" % fallback_exc)
 
     # ----------------------------------------------------------- main thread
 

--- a/live_browser_bridge/tests/test_browser_bridge.py
+++ b/live_browser_bridge/tests/test_browser_bridge.py
@@ -1,0 +1,88 @@
+# Ableton DJ MCP - Live Browser Bridge tests
+# Copyright (C) 2026 Gabriel Pulga
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Unit tests for BrowserBridge's send-failure fallback. Live/ControlSurface
+are not imported here; BrowserBridge.py falls back to a stub base class when
+they're unavailable, so the module imports cleanly outside Live."""
+
+import json
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.abspath(os.path.join(HERE, os.pardir, os.pardir))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from live_browser_bridge.BrowserBridge import BrowserBridge  # type: ignore  # noqa: E402
+
+
+class FakeSocket(object):
+    def __init__(self, side_effects):
+        self.side_effects = list(side_effects)
+        self.sent = []
+
+    def sendto(self, data, addr):
+        effect = self.side_effects.pop(0)
+        self.sent.append(json.loads(data.decode("utf-8")))
+        if isinstance(effect, Exception):
+            raise effect
+
+
+def _make_bridge(socket_):
+    # Bypass __init__ (which binds a real UDP socket and starts a thread).
+    bridge = BrowserBridge.__new__(BrowserBridge)
+    bridge._socket = socket_
+    bridge._log = lambda message: None
+    return bridge
+
+
+class SendFallbackTest(unittest.TestCase):
+    def test_oversized_reply_sends_reply_too_large(self):
+        sock = FakeSocket([OSError(40, "Message too long"), None])
+        bridge = _make_bridge(sock)
+
+        bridge._send("addr", {"id": "req_1", "ok": True, "result": {"items": []}})
+
+        self.assertEqual(len(sock.sent), 2)
+        fallback = sock.sent[1]
+        self.assertEqual(fallback["id"], "req_1")
+        self.assertFalse(fallback["ok"])
+        self.assertEqual(fallback["error"]["code"], "REPLY_TOO_LARGE")
+
+    def test_other_send_failure_sends_send_failed(self):
+        sock = FakeSocket([OSError(9, "Bad file descriptor"), None])
+        bridge = _make_bridge(sock)
+
+        bridge._send("addr", {"id": "req_2", "ok": True, "result": {}})
+
+        fallback = sock.sent[1]
+        self.assertEqual(fallback["error"]["code"], "SEND_FAILED")
+
+    def test_fallback_send_failure_does_not_raise(self):
+        sock = FakeSocket([OSError(40, "Message too long"), OSError(9, "still broken")])
+        bridge = _make_bridge(sock)
+
+        bridge._send("addr", {"id": "req_3", "ok": True, "result": {}})  # must not raise
+
+    def test_missing_id_skips_fallback(self):
+        sock = FakeSocket([OSError(40, "Message too long")])
+        bridge = _make_bridge(sock)
+
+        bridge._send("addr", {"id": None, "ok": True, "result": {}})
+
+        self.assertEqual(len(sock.sent), 1)
+
+    def test_successful_send_does_not_trigger_fallback(self):
+        sock = FakeSocket([None])
+        bridge = _make_bridge(sock)
+
+        bridge._send("addr", {"id": "req_4", "ok": True, "result": {}})
+
+        self.assertEqual(len(sock.sent), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/mcp-server/browser-bridge-client.ts
+++ b/src/mcp-server/browser-bridge-client.ts
@@ -35,7 +35,9 @@ export type BridgeErrorCode =
   | "BROWSER_API_FAILED"
   | "AUTOMATION_FAILED"
   | "INVALID_ARGS"
-  | "TIMEOUT_INTERNAL";
+  | "TIMEOUT_INTERNAL"
+  | "REPLY_TOO_LARGE"
+  | "SEND_FAILED";
 
 export const INSTALL_HINT =
   "Bridge unavailable. Run `npm run install:bridge`, then restart Live and " +
@@ -355,10 +357,8 @@ export class BrowserBridgeClient {
     }).catch((err: Error) => {
       const pending = this.pending.get(id);
 
-      if (pending) {
-        clearTimeout(pending.timer);
-        this.pending.delete(id);
-      }
+      if (pending) clearTimeout(pending.timer);
+      this.pending.delete(id);
 
       throw new BridgeCallError({
         code: "BRIDGE_NOT_FOUND",

--- a/src/mcp-server/tests/bridge/browser-bridge-client.test.ts
+++ b/src/mcp-server/tests/bridge/browser-bridge-client.test.ts
@@ -116,6 +116,24 @@ describe("BrowserBridgeClient", () => {
     );
   });
 
+  it("surfaces REPLY_TOO_LARGE when the bridge reports an oversized reply", async () => {
+    const { client, socket } = makeClient();
+
+    socket.onSend = (msg) =>
+      socket.reply({
+        id: msg.id,
+        ok: false,
+        error: {
+          code: "REPLY_TOO_LARGE",
+          message: "[Errno 40] Message too long",
+        },
+      });
+
+    await expect(client.browse({ category: "sounds" })).rejects.toMatchObject({
+      code: "REPLY_TOO_LARGE",
+    });
+  });
+
   it("times out when bridge does not reply", async () => {
     vi.useFakeTimers();
     const { client, socket } = makeClient();


### PR DESCRIPTION
### **User description**
## Summary

Follow-up to #290, which squash-merged before this last commit made it in — this PR carries the remaining work.

- `BrowserBridge._send()` previously caught any `sendto()` exception and only logged it, so a failed reply left the caller with nothing but a bare timeout. `MAX_REPLY_BYTES` (landed in #290) should keep `browse` replies under the OS datagram ceiling going forward, but this closes the gap for any future oversized-reply bug (or any other send failure): `_send()` now attempts a small fallback error reply (`REPLY_TOO_LARGE` for `EMSGSIZE`, `SEND_FAILED` otherwise) so the client fails fast with a clear reason instead of timing out with zero information.
- Adds the two error codes to `BridgeErrorCode` on the TS side and documents them in `Browser-Bridge-Spec.md`.
- Captures two findings from the #270/#290 investigation:
  - `large-udp-reply-silently-dropped` — the root-cause fact, corrected from the initial (wrong) enumeration-speed diagnosis
  - `browser-bridge-needs-live-restart` — `install:bridge` alone doesn't reload edited Python while Live keeps running, validated twice during that session

## Test plan

- [x] `python3 -m unittest discover -s live_browser_bridge/tests` — 56 tests pass, including new `test_browser_bridge.py` covering the fallback (oversized payload → `REPLY_TOO_LARGE`, other send failures → `SEND_FAILED`, fallback-send-also-fails doesn't raise, missing id skips fallback)
- [x] `npm test` / `npx vitest run src/mcp-server/tests/bridge/browser-bridge-client.test.ts` — full suite + new client-side test asserting `REPLY_TOO_LARGE` propagates through `BridgeCallError.code`
- [x] `npm run typecheck` — clean
- [x] `eslint` / `prettier` — clean


___

### **PR Type**
Bug fix, Enhancement, Documentation, Tests


___

### **Description**
- Implement fallback error replies for failed UDP `sendto()` operations.

- Surface `REPLY_TOO_LARGE` or `SEND_FAILED` errors instead of silently dropping replies.

- Update `BrowserBridge` specification and client-side error handling.

- Add comprehensive unit tests for the new send failure fallback mechanisms.

- Document findings on large UDP replies and bridge deployment workflow.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[BrowserBridge._send()] -- "UDP sendto() fails" --> B{Exception type?};
  B -- "EMSGSIZE (errno 40)" --> C[Send REPLY_TOO_LARGE error];
  B -- "Other Exception" --> D[Send SEND_FAILED error];
  C --> E[Client receives error];
  D --> E;
  A -- "UDP sendto() succeeds" --> F[Client receives reply];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>browser-bridge-client.ts</strong><dd><code>Add `REPLY_TOO_LARGE` and `SEND_FAILED` to `BridgeErrorCode`</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/293/files#diff-fa1ca103845c55e76ff0f5a978d536442a515090654bdedf7877cf01427c9343">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>browser-bridge-client.test.ts</strong><dd><code>Add test for `REPLY_TOO_LARGE` error propagation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/293/files#diff-fa3d79969ee84673e1fcaa4fb4426a9b7cc2c34eff610e409ad3973083fd2aed">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_browser_bridge.py</strong><dd><code>Add unit tests for `BrowserBridge` send failure fallback</code>&nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/293/files#diff-3363952213d6058a52fadb8da758399e12cb7ca3b8b2919776c341ea31dcdd64">+88/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>BrowserBridge.py</strong><dd><code>Implement fallback error replies for UDP send failures</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/293/files#diff-6640acee310b1a77c7f046a1edb55eb118072d8687cdf8df4dcf3e999407688c">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>INDEX.md</strong><dd><code>Add new findings for large UDP replies and bridge restart requirements</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/293/files#diff-979fccfe801351786b9cff5fb897af3ff04082c758a89f3c81ac6903e5592f98">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>large-udp-reply-silently-dropped.md</strong><dd><code>Document silent dropping of oversized UDP replies due to `EMSGSIZE`</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/293/files#diff-f6d15088bc3eef4543da8566a71a1c68f7db6a261c2490071ceaa14bf0559f1c">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>browser-bridge-needs-live-restart.md</strong><dd><code>Document the requirement to restart Live after bridge changes</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/293/files#diff-20d45aa2b8ac7a762327e2a61c5a4e33eec7b105acfa46eafe49e18c4dfe2041">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Browser-Bridge-Spec.md</strong><dd><code>Update <code>BrowserBridge</code> spec with new error codes and handling for <br>oversized replies</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/293/files#diff-be385f4b984bc7a1e837b48386aae08a2e98bb8f22d5e60b3cc68893206104ae">+19/-14</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

