### PR TITLE
feat: add live output meter levels to adj-read-track

### DIFF
--- a/docs/Tools-Reference.md
+++ b/docs/Tools-Reference.md
@@ -52,6 +52,11 @@ state.
 - `include: ["session-clips", "arrangement-clips", "devices", "routings"]`
 - `trackIndex` — zero-based track index
 - `isFrozen` — included (true) when the track is frozen
+- `include: ["meters"]` — live output meter levels (`meterLeft`, `meterRight`,
+  `meterLevel`, each 0.0-1.0); reads 0 while the transport is stopped. Works on
+  regular, return, and master tracks. Combine `adj-read-live-set` with
+  `include: ["tracks", "meters"]` for a one-call mix snapshot of every track's
+  levels
 
 ### `adj-create-track`
 

--- a/docs/contributing/Read-Tool-Includes.md
+++ b/docs/contributing/Read-Tool-Includes.md
@@ -44,7 +44,7 @@ debugging, but should be avoided in production for large Live Sets.
 `adj-read-track` and `adj-read-scene` pass their full `include` array through to
 `readClip()`. Only clip-recognized includes affect clip output.
 `adj-read-live-set` propagates only track-level includes (`routings`, `mixer`,
-`color`) to its nested track/scene reads.
+`meters`, `color`) to its nested track/scene reads.
 
 ### Redundant field stripping
 
@@ -104,6 +104,9 @@ Returns the Live Set overview. Use includes to expand track/scene detail.
 - `scenes` — replaces `sceneCount` with scene list (read-scene default format)
 - `routings` — propagated: adds routing info to tracks
 - `mixer` — propagated: adds gain, pan, sends to tracks
