### PR TITLE
fix: dispatch CI explicitly so bot-authored PRs aren't blocked forever

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/rebuild-dist.yml
+++ b/.github/workflows/rebuild-dist.yml
@@ -11,6 +11,8 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
+  actions: write
 
 jobs:
   rebuild-dist:
@@ -27,14 +29,32 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - name: Commit dist if changed
+      - name: Open PR with rebuilt dist if changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add dist/
           if git diff --cached --quiet; then
             echo "dist/ unchanged, nothing to commit"
-          else
-            git commit -m "chore: rebuild dist [skip ci]"
-            git push
+            exit 0
           fi
+
+          BRANCH="chore/rebuild-dist-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+          git commit -m "chore: rebuild dist"
+          git push origin "$BRANCH"
+
+          PR_URL=$(gh pr create --title "chore: rebuild dist" \
+            --body "Automated dist/ rebuild for $(git rev-parse --short main)." \
+            --base main --head "$BRANCH")
+
+          # main requires 5 status checks, but a GITHUB_TOKEN-authored push/PR
+          # never triggers push/pull_request workflow runs (GitHub Actions
+          # anti-recursion rule), so those checks would never appear on this
+          # PR's head commit and it would sit BLOCKED forever. Dispatch CI
+          # explicitly against this branch instead -- the resulting check runs
+          # attach to the branch's head SHA and satisfy the requirement.
+          gh workflow run ci.yml --ref "$BRANCH"
+          gh pr merge --auto --squash --delete-branch "$PR_URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
@@ -18,3 +19,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: config/release-please-config.json
           manifest-file: config/.release-please-manifest.json
+      - name: Dispatch CI for the release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # main requires 5 status checks, but release-please's PR is created/
+          # updated with GITHUB_TOKEN, which never triggers push/pull_request
+          # workflow runs (GitHub Actions anti-recursion rule). Without this,
+          # the release PR sits BLOCKED forever with no checks ever recorded
+          # on its head commit. Dispatch CI explicitly against its branch so
+          # the resulting check runs attach to that commit and satisfy the
+          # requirement.
+          for branch in $(gh pr list --state open --json headRefName \
+            -q '.[] | select(.headRefName | startswith("release-please--")) | .headRefName'); do
+            gh workflow run ci.yml --ref "$branch"
+          done

