### PR TITLE
docs: add findings on getProperty cost and write-tool batching

### DIFF
--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -9,6 +9,11 @@ subdirs (see `HOW-TO-WRITE.md`).
 
 ## dev
 
+- [getproperty-no-boundary-cost](dev/getproperty-no-boundary-cost.md)
+  [src/live-api-adapter/**, src/tools/live-set/read-live-set.ts,
+  src/tools/track/read/read-track.ts] — LiveAPI .get()/getProperty() is an
+  in-process call, no IPC boundary cost to amortize; batching reads is not a
+  real optimization
 - [live-api-property-names-need-external-check](dev/live-api-property-names-need-external-check.md)
   [src/tools/live-set/**, src/tools/track/**, src/tools/clip/**] — mocked tests
   can't catch a wrong LOM property name; verify against AbletonOSC/Adam Murray's
@@ -25,6 +30,11 @@ subdirs (see `HOW-TO-WRITE.md`).
   [src/shared/v8-sleep.ts, src/live-api-adapter/**] — inline
   `new Task(cb).schedule(ms)` risks GC before firing; keep a persistent
   reference until the callback runs
+- [write-tools-already-batch](dev/write-tools-already-batch.md)
+  [src/tools/_/update/_.def.ts, src/tools/_/create/_.def.ts,
+  src/tools/operations/**/*.def.ts] — update/create/delete/duplicate tools
+  already accept comma-separated ids or a count param; no round-trip gap to fix
+  there
 
 ### notation
 

--- a/docs/findings/dev/getproperty-no-boundary-cost.md
+++ b/docs/findings/dev/getproperty-no-boundary-cost.md
@@ -1,0 +1,29 @@
+---
+title: getproperty-no-boundary-cost
+domain: dev
+validated: 2026-08-08
+evidence: "src/live-api-adapter/live-api-extensions.ts:33-67, src/mcp-server/max-api-adapter.ts:73"
+---
+
+## Fact
+
+`LiveAPI.getProperty()`/`.get()` calls inside the device's V8 adapter are
+plain in-process JS calls into Max's native object, not IPC or thread-boundary
+crossings. The one real MCP round trip happens per tool call, not per
+property — batching individual property reads would not reduce any actual
+crossing cost.
+
+## Evidence
+
+`getProperty` (live-api-extensions.ts:33-67) synchronously wraps `this.get(property)`
+inside the same V8 context that already received a single
+`Max.outlet("mcp_request", ...)` per tool call (max-api-adapter.ts:73).
+`readLiveSet`/`readTrack` (live-api-adapter.ts:262-316) loop hundreds of
+`.get()` calls before one `sendResponse()` — all inside that one crossing.
+
+## Apply when
+
+Considering "batch the property reads" as a fix for `adj-read-live-set` /
+`adj-read-track` feeling slow on large sets — there's no per-property
+boundary cost to amortize. Look at payload size or Live main-thread
+enumeration work instead.

--- a/docs/findings/dev/getproperty-no-boundary-cost.md
+++ b/docs/findings/dev/getproperty-no-boundary-cost.md
@@ -2,21 +2,22 @@
 title: getproperty-no-boundary-cost
 domain: dev
 validated: 2026-08-08
-evidence: "src/live-api-adapter/live-api-extensions.ts:33-67, src/mcp-server/max-api-adapter.ts:73"
+evidence:
+  "src/live-api-adapter/live-api-extensions.ts:33-67,
+  src/mcp-server/max-api-adapter.ts:73"
 ---
 
 ## Fact
 
-`LiveAPI.getProperty()`/`.get()` calls inside the device's V8 adapter are
-plain in-process JS calls into Max's native object, not IPC or thread-boundary
-crossings. The one real MCP round trip happens per tool call, not per
-property — batching individual property reads would not reduce any actual
-crossing cost.
+`LiveAPI.getProperty()`/`.get()` calls inside the device's V8 adapter are plain
+in-process JS calls into Max's native object, not IPC or thread-boundary
+crossings. The one real MCP round trip happens per tool call, not per property —
+batching individual property reads would not reduce any actual crossing cost.
 
 ## Evidence
 
-`getProperty` (live-api-extensions.ts:33-67) synchronously wraps `this.get(property)`
-inside the same V8 context that already received a single
+`getProperty` (live-api-extensions.ts:33-67) synchronously wraps
+`this.get(property)` inside the same V8 context that already received a single
 `Max.outlet("mcp_request", ...)` per tool call (max-api-adapter.ts:73).
 `readLiveSet`/`readTrack` (live-api-adapter.ts:262-316) loop hundreds of
 `.get()` calls before one `sendResponse()` — all inside that one crossing.
@@ -24,6 +25,6 @@ inside the same V8 context that already received a single
 ## Apply when
 
 Considering "batch the property reads" as a fix for `adj-read-live-set` /
-`adj-read-track` feeling slow on large sets — there's no per-property
-boundary cost to amortize. Look at payload size or Live main-thread
-enumeration work instead.
+`adj-read-track` feeling slow on large sets — there's no per-property boundary
+cost to amortize. Look at payload size or Live main-thread enumeration work
+instead.