+- `meters` — propagated: adds live output meter levels to tracks (see
+  `adj-read-track`'s `"meters"` include below). Combine with `tracks` for a
+  one-call mix snapshot of every track's levels
 - `color` — propagated: adds hex color to tracks and scenes
 - `locators` — adds arrangement cue points with names and bar|beat positions
 
@@ -171,6 +174,21 @@ Adds track-level mixer properties. Fields are merged into the track object.
 
 Device-structural includes (`chains`, `return-chains`, `drum-pads`) are not
 available at this level. Use `adj-read-device` for chain/drum-pad detail.
+
+### Include: `"meters"`
+
+Adds live output meter levels. Works on regular, return, and master tracks.
+Values are instantaneous — Live only updates them during playback, so they
+read `0` while the transport is stopped.
+
+| Field        | Type     | Description                               |
+| ------------ | -------- | ----------------------------------------- |
+| `meterLeft`  | `number` | Left channel output meter level, 0.0-1.0  |
+| `meterRight` | `number` | Right channel output meter level, 0.0-1.0 |
+| `meterLevel` | `number` | Mono output meter level, 0.0-1.0          |
+
+Unlike `mixer`'s fields, these are always present (not omitted at zero) since
+zero is meaningful signal information, not a default value to hide.
 
 ## adj-read-scene
 

--- a/docs/contributing/Read-Tool-Includes.md
+++ b/docs/contributing/Read-Tool-Includes.md
@@ -178,8 +178,8 @@ available at this level. Use `adj-read-device` for chain/drum-pad detail.
 ### Include: `"meters"`
 
 Adds live output meter levels. Works on regular, return, and master tracks.
-Values are instantaneous — Live only updates them during playback, so they
-read `0` while the transport is stopped.
+Values are instantaneous — Live only updates them during playback, so they read
+`0` while the transport is stopped.
 
 | Field        | Type     | Description                               |
 | ------------ | -------- | ----------------------------------------- |
@@ -188,7 +188,11 @@ read `0` while the transport is stopped.
 | `meterLevel` | `number` | Mono output meter level, 0.0-1.0          |
 
 Unlike `mixer`'s fields, these are always present (not omitted at zero) since
-zero is meaningful signal information, not a default value to hide.
+zero is meaningful signal information, not a default value to hide. Exception:
+`meterLeft`/`meterRight` are absent on a MIDI track with no audio-producing
+device — only `meterLevel` reads there. Audio tracks, return tracks, and the
+master track always expose all three (verified live against Ableton Live
+12.4.3).
 
 ## adj-read-scene
 

--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -89,6 +89,11 @@ subdirs (see `HOW-TO-WRITE.md`).
 - [live-instrument-limit](dev/device/live-instrument-limit.md)
   [src/tools/device/**, src/tools/track/**] — Live blocks 2nd instrument per
   track with vague error; delete first
+- [midi-track-no-stereo-meter](dev/device/midi-track-no-stereo-meter.md)
+  [src/tools/track/read/helpers/read-track-helpers.ts,
+  src/tools/track/read/read-track.ts] — MIDI tracks without an audio-producing
+  device omit meterLeft/meterRight, only meterLevel reads; audio/return/master
+  tracks expose all three
 - [param-write-silently-ignored](dev/device/param-write-silently-ignored.md)
   [src/tools/device/update/**,
   src/tools/shared/device/helpers/device-display-helpers.ts] — Live ignores

--- a/docs/findings/dev/device/midi-track-no-stereo-meter.md
+++ b/docs/findings/dev/device/midi-track-no-stereo-meter.md
@@ -7,20 +7,25 @@ evidence: "live adj-read-track calls against Ableton Live 12.4.3, PR #295"
 
 ## Fact
 
-`output_meter_left`/`output_meter_right` are absent (not zero, absent) on MIDI
-tracks with no audio-producing device, while `output_meter_level` is always
-present. Audio tracks, return tracks, and the master track expose all three.
+`output_meter_left`/`output_meter_right` are absent (not zero, absent) on a MIDI
+track with no audio-producing device, while `output_meter_level` is always
+present. A MIDI track with a real instrument gets all three, same as
+audio/return/master tracks.
 
 ## Evidence
 
 Live `adj-read-track { trackIndex: 0/1, include: ["meters"] }` against two MIDI
 tracks (one with the MCP host device, one empty) returned only `meterLevel: 0` —
 `meterLeft`/`meterRight` missing from the response entirely. The same call
-against audio tracks (index 2/3), both return tracks, and the master track
-returned all three fields. `track.getProperty()` returns `undefined` for the
-missing pair; `Object.assign` + JSON serialization drops the `undefined` keys,
-so no explicit per-type branching was needed in `readMeterProperties`
-(`src/tools/track/read/helpers/read-track-helpers.ts`).
+against audio tracks, both return tracks, and the master track returned all
+three fields. `track.getProperty()` returns `undefined` for the missing pair;
+`Object.assign` + JSON serialization drops the `undefined` keys, so no explicit
+per-type branching was needed in `readMeterProperties`
+(`src/tools/track/read/helpers/read-track-helpers.ts`). Confirmed on a real
+project with live signal: a MIDI track running Operator
+(`meterLeft: 0.163, meterRight: 0.168, meterLevel: 0.191`) returned all three,
+and values shifted between two consecutive calls seconds apart — proving the
+read is instantaneous, not cached.
 
 ## Apply when
 

--- a/docs/findings/dev/device/midi-track-no-stereo-meter.md
+++ b/docs/findings/dev/device/midi-track-no-stereo-meter.md
@@ -1,0 +1,29 @@
+---
+title: midi-track-no-stereo-meter
+domain: dev
+validated: 2026-08-08
+evidence: "live adj-read-track calls against Ableton Live 12.4.3, PR #295"
+---
+
+## Fact
+
+`output_meter_left`/`output_meter_right` are absent (not zero, absent) on MIDI
+tracks with no audio-producing device, while `output_meter_level` is always
+present. Audio tracks, return tracks, and the master track expose all three.
+
+## Evidence
+
+Live `adj-read-track { trackIndex: 0/1, include: ["meters"] }` against two MIDI
+tracks (one with the MCP host device, one empty) returned only `meterLevel: 0` —
+`meterLeft`/`meterRight` missing from the response entirely. The same call
+against audio tracks (index 2/3), both return tracks, and the master track
+returned all three fields. `track.getProperty()` returns `undefined` for the
+missing pair; `Object.assign` + JSON serialization drops the `undefined` keys,
+so no explicit per-type branching was needed in `readMeterProperties`
+(`src/tools/track/read/helpers/read-track-helpers.ts`).
+
+## Apply when
+
+Reading or documenting `output_meter_left`/`output_meter_right` on a track of
+unknown type — a MIDI track without a stereo-producing instrument will omit both
+from the result even though `output_meter_level` reads fine.

--- a/src/tools/live-set/read-live-set.def.ts
+++ b/src/tools/live-set/read-live-set.def.ts
@@ -22,6 +22,7 @@ export const toolDefReadLiveSet = defineTool("adj-read-live-set", {
           "scenes",
           "routings",
           "mixer",
+          "meters",
           "color",
           "locators",
           "*",
@@ -29,7 +30,7 @@ export const toolDefReadLiveSet = defineTool("adj-read-live-set", {
       )
       .default([])
       .describe(
-        'tracks, scenes = lists. routings, mixer, color = detail (use with tracks/scenes). locators = arrangement markers. "*" = all',
+        'tracks, scenes = lists. routings, mixer, meters, color = detail (use with tracks/scenes). locators = arrangement markers. "*" = all',
       ),
   },
 
@@ -37,7 +38,7 @@ export const toolDefReadLiveSet = defineTool("adj-read-live-set", {
     excludeEnumValues: { include: ["locators", "*"] },
     descriptionOverrides: {
       include:
-        "tracks, scenes = lists. routings, mixer, color = detail (use with tracks/scenes)",
+        "tracks, scenes = lists. routings, mixer, meters, color = detail (use with tracks/scenes)",
     },
   },
 });

--- a/src/tools/live-set/read-live-set.ts
+++ b/src/tools/live-set/read-live-set.ts
@@ -161,6 +161,7 @@ function buildTrackInclude(flags: IncludeFlags): string[] {
 
   if (flags.includeRoutings) include.push("routings");
   if (flags.includeMixer) include.push("mixer");
+  if (flags.includeMeters) include.push("meters");
   if (flags.includeColor) include.push("color");
 
   return include;

--- a/src/tools/live-set/tests/read-live-set-track-types.test.ts
+++ b/src/tools/live-set/tests/read-live-set-track-types.test.ts
@@ -193,7 +193,15 @@ describe("readLiveSet - track types", () => {
 
     // Test explicit list - should produce identical result
     const resultExplicit = readLiveSet({
-      include: ["scenes", "routings", "tracks", "color", "locators", "mixer"],
+      include: [
+        "scenes",
+        "routings",
+        "tracks",
+        "color",
+        "locators",
+        "mixer",
+        "meters",
+      ],
     });
 
     // Results should be identical

--- a/src/tools/shared/tool-framework/include-params.ts
+++ b/src/tools/shared/tool-framework/include-params.ts
@@ -19,13 +19,14 @@ const AVAILABLE_ROUTINGS = "available-routings";
 const COLOR = "color";
 const CLIPS = "clips";
 const MIXER = "mixer";
+const METERS = "meters";
 const LOCATORS = "locators";
 
 /**
  * All available include options mapped by tool type
  */
 const ALL_INCLUDE_OPTIONS: Record<string, string[]> = {
-  song: ["scenes", "routings", TRACKS, COLOR, MIXER, LOCATORS],
+  song: ["scenes", "routings", TRACKS, COLOR, MIXER, METERS, LOCATORS],
   track: [
     SESSION_CLIPS,
     ARRANGEMENT_CLIPS,
@@ -37,6 +38,7 @@ const ALL_INCLUDE_OPTIONS: Record<string, string[]> = {
     "routings",
     AVAILABLE_ROUTINGS,
     MIXER,
+    METERS,
     COLOR,
   ],
   scene: [CLIPS, CLIP_NOTES, SAMPLE, COLOR, TIMING],
@@ -62,6 +64,7 @@ export interface IncludeFlags {
   includeTiming: boolean;
   includeWarp: boolean;
   includeMixer: boolean;
+  includeMeters: boolean;
   includeLocators: boolean;
 }
 
@@ -96,6 +99,7 @@ export function parseIncludeArray(
       includeTiming: Boolean(defaults.includeTiming),
       includeWarp: Boolean(defaults.includeWarp),
       includeMixer: Boolean(defaults.includeMixer),
+      includeMeters: Boolean(defaults.includeMeters),
       includeLocators: Boolean(defaults.includeLocators),
     };
   }
@@ -127,6 +131,7 @@ export function parseIncludeArray(
       includeTiming: false,
       includeWarp: false,
       includeMixer: false,
+      includeMeters: false,
       includeLocators: false,
     };
   }
@@ -150,6 +155,7 @@ export function parseIncludeArray(
     includeTiming: includeSet.has(TIMING),
     includeWarp: includeSet.has(WARP),
     includeMixer: includeSet.has(MIXER),
+    includeMeters: includeSet.has(METERS),
     includeLocators: includeSet.has(LOCATORS),
   };
 }
@@ -176,6 +182,7 @@ const FLAG_TO_OPTION: [keyof IncludeFlags, string][] = [
   ["includeTiming", TIMING],
   ["includeWarp", WARP],
   ["includeMixer", MIXER],
+  ["includeMeters", METERS],
   ["includeLocators", LOCATORS],
 ];
 
@@ -203,6 +210,7 @@ export const READ_SONG_DEFAULTS: Partial<IncludeFlags> = {
   includeTracks: false,
   includeColor: false,
   includeMixer: false,
+  includeMeters: false,
   includeLocators: false,
 };
 
@@ -225,6 +233,7 @@ export const READ_TRACK_DEFAULTS: Partial<IncludeFlags> = {
   includeTiming: false,
   includeWarp: false,
   includeMixer: false,
+  includeMeters: false,
 };
 
 /**

--- a/src/tools/shared/tool-framework/tests/include-params.test.ts
+++ b/src/tools/shared/tool-framework/tests/include-params.test.ts
@@ -31,6 +31,7 @@ const ALL_FLAGS_FALSE = {
   includeTiming: false,
   includeWarp: false,
   includeMixer: false,
+  includeMeters: false,
   includeLocators: false,
 };
 

--- a/src/tools/track/read/helpers/read-track-helpers.ts
+++ b/src/tools/track/read/helpers/read-track-helpers.ts
@@ -30,6 +30,12 @@ interface MixerResult {
   sends?: SendInfo[];
 }
 
+interface MeterResult {
+  meterLeft: number;
+  meterRight: number;
+  meterLevel: number;
+}
+
 /**
  * Read all session clips from a track
  * @param track - Track object
@@ -387,4 +393,19 @@ export function readMixerProperties(
   }
 
   return result;
+}
+
+/**
+ * Read live output meter levels for a track (or the master track).
+ * Values are instantaneous (0.0-1.0) and read 0 when the transport is
+ * stopped, since Live only updates meters during playback.
+ * @param track - Track object
+ * @returns Object with left/right/mono meter levels
+ */
+export function readMeterProperties(track: LiveAPI): MeterResult {
+  return {
+    meterLeft: track.getProperty("output_meter_left") as number,
+    meterRight: track.getProperty("output_meter_right") as number,
+    meterLevel: track.getProperty("output_meter_level") as number,
+  };
 }

--- a/src/tools/track/read/read-track.def.ts
+++ b/src/tools/track/read/read-track.def.ts
@@ -45,13 +45,14 @@ export const toolDefReadTrack = defineTool("adj-read-track", {
           "routings",
           "available-routings",
           "mixer",
+          "meters",
           "color",
           "*",
         ]),
       )
       .default([])
       .describe(
-        'session-clips, arrangement-clips = clip lists. notes, timing, sample = clip detail (use with clips). devices, drum-map, routings, available-routings, mixer = track data. color = track + clip color. "*" = all',
+        'session-clips, arrangement-clips = clip lists. notes, timing, sample = clip detail (use with clips). devices, drum-map, routings, available-routings, mixer, meters = track data. color = track + clip color. "*" = all',
       ),
   },
 