--- a/docs/findings/INDEX.md
+++ b/docs/findings/INDEX.md
@@ -154,6 +154,10 @@ subdirs (see `HOW-TO-WRITE.md`).
 - [device-deploy-flow](workflow/device-deploy-flow.md) [max-for-live-device/**,
   dist/**, package.json] — build → copy bundles to max-for-live-device → restart
   Live to load new version
+- [github-token-blocks-required-checks](workflow/github-token-blocks-required-checks.md)
+  [.github/workflows/*.yml] — GITHUB_TOKEN-authored pushes/PRs never trigger
+  push/pull_request runs; required status checks block them forever unless CI is
+  dispatched explicitly against that branch
 - [portal-restart-exposes-new-tools](workflow/portal-restart-exposes-new-tools.md)
   [src/portal/**, src/mcp-server/**, dist/**] — MCP tool list fixed at connect
   time; tools added by a server update need an MCP reconnect to appear

--- a/docs/findings/workflow/github-token-blocks-required-checks.md
+++ b/docs/findings/workflow/github-token-blocks-required-checks.md
@@ -1,0 +1,40 @@
+---
+title: github-token-blocks-required-checks
+domain: workflow
+validated: 2026-08-08
+evidence:
+  "gh pr view 282 --json mergeStateStatus -> BLOCKED, statusCheckRollup: []; 9
+  consecutive Rebuild dist run failures (GH006: 5 of 5 required status checks
+  are expected)"
+---
+
+## Fact
+
+A push or PR made with the default `secrets.GITHUB_TOKEN` inside a workflow
+never triggers `push`/`pull_request` runs on other workflows (GitHub Actions'
+anti-recursion rule). Once main requires status checks to merge, any
+GITHUB_TOKEN-authored PR sits permanently `BLOCKED` with an empty
+`statusCheckRollup`, and any GITHUB_TOKEN-authored direct push to main is
+rejected outright.
+
+## Evidence
+
+After PR #281 added 5 required status checks to main: `rebuild-dist.yml`'s
+direct `git push` to main failed 9 times in a row with
+`remote: - 5 of 5 required status checks are expected` /
+`protected branch hook declined` (`gh run list --workflow="Rebuild dist"`).
+Separately, release-please's own release PR (#282) showed
+`mergeStateStatus: BLOCKED`, `mergeable: MERGEABLE`, `statusCheckRollup: []` —
+mergeable by content, blocked only because no check run had ever attached to its
+head commit.
+
+## Apply when
+
+Adding required status checks to a branch that any workflow pushes to or opens
+PRs against using `secrets.GITHUB_TOKEN` (release-please, a dist/docs rebuild
+bot, etc.). Fix: after the push/PR-open step, explicitly
+`gh workflow run <ci-workflow> --ref <branch>` (requires `actions: write` and a
+`workflow_dispatch:` trigger on that workflow) — the dispatched run's check
+results attach to the branch's head SHA the same as a normal trigger would,
+satisfying the requirement. A PAT/GitHub App token would also work but adds a
+secret to manage; dispatch needs no new credentials.


### PR DESCRIPTION
### **User description**
## Summary

- #281 added 5 required status checks to main. Since GITHUB_TOKEN-authored pushes/PRs never trigger `push`/`pull_request` workflow runs (GitHub's anti-recursion rule), those checks never land on a bot PR's head commit.
- Confirmed live: `#282` (release-please's own PR) is `BLOCKED` with an empty `statusCheckRollup`. `rebuild-dist.yml`'s direct push to main has failed 9 times in a row since #281 merged (`GH006: 5 of 5 required status checks are expected`), leaving `dist/` on main stale — missing both #288 (sidechain routing) and #295 (meters).
- Fix: after a bot workflow opens/updates a PR, explicitly `gh workflow run ci.yml --ref <branch>`. The dispatched run's checks attach to that branch's head SHA exactly like a normal trigger would, satisfying the requirement without a new secret/PAT.

## Changes

- `ci.yml`: add `workflow_dispatch:` trigger (required for it to be dispatchable at all)
- `rebuild-dist.yml`: instead of pushing straight to protected main, push to a branch, open a PR, dispatch CI against it, enable auto-merge + branch delete
- `release.yml`: after each release-please run, dispatch CI against any open `release-please--*` branch so its PR isn't permanently blocked either
- New finding: `docs/findings/workflow/github-token-blocks-required-checks.md`

## Follow-up needed after merge

`dist/` is still stale on main right now (this PR doesn't touch `src/`, so it won't self-trigger). Once merged, either push any trivial `src/` change to let `rebuild-dist.yml` catch up, or I can manually trigger a dist rebuild — let me know which you'd prefer.

## Test plan

- [x] `npm run format:check` — clean
- [ ] CI on this PR (normal — opened via my own credentials, not GITHUB_TOKEN, so it triggers normally)
- [ ] Manually verify `rebuild-dist.yml`'s new flow end-to-end after merge (needs a real `src/**` push to main)
- [ ] Manually verify `release.yml`'s dispatch unblocks #282 after merge


___

### **PR Type**
Bug fix, Enhancement, Documentation


___

### **Description**
- Unblock bot-authored PRs from required status checks.

- Enable explicit CI workflow dispatch.

- Refactor `rebuild-dist` to use PRs and dispatch CI.

- Dispatch CI for `release-please` PRs.

- Document `GITHUB_TOKEN` CI blocking issue.


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Bot-authored PR/Push"] --> B{"Required Status Checks"};
  B -- "Blocked (GITHUB_TOKEN anti-recursion)" --> C["CI Blocked"];
  C --> D["ci.yml: Add workflow_dispatch"];
  D --> E["rebuild-dist.yml: Create PR & Dispatch CI"];
  D --> F["release.yml: Dispatch CI for Release PRs"];
  E --> G["CI Unblocked"];
  F --> G;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Enable explicit CI workflow dispatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Added <code>workflow_dispatch</code> to the <code>on</code> trigger.<br> <li> This allows the CI workflow to be manually or programmatically <br>triggered.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/296/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rebuild-dist.yml</strong><dd><code>Refactor `rebuild-dist` to use PRs and explicit CI dispatch</code></dd></summary>
<hr>

.github/workflows/rebuild-dist.yml

<ul><li>Added <code>pull-requests: write</code> and <code>actions: write</code> permissions.<br> <li> Changed the workflow to create a new branch, commit <code>dist/</code> changes, and <br>open a PR.<br> <li> Explicitly dispatches the <code>ci.yml</code> workflow against the new PR branch to <br>satisfy required status checks.<br> <li> Configured auto-merge and branch deletion for the created PR.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/296/files#diff-53cc86eaecf1a5ddc4b1a5ebb7acc00e5de18dd1567fdc2f80f000e2fedce460">+24/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Dispatch CI for release-please PRs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Added <code>actions: write</code> permission.<br> <li> Implemented a step to iterate through open <code>release-please--*</code> PRs.<br> <li> Dispatches the <code>ci.yml</code> workflow for each identified release PR branch.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/296/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>INDEX.md</strong><dd><code>Update findings index with new CI blocking issue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/INDEX.md

<ul><li>Added a new entry for <code>github-token-blocks-required-checks</code>.<br> <li> This points to the new documentation explaining the CI blocking issue.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/296/files#diff-979fccfe801351786b9cff5fb897af3ff04082c758a89f3c81ac6903e5592f98">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>github-token-blocks-required-checks.md</strong><dd><code>Document `GITHUB_TOKEN` blocking required status checks</code>&nbsp; &nbsp; </dd></summary>
<hr>

docs/findings/workflow/github-token-blocks-required-checks.md

<ul><li>New document detailing the "Fact" that <code>GITHUB_TOKEN</code>-authored actions <br>do not trigger other workflows.<br> <li> Provides "Evidence" from failed <code>rebuild-dist</code> runs and blocked <br><code>release-please</code> PRs.<br> <li> Explains how to "Apply" the fix by explicitly dispatching CI <br>workflows.</ul>


</details>


  </td>
  <td><a href="https://github.com/gabrielpulga/ableton-dj-mcp/pull/296/files#diff-27ddee1d395018f14000433a3fac02d3cda9efdc45a8ed281e6dfddc1c1a619e">+40/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