--- a/docs/findings/dev/write-tools-already-batch.md
+++ b/docs/findings/dev/write-tools-already-batch.md
@@ -1,0 +1,27 @@
+---
+title: write-tools-already-batch
+domain: dev
+validated: 2026-08-08
+evidence: "update-clip.def.ts:20, update-track.def.ts:19, update-scene.def.ts:16, delete.def.ts:18, create-track.def.ts:22, create-clip.def.ts:24, duplicate.def.ts:34"
+---
+
+## Fact
+
+The write tools already support batching multiple targets in one call, so
+"one object per call" round-trip chattiness is not a gap to fix. Only
+`adj-automate` is single-target, and that's inherent to the operation (one
+clip/param envelope at a time).
+
+## Evidence
+
+`update-clip`, `update-track`, `update-scene`, `delete` all take a
+comma-separated `ids` field. `create-track` takes `count`. `create-clip`
+takes comma-separated `slot`/`arrangementStart`. `duplicate` takes `count`
+plus comma-separated destination params (`arrangementStart`, `toSlot`,
+`toPath`).
+
+## Apply when
+
+Considering "add batch support to write tools" as a performance fix — check
+the tool's `.def.ts` first, it likely already accepts comma-separated ids or
+a count param.

--- a/docs/findings/dev/write-tools-already-batch.md
+++ b/docs/findings/dev/write-tools-already-batch.md
@@ -2,26 +2,28 @@
 title: write-tools-already-batch
 domain: dev
 validated: 2026-08-08
-evidence: "update-clip.def.ts:20, update-track.def.ts:19, update-scene.def.ts:16, delete.def.ts:18, create-track.def.ts:22, create-clip.def.ts:24, duplicate.def.ts:34"
+evidence:
+  "update-clip.def.ts:20, update-track.def.ts:19, update-scene.def.ts:16,
+  delete.def.ts:18, create-track.def.ts:22, create-clip.def.ts:24,
+  duplicate.def.ts:34"
 ---
 
 ## Fact
 
-The write tools already support batching multiple targets in one call, so
-"one object per call" round-trip chattiness is not a gap to fix. Only
-`adj-automate` is single-target, and that's inherent to the operation (one
-clip/param envelope at a time).
+The write tools already support batching multiple targets in one call, so "one
+object per call" round-trip chattiness is not a gap to fix. Only `adj-automate`
+is single-target, and that's inherent to the operation (one clip/param envelope
+at a time).
 
 ## Evidence
 
 `update-clip`, `update-track`, `update-scene`, `delete` all take a
-comma-separated `ids` field. `create-track` takes `count`. `create-clip`
-takes comma-separated `slot`/`arrangementStart`. `duplicate` takes `count`
-plus comma-separated destination params (`arrangementStart`, `toSlot`,
-`toPath`).
+comma-separated `ids` field. `create-track` takes `count`. `create-clip` takes
+comma-separated `slot`/`arrangementStart`. `duplicate` takes `count` plus
+comma-separated destination params (`arrangementStart`, `toSlot`, `toPath`).
 
 ## Apply when
 
-Considering "add batch support to write tools" as a performance fix — check
-the tool's `.def.ts` first, it likely already accepts comma-separated ids or
-a count param.
+Considering "add batch support to write tools" as a performance fix — check the
+tool's `.def.ts` first, it likely already accepts comma-separated ids or a count
+param.


### PR DESCRIPTION
### **User description**
## Summary

- Two findings captured from a read/write MCP round-trip performance investigation, ruling out ideas that turned out not to be real problems, so they don't get re-investigated later.
- `getproperty-no-boundary-cost`: LiveAPI `.get()`/`getProperty()` calls inside the device's V8 adapter are in-process, no IPC/thread-boundary cost to amortize by batching.
- `write-tools-already-batch`: update/create/delete/duplicate tools already accept comma-separated `ids` or a `count` param — no round-trip-chattiness gap to fix.
- Related open issues from the same investigation: #291 (read caching, needs invalidation-safety design) and #292 (pagination for include-flag reads).

## Test plan

- [x] Format/lint N/A (docs-only, markdown findings files matching existing template)


___

### **PR Type**
Documentation


___

### **Description**
- Documented `LiveAPI.getProperty()` in-process cost.

- Confirmed write tools already support batching.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>INDEX.md</strong><dd><code>Update `dev` findings index with new performance insights</code></dd></summary>
<hr>

docs/findings/INDEX.md

<ul><li>Added an entry for <code>getproperty-no-boundary-cost.md</code> under the <code>dev</code> <br>findings.<br> <li> Added an entry for <code>write-tools-already-batch.md</code> under the <code>dev</code> <br>findings.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/294/files#diff-979fccfe801351786b9cff5fb897af3ff04082c758a89f3c81ac6903e5592f98">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>getproperty-no-boundary-cost.md</strong><dd><code>Document `LiveAPI.getProperty()` in-process cost</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/dev/getproperty-no-boundary-cost.md

<ul><li>Created a new finding document <code>getproperty-no-boundary-cost.md</code>.<br> <li> Explained that <code>LiveAPI.getProperty()</code> calls are in-process, not IPC, <br>meaning batching them is not a performance optimization.<br> <li> Provided evidence from <code>src/live-api-adapter/live-api-extensions.ts</code> and <br><code>src/mcp-server/max-api-adapter.ts</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/294/files#diff-82fd271bc904064eb5c9d8260a7159e82d72a020f3ef29163ea240c93425664f">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>write-tools-already-batch.md</strong><dd><code>Document write tools' existing batching support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/dev/write-tools-already-batch.md

<ul><li>Created a new finding document <code>write-tools-already-batch.md</code>.<br> <li> Documented that write tools already support batching multiple targets <br>(e.g., <code>ids</code>, <code>count</code>).<br> <li> Provided evidence from various <code>.def.ts</code> files for <code>update</code>, <code>create</code>, <br><code>delete</code>, and <code>duplicate</code> tools.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/294/files#diff-bc84360443ea4c2e559b21051190bac6cd2917c81775df750e9a896e0dc5348a">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