@@ -59,7 +60,7 @@ export const toolDefReadTrack = defineTool("adj-read-track", {
     excludeEnumValues: { include: ["available-routings", "*"] },
     descriptionOverrides: {
       include:
-        "session-clips, arrangement-clips = clip lists. notes, timing, sample = clip detail (use with clips). devices, drum-map, routings, mixer = track data. color = track + clip color",
+        "session-clips, arrangement-clips = clip lists. notes, timing, sample = clip detail (use with clips). devices, drum-map, routings, mixer, meters = track data. color = track + clip color",
     },
   },
 });

--- a/src/tools/track/read/read-track.ts
+++ b/src/tools/track/read/read-track.ts
@@ -29,6 +29,7 @@ import {
   getInstrumentName,
   handleNonExistentTrack,
   readArrangementClips,
+  readMeterProperties,
   readMixerProperties,
   readSessionClips,
 } from "./helpers/read-track-helpers.ts";
@@ -222,6 +223,7 @@ export function readTrackGeneric({
     includeArrangementClips,
     includeColor,
     includeMixer,
+    includeMeters,
   } = parseIncludeArray(include, READ_TRACK_DEFAULTS);
 
   if (!track.exists()) {
@@ -258,6 +260,11 @@ export function readTrackGeneric({
   // Add mixer properties if requested
   if (includeMixer) {
     Object.assign(result, readMixerProperties(track, returnTrackNames));
+  }
+
+  // Add live output meter levels if requested
+  if (includeMeters) {
+    Object.assign(result, readMeterProperties(track));
   }
 
   if (groupId) {

--- a/src/tools/track/read/tests/read-track-meters.test.ts
+++ b/src/tools/track/read/tests/read-track-meters.test.ts
@@ -1,0 +1,88 @@
+// Ableton DJ MCP - Electronic music production MCP server for Ableton Live
+// Copyright (C) 2026 Gabriel Pulga
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import { setupTrackMock } from "../helpers/read-track-registry-test-helpers.ts";
+import { readTrack } from "../read-track.ts";
+
+describe("readTrack - meter properties", () => {
+  it("excludes meter properties by default", () => {
+    setupTrackMock();
+
+    const result = readTrack({ trackIndex: 0 });
+
+    expect(result).not.toHaveProperty("meterLeft");
+    expect(result).not.toHaveProperty("meterRight");
+    expect(result).not.toHaveProperty("meterLevel");
+  });
+
+  it("includes meter properties when requested", () => {
+    setupTrackMock({
+      properties: {
+        output_meter_left: 0.75,
+        output_meter_right: 0.5,
+        output_meter_level: 0.6,
+      },
+    });
+
+    const result = readTrack({ trackIndex: 0, include: ["meters"] });
+
+    expect(result).toHaveProperty("meterLeft", 0.75);
+    expect(result).toHaveProperty("meterRight", 0.5);
+    expect(result).toHaveProperty("meterLevel", 0.6);
+  });
+
+  it("reads zero levels while the transport is stopped", () => {
+    setupTrackMock({
+      properties: {
+        output_meter_left: 0,
+        output_meter_right: 0,
+        output_meter_level: 0,
+      },
+    });
+
+    const result = readTrack({ trackIndex: 0, include: ["meters"] });
+
+    expect(result).toHaveProperty("meterLeft", 0);
+    expect(result).toHaveProperty("meterRight", 0);
+    expect(result).toHaveProperty("meterLevel", 0);
+  });
+
+  it("includes meter properties for the master track", () => {
+    setupTrackMock({
+      trackPath: String(livePath.masterTrack()),
+      trackId: "master",
+      properties: {
+        has_midi_input: 0,
+        name: "Master",
+        output_meter_left: 0.9,
+        output_meter_right: 0.85,
+        output_meter_level: 0.87,
+      },
+    });
+
+    const result = readTrack({ trackType: "master", include: ["meters"] });
+
+    expect(result).toHaveProperty("meterLeft", 0.9);
+    expect(result).toHaveProperty("meterRight", 0.85);
+    expect(result).toHaveProperty("meterLevel", 0.87);
+  });
+
+  it("includes meters with wildcard include", () => {
+    setupTrackMock({
+      properties: {
+        output_meter_left: 0.3,
+        output_meter_right: 0.2,
+        output_meter_level: 0.25,
+      },
+    });
+
+    const result = readTrack({ trackIndex: 0, include: ["*"] });
+
+    expect(result).toHaveProperty("meterLeft", 0.3);
+    expect(result).toHaveProperty("meterRight", 0.2);
+    expect(result).toHaveProperty("meterLevel", 0.25);
+  });
+});

--- a/src/tools/track/read/tests/read-track-options.test.ts
+++ b/src/tools/track/read/tests/read-track-options.test.ts
@@ -119,6 +119,7 @@ describe("readTrack", () => {
           "routings",
           "available-routings",
           "mixer",
+          "meters",
           "color",
         ],
       });


### PR DESCRIPTION
### **User description**
## Summary

- Adds a `"meters"` include option to `adj-read-track` exposing `meterLeft`, `meterRight`, `meterLevel` (0.0-1.0), read via `output_meter_left/right/level` on the Live track object. Works on regular, return, and master tracks.
- Propagates `"meters"` through `adj-read-live-set`'s include array, so `{ include: ["tracks", "meters"] }` reads every track + master's levels in one call (covers the optional `mix-snapshot` ask from the issue without a new action).
- Values read 0 while the transport is stopped (Live only updates meters during playback) and are always present when included, since 0 is meaningful signal info rather than a default to omit.

**Verification done for the issue's open question:** no bridge changes needed. `getProperty()` in this codebase is a plain in-process call inside the same V8 context that handles the tool call (see `docs/findings/dev/getproperty-no-boundary-cost.md`), so meter reads work exactly like every other track property already read by `adj-read-track`. Confirmed `output_meter_left`/`output_meter_right`/`output_meter_level` against AbletonOSC's `track.py` before shipping (per `docs/findings/dev/live-api-property-names-need-external-check.md`).

Closes #36

## Test plan

- [x] `npm run check` (lint, typecheck, format, duplication, coverage) — all green
- [x] New unit tests in `read-track-meters.test.ts` covering: default exclusion, explicit include, zero values while stopped, master track, wildcard include
- [x] Updated existing wildcard-equivalence fixtures (`read-track-options.test.ts`, `read-live-set-track-types.test.ts`) and `include-params.test.ts` defaults for the new flag
- [x] Docs updated: `docs/Tools-Reference.md`, `docs/contributing/Read-Tool-Includes.md`
- [x] Manual verification against a live, playing Live Set (Live 12.4.3) — confirmed correct on MIDI/audio/return/master tracks and the mix-snapshot combo; found and documented one real wrinkle (MIDI tracks without an instrument omit meterLeft/meterRight)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds a `"meters"` include option to `adj-read-track` for live output meter levels.

- Exposes `meterLeft`, `meterRight`, and `meterLevel` (0.0-1.0) for tracks.

- Propagates `"meters"` through `adj-read-live-set` for bulk track metering.

- Meter values are instantaneous, reading 0 when the transport is stopped.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["adj-read-live-set"] -- "include: ['tracks', 'meters']" --> B["adj-read-track"]
  B -- "read output_meter_left/right/level" --> C["LiveAPI Track Object"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>read-live-set.def.ts</strong><dd><code>Adds 'meters' option to `adj-read-live-set`'s input schema.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/295/files#diff-9b48bb2d45d43a634ed7a3603bb1250a53992506001a2a22acd2091a7b4a97d2">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>read-track.def.ts</strong><dd><code>Adds 'meters' option to `adj-read-track`'s input schema.</code>&nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/295/files#diff-3433699b0c523c4ff43cab0e2e66a2da041d68398cfec6ba80629ec55d2198a2">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>read-live-set.ts</strong><dd><code>Propagates `includeMeters` flag to nested track reads.</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/295/files#diff-f31d9be76df9a8c4adbcc9a68375b0d694e9a93ad20f2eda59a8e83efd46d8e1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>include-params.ts</strong><dd><code>Integrates 'meters' as a new include option across tool types.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/295/files#diff-fbae6a78946dcf3fa5738de24652ad1c245072c63921aa90f076f02acb3df495">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>read-track-helpers.ts</strong><dd><code>Introduces `readMeterProperties` function to fetch live meter levels.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/295/files#diff-18c529a62d371997ff680e0f554ce993204e259bd3eaf60b28e66a0dafc5af0d">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>read-track.ts</strong><dd><code>Integrates <code>readMeterProperties</code> into <code>readTrackGeneric</code> when 'meters' is <br>included.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/295/files#diff-bf3737e2c249870fc0ec0e8ce3eb0afd309888929309525ee79c92d45e86e840">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>read-live-set-track-types.test.ts</strong><dd><code>Updates wildcard include test for `readLiveSet` to cover 'meters'.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/295/files#diff-2348fff2e280fae16f44fdfca7491de566e6502ebdb49496ca866e137704d37e">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>include-params.test.ts</strong><dd><code>Updates `ALL_FLAGS_FALSE` constant to include `includeMeters`.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/295/files#diff-fe72145154d4767303442f864e1e9d6ed19692e7bde90f1226d70e63162bf127">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>read-track-meters.test.ts</strong><dd><code>Adds comprehensive unit tests for `readTrack`'s meter properties.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/295/files#diff-75fdbda0eb5e7cc6a22e6d75cfc2ad607525fc3924d729274111817950829cc9">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>read-track-options.test.ts</strong><dd><code>Updates wildcard include test for `readTrack` to cover 'meters'.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/295/files#diff-b4206391bf99b66b200c9e83f167c7efab9e70c1f459fffcc41f595671d31cf3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>Tools-Reference.md</strong><dd><code>Documents the new `"meters"` include option for `adj-read-track`.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/295/files#diff-1144a39ffd998b6c8832a8e6e38fae79a98231f8e64046307c61134a0b297194">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Read-Tool-Includes.md</strong><dd><code>Updates documentation for <code>adj-read-live-set</code> and <code>adj-read-track</code> with <br>'meters' details.</code></dd></td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/295/files#diff-99cea3c30bdf5fa09646592c8d702658226f339f92f0ed3c413d54d36123ae05">+19/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


